### PR TITLE
Replace PNG screenshots with PPM; drop libpng dependency #31

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,8 +18,8 @@ bin_PROGRAMS = 1984
 	src/psg.c \
 	src/z80.c
 
-1984_CFLAGS  = $(AM_CFLAGS) $(SDL3_CFLAGS) $(LIBPNG_CFLAGS) -Wall -Wextra
-1984_LDADD   = $(SDL3_LIBS) $(LIBPNG_LIBS) -lm
+1984_CFLAGS  = $(AM_CFLAGS) $(SDL3_CFLAGS) -Wall -Wextra
+1984_LDADD   = $(SDL3_LIBS) -lm
 
 # Keep the hand-written Makefile usable alongside autotools
 EXTRA_DIST = Makefile

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Boots to Locomotive BASIC. Keyboard, disk (DSK images via µPD765 FDC), AMSDOS f
 
 - GCC (C11)
 - SDL3
-- libpng
 - CPC ROM images (not included — dump your own or source from the web)
 
 ## Build
@@ -133,7 +132,7 @@ The machine model can be selected from the command line (`--464` / `--6128`) or 
 
 | Key    | Action |
 |--------|--------|
-| F4     | Save screenshot (`<binary>_<timestamp>.png`) and play camera shutter sound |
+| F4     | Save screenshot (`<binary>_<timestamp>.ppm`) and play camera shutter sound |
 | F5     | Warm reset |
 | F9     | Open/close options overlay |
 | F11    | Toggle fullscreen |

--- a/configure.ac
+++ b/configure.ac
@@ -15,9 +15,8 @@ AC_SUBST([AM_CFLAGS])
 PKG_PROG_PKG_CONFIG
 
 # Required libraries
-PKG_CHECK_MODULES([SDL3],   [sdl3],   [], [AC_MSG_ERROR([SDL3 not found])])
-PKG_CHECK_MODULES([LIBPNG], [libpng], [], [AC_MSG_ERROR([libpng not found])])
-AC_CHECK_LIB([m], [sqrt],  [], [AC_MSG_ERROR([libm not found])])
+PKG_CHECK_MODULES([SDL3], [sdl3], [], [AC_MSG_ERROR([SDL3 not found])])
+AC_CHECK_LIB([m], [sqrt], [], [AC_MSG_ERROR([libm not found])])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/src/display.c
+++ b/src/display.c
@@ -1,7 +1,6 @@
 #include "display.h"
 #include <string.h>
 #include <stdio.h>
-#include <png.h>
 
 int display_init(Display *d, const char *title) {
     memset(d, 0, sizeof(*d));
@@ -77,41 +76,25 @@ void display_flip(Display *d) {
     SDL_RenderPresent(d->renderer);
 }
 
-void display_save_png(Display *d, const char *path) {
+void display_save_ppm(Display *d, const char *path) {
     FILE *f = fopen(path, "wb");
     if (!f) return;
 
-    png_structp png = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
-    if (!png) { fclose(f); return; }
-    png_infop info = png_create_info_struct(png);
-    if (!info) { png_destroy_write_struct(&png, NULL); fclose(f); return; }
-
-    if (setjmp(png_jmpbuf(png))) {
-        png_destroy_write_struct(&png, &info);
-        fclose(f);
-        return;
-    }
-
-    png_init_io(png, f);
-    png_set_IHDR(png, info, CPC_SCREEN_W, WINDOW_H, 8,
-                 PNG_COLOR_TYPE_RGB, PNG_INTERLACE_NONE,
-                 PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
-    png_write_info(png, info);
+    fprintf(f, "P6\n%d %d\n255\n", CPC_SCREEN_W, WINDOW_H);
 
     /* Scale vertically from CPC_SCREEN_H to WINDOW_H for correct 4:3 aspect */
-    png_byte row[CPC_SCREEN_W * 3];
     for (int y = 0; y < WINDOW_H; y++) {
         int src_y = y * CPC_SCREEN_H / WINDOW_H;
         for (int x = 0; x < CPC_SCREEN_W; x++) {
             u32 px = d->pixels[src_y * CPC_SCREEN_W + x];
-            row[x * 3 + 0] = (px >> 16) & 0xFF;
-            row[x * 3 + 1] = (px >>  8) & 0xFF;
-            row[x * 3 + 2] =  px        & 0xFF;
+            unsigned char rgb[3] = {
+                (px >> 16) & 0xFF,
+                (px >>  8) & 0xFF,
+                 px        & 0xFF,
+            };
+            fwrite(rgb, 1, 3, f);
         }
-        png_write_row(png, row);
     }
 
-    png_write_end(png, NULL);
-    png_destroy_write_struct(&png, &info);
     fclose(f);
 }

--- a/src/display.h
+++ b/src/display.h
@@ -30,4 +30,4 @@ void display_next_line(Display *d);
 void display_vsync(Display *d);
 void display_upload(Display *d);   /* update texture + blit to renderer (no flip) */
 void display_flip(Display *d);     /* SDL_RenderPresent */
-void display_save_png(Display *d, const char *path);
+void display_save_ppm(Display *d, const char *path);

--- a/src/main.c
+++ b/src/main.c
@@ -33,7 +33,7 @@ static void usage(const char *prog, int code) {
         "  -h, --help          Show this help and exit\n"
         "\n"
         "Keyboard shortcuts:\n"
-        "  F4     Save screenshot\n"
+        "  F4     Save screenshot (.ppm)\n"
         "  F5     Warm reset\n"
         "  F9     Options overlay\n"
         "  F11    Toggle fullscreen\n"
@@ -239,8 +239,8 @@ int main(int argc, char *argv[]) {
                     char tmp[256];
                     strncpy(tmp, argv[0], sizeof(tmp) - 1);
                     tmp[sizeof(tmp) - 1] = '\0';
-                    snprintf(path, sizeof(path), "%s_%ld.png", basename(tmp), (long)time(NULL));
-                    display_save_png(&cpc.display, path);
+                    snprintf(path, sizeof(path), "%s_%ld.ppm", basename(tmp), (long)time(NULL));
+                    display_save_ppm(&cpc.display, path);
                     if (sfx_stream && sfx_buf) {
                         SDL_ClearAudioStream(sfx_stream);
                         SDL_PutAudioStreamData(sfx_stream, sfx_buf, (int)sfx_buf_len);
@@ -326,7 +326,7 @@ int main(int argc, char *argv[]) {
                 if (hist[i]) fprintf(stderr, "  [%02X] = %d\n", i, hist[i]);
         }
         if (screenshot_frame >= 0 && frame_count == screenshot_frame) {
-            display_save_png(&cpc.display, screenshot_path);
+            display_save_ppm(&cpc.display, screenshot_path);
             running = false;
         }
 


### PR DESCRIPTION
PPM (P6 binary) needs no external library — the writer is 15 lines of plain stdio. configure.ac and Makefile.am updated to remove the PKG_CHECK_MODULES([LIBPNG]) check and all LIBPNG_CFLAGS/LIBPNG_LIBS references. display_save_png() renamed to display_save_ppm(); F4 and --screenshot-at now produce .ppm files.