### PR TITLE
Add Yarek/RAM7 memory expansion: 768 KB and 1024 KB support #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The overlay lets you change the machine model, RAM size, ROM paths, and hardware
 
 Switching the model automatically sets the matching ROM paths and RAM size.
 
-**RAM size** (Advanced → Memory): press Enter to cycle through 64, 128, 256, 512, and 576 KB. 576 KB is the DK'tronics hardware ceiling (64 KB base + 8 × 64 KB expansion banks). Extra RAM beyond 64 KB is accessible via DK'tronics-compatible banking (Gate Array port 0x7Fxx). Banking is supported on both the 464 and 6128. Changing RAM size triggers a cold boot on save.
+**RAM size** (Advanced → Memory): press Enter to cycle through 64, 128, 256, 512, 576, 768, and 1024 KB. Up to 576 KB uses DK'tronics-compatible banking (Gate Array port 0x7Fxx, data bits[5:3] select the 64 KB bank group). 768 KB and 1024 KB switch to the Yarek/RAM7 extended scheme, where port address bits A10–A8 carry an additional bank group selector: port 0x7Exx adds a second 512 KB block (576–1088 KB range), giving a practical ceiling of 1024 KB with bank_high values 0–1. Banking is supported on both the 464 and 6128. Changing RAM size triggers a cold boot on save.
 
 **CPC 464 and DD1:** on the 464, the Storage tab drives are greyed out by default. Enable **DD1** in the Advanced tab to activate the DDI-1 floppy interface — this enables drive access and loads AMSDOS into ROM slot 7. On the 6128, drives are always enabled and the DD1 option is greyed out.
 

--- a/src/config.c
+++ b/src/config.c
@@ -163,7 +163,8 @@ int config_load(Config *cfg) {
                 else { fprintf(stderr, "1984.conf:%d: unknown model '%s', using default\n", lineno, val); }
             } else if (!strcmp(key, "memory")) {
                 int kb = atoi(val);
-                if (kb == 64 || kb == 128 || kb == 256 || kb == 512 || kb == 576)
+                if (kb == 64 || kb == 128 || kb == 256 || kb == 512 || kb == 576
+                        || kb == 768 || kb == 1024)
                     cfg->memory_kb = kb;
                 else { fprintf(stderr, "1984.conf:%d: invalid memory '%s', using default (%d KB)\n", lineno, val, cfg->memory_kb); }
             }

--- a/src/cpc.c
+++ b/src/cpc.c
@@ -75,11 +75,17 @@ static void bus_io_write(void *ctx, u16 port, u8 val) {
         ga_write(&cpc->ga, val);
         cpc->mem.lower_rom_enabled = cpc->ga.lower_rom;
         cpc->mem.upper_rom_enabled = cpc->ga.upper_rom;
-        /* RAM banking — bits[5:0] select 16KB page for 0xC000-0xFFFF.
+        /* RAM banking — bits[5:0] of data select bank group and mode.
          * Standard on 6128; emulator extension enables it on 464 too
-         * when memory > 64 KB is configured. */
-        if ((val & 0xC0) == 0xC0)
-            cpc->mem.ram_bank = val & 0x3F;
+         * when memory > 64 KB is configured.
+         * Yarek extension: port address bits A10-A8 carry an upper bank_high
+         * selector for RAM above 576 KB. Port 0x7Fxx = bank_high 0 (DK'tronics
+         * compatible); 0x7Exx = 1, 0x7Dxx = 2, 0x7Cxx = 3. bank_high is packed
+         * into ram_bank bits[7:6] so banked_ram_offset() can read it. */
+        if ((val & 0xC0) == 0xC0) {
+            u8 bank_high = ((hi & 0xFC) == 0x7C) ? ((~hi) & 0x03) : 0;
+            cpc->mem.ram_bank = (u8)((bank_high << 6) | (val & 0x3F));
+        }
         return;
     }
     /* CRTC: A14=0 → 0xBCxx (select, A8=0) / 0xBDxx (write, A8=1) */

--- a/src/mem.c
+++ b/src/mem.c
@@ -101,9 +101,11 @@ void mem_unload_rom_ext(Mem *m, int slot) {
  * (handled in mem_read); writes always go to the banked RAM page (here).
  * Video reads (mem_read_video) bypass ROM and use this function directly. */
 static u32 banked_ram_offset(const Mem *m, u16 addr) {
-    u8  mode  = m->ram_bank & 0x07;
-    u8  group = (m->ram_bank >> 3) & 0x07;
-    u32 extra = (u32)(group + 1) * 0x10000u;   /* start of romb4-romb7 */
+    u8  mode      = m->ram_bank & 0x07;
+    u8  group     = (m->ram_bank >> 3) & 0x07;
+    u8  bank_high = (m->ram_bank >> 6) & 0x03;  /* Yarek upper bank group (0=DK'tronics) */
+    u32 full_bg   = (u32)bank_high * 8u + group;
+    u32 extra     = (full_bg + 1u) * 0x10000u;  /* start of romb4-romb7 */
 
     if (addr < 0x4000) {
         return (mode == 2) ? extra + (u32)addr : (u32)addr;

--- a/src/mem.h
+++ b/src/mem.h
@@ -10,15 +10,18 @@
  * Upper ROM slots: 0=BASIC, 7=AMSDOS. All others return 0xFF.
  * 464: 64 KB RAM, no extra banks
  * 6128: 128 KB RAM, banked via Gate Array (modes 0-7)
- * Expansion: DK'tronics-compatible banking via Gate Array bits[5:3]:
+ * Expansion — DK'tronics (≤576 KB): port 0x7Fxx, data bits[5:3] select bank group.
  *   bits[5:3]=0 → standard 6128 extra 64 KB (RAM banks at offset 64–128 KB)
  *   bits[5:3]=1–7 → 7 × 64 KB expansion banks (128–576 KB)
- *   Maximum: 64 KB base + 8 × 64 KB = 576 KB (DK'tronics ceiling).
+ * Expansion — Yarek/RAM7 (>576 KB): port address bits A10–A8 carry the upper
+ *   bank group (bank_high). Port 0x7Fxx = bank_high 0 (DK'tronics compatible).
+ *   Port 0x7Exx = bank_high 1 (576–1088 KB), 0x7Dxx = 2, 0x7Cxx = 3.
+ *   Full bank group = bank_high*8 + data_bits[5:3]; max 1024 KB with bank_high≤1.
  */
 
 #define ROM_OS_SIZE    0x4000
 #define ROM_BASIC_SIZE 0x4000
-#define RAM_SIZE       0x90000   /* 576 KB max (DK'tronics ceiling); actual usable size is Mem.ram_size */
+#define RAM_SIZE       0x100000  /* 1024 KB max (Yarek ceiling); actual usable size is Mem.ram_size */
 #define ROM_EXT_COUNT  32        /* expansion ROM slots 0-31 */
 
 typedef struct {

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -213,7 +213,7 @@ static void activate_item(Overlay *ov) {
     case OV_ADVANCED:
         switch (ov->row) {
         case 0: {
-            static const int sizes[] = { 64, 128, 256, 512, 576 };
+            static const int sizes[] = { 64, 128, 256, 512, 576, 768, 1024 };
             int n = (int)(sizeof(sizes) / sizeof(sizes[0]));
             int min_idx = (ov->cfg->model == MODEL_6128) ? 1 : 0;
             int cur = min_idx;


### PR DESCRIPTION
DK'tronics banking (port 0x7Fxx) tops out at 576 KB. The Yarek/RAM7 extended scheme uses port address bits A10-A8 as an upper bank group selector: port 0x7Exx (bank_high=1) adds a second 512 KB block, giving a usable ceiling of 1024 KB. Port 0x7Fxx (bank_high=0) is fully DK'tronics compatible.

- mem.h: RAM_SIZE increased from 576 KB to 1024 KB
- mem.c: banked_ram_offset() extracts bank_high from ram_bank bits[7:6] and computes full_bg = bank_high*8 + group for the extra page base
- cpc.c: RAM bank write encodes bank_high from port hi byte into ram_bank bits[7:6] when port is in the Yarek range (hi & 0xFC == 0x7C)
- config.c, overlay.c: 768 and 1024 added as valid memory sizes
- README: updated RAM size description