### PR TITLE
feat: add SYMBiFACE II / Cyboard compatible IDE emulation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ am_1984_OBJECTS = src/1984-config.$(OBJEXT) src/1984-cpc.$(OBJEXT) \
 	src/1984-main.$(OBJEXT) src/1984-mem.$(OBJEXT) \
 	src/1984-overlay.$(OBJEXT) src/1984-paste.$(OBJEXT) \
 	src/1984-ppi.$(OBJEXT) src/1984-psg.$(OBJEXT) \
-	src/1984-rtc.$(OBJEXT) src/1984-z80.$(OBJEXT)
+	src/1984-rtc.$(OBJEXT) src/1984-ide.$(OBJEXT) src/1984-z80.$(OBJEXT)
 1984_OBJECTS = $(am_1984_OBJECTS)
 am__DEPENDENCIES_1 =
 1984_DEPENDENCIES = $(am__DEPENDENCIES_1)
@@ -144,7 +144,7 @@ am__depfiles_remade = src/$(DEPDIR)/1984-config.Po \
 	src/$(DEPDIR)/1984-monitor.Po src/$(DEPDIR)/1984-net4cpc.Po \
 	src/$(DEPDIR)/1984-overlay.Po src/$(DEPDIR)/1984-paste.Po \
 	src/$(DEPDIR)/1984-ppi.Po src/$(DEPDIR)/1984-psg.Po \
-	src/$(DEPDIR)/1984-rtc.Po src/$(DEPDIR)/1984-z80.Po \
+	src/$(DEPDIR)/1984-rtc.Po src/$(DEPDIR)/1984-ide.Po src/$(DEPDIR)/1984-z80.Po \
 	src/$(DEPDIR)/1984-z80dis.Po
 am__mv = mv -f
 AM_V_lt = $(am__v_lt_$(V))
@@ -331,6 +331,7 @@ top_srcdir = .
 	src/ppi.c \
 	src/psg.c \
 	src/rtc.c \
+	src/ide.c \
 	src/z80.c
 
 1984_CFLAGS = $(AM_CFLAGS) $(SDL3_CFLAGS) -Wall -Wextra
@@ -461,6 +462,8 @@ src/1984-psg.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-rtc.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
+src/1984-ide.$(OBJEXT): src/$(am__dirstamp) \
+	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-z80.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 
@@ -493,6 +496,7 @@ include src/$(DEPDIR)/1984-paste.Po # am--include-marker
 include src/$(DEPDIR)/1984-ppi.Po # am--include-marker
 include src/$(DEPDIR)/1984-psg.Po # am--include-marker
 include src/$(DEPDIR)/1984-rtc.Po # am--include-marker
+include src/$(DEPDIR)/1984-ide.Po # am--include-marker
 include src/$(DEPDIR)/1984-z80.Po # am--include-marker
 include src/$(DEPDIR)/1984-z80dis.Po # am--include-marker
 
@@ -783,6 +787,20 @@ src/1984-rtc.obj: src/rtc.c
 #	$(AM_V_CC)source='src/rtc.c' object='src/1984-rtc.obj' libtool=no \
 #	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) \
 #	$(AM_V_CC_no)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-rtc.obj `if test -f 'src/rtc.c'; then $(CYGPATH_W) 'src/rtc.c'; else $(CYGPATH_W) '$(srcdir)/src/rtc.c'; fi`
+
+src/1984-ide.o: src/ide.c
+	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-ide.o -MD -MP -MF src/$(DEPDIR)/1984-ide.Tpo -c -o src/1984-ide.o `test -f 'src/ide.c' || echo '$(srcdir)/'`src/ide.c
+	$(AM_V_at)$(am__mv) src/$(DEPDIR)/1984-ide.Tpo src/$(DEPDIR)/1984-ide.Po
+#	$(AM_V_CC)source='src/ide.c' object='src/1984-ide.o' libtool=no \
+#	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) \
+#	$(AM_V_CC_no)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-ide.o `test -f 'src/ide.c' || echo '$(srcdir)/'`src/ide.c
+
+src/1984-ide.obj: src/ide.c
+	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-ide.obj -MD -MP -MF src/$(DEPDIR)/1984-ide.Tpo -c -o src/1984-ide.obj `if test -f 'src/ide.c'; then $(CYGPATH_W) 'src/ide.c'; else $(CYGPATH_W) '$(srcdir)/src/ide.c'; fi`
+	$(AM_V_at)$(am__mv) src/$(DEPDIR)/1984-ide.Tpo src/$(DEPDIR)/1984-ide.Po
+#	$(AM_V_CC)source='src/ide.c' object='src/1984-ide.obj' libtool=no \
+#	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) \
+#	$(AM_V_CC_no)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-ide.obj `if test -f 'src/ide.c'; then $(CYGPATH_W) 'src/ide.c'; else $(CYGPATH_W) '$(srcdir)/src/ide.c'; fi`
 
 src/1984-z80.o: src/z80.c
 	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-z80.o -MD -MP -MF src/$(DEPDIR)/1984-z80.Tpo -c -o src/1984-z80.o `test -f 'src/z80.c' || echo '$(srcdir)/'`src/z80.c
@@ -1098,6 +1116,7 @@ distclean: distclean-am
 	-rm -f src/$(DEPDIR)/1984-ppi.Po
 	-rm -f src/$(DEPDIR)/1984-psg.Po
 	-rm -f src/$(DEPDIR)/1984-rtc.Po
+	-rm -f src/$(DEPDIR)/1984-ide.Po
 	-rm -f src/$(DEPDIR)/1984-z80.Po
 	-rm -f src/$(DEPDIR)/1984-z80dis.Po
 	-rm -f Makefile

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,7 @@ bin_PROGRAMS = 1984
 	src/ppi.c \
 	src/psg.c \
 	src/rtc.c \
+	src/ide.c \
 	src/z80.c
 
 1984_CFLAGS  = $(AM_CFLAGS) $(SDL3_CFLAGS) -Wall -Wextra

--- a/Makefile.in
+++ b/Makefile.in
@@ -114,7 +114,7 @@ am_1984_OBJECTS = src/1984-config.$(OBJEXT) src/1984-cpc.$(OBJEXT) \
 	src/1984-main.$(OBJEXT) src/1984-mem.$(OBJEXT) \
 	src/1984-overlay.$(OBJEXT) src/1984-paste.$(OBJEXT) \
 	src/1984-ppi.$(OBJEXT) src/1984-psg.$(OBJEXT) \
-	src/1984-rtc.$(OBJEXT) src/1984-z80.$(OBJEXT)
+	src/1984-rtc.$(OBJEXT) src/1984-ide.$(OBJEXT) src/1984-z80.$(OBJEXT)
 1984_OBJECTS = $(am_1984_OBJECTS)
 am__DEPENDENCIES_1 =
 1984_DEPENDENCIES = $(am__DEPENDENCIES_1)
@@ -144,7 +144,7 @@ am__depfiles_remade = src/$(DEPDIR)/1984-config.Po \
 	src/$(DEPDIR)/1984-monitor.Po src/$(DEPDIR)/1984-net4cpc.Po \
 	src/$(DEPDIR)/1984-overlay.Po src/$(DEPDIR)/1984-paste.Po \
 	src/$(DEPDIR)/1984-ppi.Po src/$(DEPDIR)/1984-psg.Po \
-	src/$(DEPDIR)/1984-rtc.Po src/$(DEPDIR)/1984-z80.Po \
+	src/$(DEPDIR)/1984-rtc.Po src/$(DEPDIR)/1984-ide.Po src/$(DEPDIR)/1984-z80.Po \
 	src/$(DEPDIR)/1984-z80dis.Po
 am__mv = mv -f
 AM_V_lt = $(am__v_lt_@AM_V@)
@@ -331,6 +331,7 @@ top_srcdir = @top_srcdir@
 	src/ppi.c \
 	src/psg.c \
 	src/rtc.c \
+	src/ide.c \
 	src/z80.c
 
 1984_CFLAGS = $(AM_CFLAGS) $(SDL3_CFLAGS) -Wall -Wextra
@@ -461,6 +462,8 @@ src/1984-psg.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-rtc.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
+src/1984-ide.$(OBJEXT): src/$(am__dirstamp) \
+	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-z80.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 
@@ -493,6 +496,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-ppi.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-psg.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-rtc.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-ide.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-z80.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-z80dis.Po@am__quote@ # am--include-marker
 
@@ -783,6 +787,20 @@ src/1984-rtc.obj: src/rtc.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/rtc.c' object='src/1984-rtc.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-rtc.obj `if test -f 'src/rtc.c'; then $(CYGPATH_W) 'src/rtc.c'; else $(CYGPATH_W) '$(srcdir)/src/rtc.c'; fi`
+
+src/1984-ide.o: src/ide.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-ide.o -MD -MP -MF src/$(DEPDIR)/1984-ide.Tpo -c -o src/1984-ide.o `test -f 'src/ide.c' || echo '$(srcdir)/'`src/ide.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/1984-ide.Tpo src/$(DEPDIR)/1984-ide.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/ide.c' object='src/1984-ide.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-ide.o `test -f 'src/ide.c' || echo '$(srcdir)/'`src/ide.c
+
+src/1984-ide.obj: src/ide.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-ide.obj -MD -MP -MF src/$(DEPDIR)/1984-ide.Tpo -c -o src/1984-ide.obj `if test -f 'src/ide.c'; then $(CYGPATH_W) 'src/ide.c'; else $(CYGPATH_W) '$(srcdir)/src/ide.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/1984-ide.Tpo src/$(DEPDIR)/1984-ide.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/ide.c' object='src/1984-ide.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-ide.obj `if test -f 'src/ide.c'; then $(CYGPATH_W) 'src/ide.c'; else $(CYGPATH_W) '$(srcdir)/src/ide.c'; fi`
 
 src/1984-z80.o: src/z80.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-z80.o -MD -MP -MF src/$(DEPDIR)/1984-z80.Tpo -c -o src/1984-z80.o `test -f 'src/z80.c' || echo '$(srcdir)/'`src/z80.c
@@ -1098,6 +1116,7 @@ distclean: distclean-am
 	-rm -f src/$(DEPDIR)/1984-ppi.Po
 	-rm -f src/$(DEPDIR)/1984-psg.Po
 	-rm -f src/$(DEPDIR)/1984-rtc.Po
+	-rm -f src/$(DEPDIR)/1984-ide.Po
 	-rm -f src/$(DEPDIR)/1984-z80.Po
 	-rm -f src/$(DEPDIR)/1984-z80dis.Po
 	-rm -f Makefile

--- a/src/config.c
+++ b/src/config.c
@@ -105,6 +105,8 @@ static void config_create_default(const char *path, const char *home) {
         "ulifac=false\n"
         "net4cpc=false\n"
         "rtc=false\n"
+        "symbiface_ide=false\n"
+        "ide_image=\n"
         "\n"
         "[display]\n"
         "# Window scale factor: 1, 2, or 3\n"
@@ -204,6 +206,11 @@ int config_load(Config *cfg) {
             } else if (!strcmp(key, "rtc")) {
                 if (parse_bool(val, &b)) cfg->rtc = b;
                 else { fprintf(stderr, "1984.conf:%d: rtc must be true/false\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "symbiface_ide")) {
+                if (parse_bool(val, &b)) cfg->symbiface_ide = b;
+                else { fprintf(stderr, "1984.conf:%d: symbiface_ide must be true/false\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "ide_image")) {
+                if (val[0]) expand_path(val, cfg->ide_image, sizeof(cfg->ide_image));
             }
         } else if (!strcmp(section, "display")) {
             if (!strcmp(key, "scale")) {
@@ -276,7 +283,9 @@ int config_save(const Config *cfg) {
         "m4=%s\n"
         "ulifac=%s\n"
         "net4cpc=%s\n"
-        "rtc=%s\n\n"
+        "rtc=%s\n"
+        "symbiface_ide=%s\n"
+        "ide_image=%s\n\n"
         "[display]\n"
         "scale=%d\n"
         "fullscreen=%s\n",
@@ -285,8 +294,10 @@ int config_save(const Config *cfg) {
         cfg->dd1     ? "true" : "false",
         cfg->m4      ? "true" : "false",
         cfg->ulifac  ? "true" : "false",
-        cfg->net4cpc ? "true" : "false",
-        cfg->rtc     ? "true" : "false",
+        cfg->net4cpc       ? "true" : "false",
+        cfg->rtc           ? "true" : "false",
+        cfg->symbiface_ide ? "true" : "false",
+        cfg->ide_image,
         cfg->scale,
         cfg->fullscreen ? "true" : "false"
     );

--- a/src/config.h
+++ b/src/config.h
@@ -27,6 +27,8 @@ typedef struct {
     bool ulifac;
     bool net4cpc;
     bool rtc;
+    bool symbiface_ide;
+    char ide_image[CONFIG_PATH_MAX];
 
     /* [display] */
     int  scale;             /* 1, 2, or 3 */

--- a/src/cpc.c
+++ b/src/cpc.c
@@ -54,10 +54,12 @@ static u8 bus_io_read(void *ctx, u16 port) {
     else if (hi == 0xFA) {
         result = 0xFF;
     }
-    /* hi=0xFD: RTC (0xFD14) and Net4CPC W5100S (0xFD20-0xFD23) */
+    /* hi=0xFD: IDE (0xFD06, 0xFD08-0xFD0F), RTC (0xFD14), Net4CPC W5100S (0xFD20-0xFD23) */
     else if (hi == 0xFD) {
         u8 lo = port & 0xFF;
-        if (cpc->rtc && lo == 0x14)
+        if (cpc->symbiface_ide && (lo == 0x06 || (lo >= 0x08 && lo <= 0x0F)))
+            result = ide_read(&cpc->ide_chip, lo);
+        else if (cpc->rtc && lo == 0x14)
             result = rtc_read_data(&cpc->rtc_chip);
         else if (cpc->net4cpc && lo >= 0x20 && lo <= 0x23)
             result = net4cpc_in(lo & 0x03);
@@ -136,9 +138,12 @@ static void bus_io_write(void *ctx, u16 port, u8 val) {
     if (hi == 0xFA) { fdc_motor_write(&cpc->fdc, val); return; }
     /* FDC data: hi=0xFB, write */
     if (hi == 0xFB) { fdc_write_data(&cpc->fdc, val); return; }
-    /* hi=0xFD: RTC (0xFD14/0xFD15) and Net4CPC W5100S (0xFD20-0xFD23) */
+    /* hi=0xFD: IDE (0xFD06, 0xFD08-0xFD0F), RTC (0xFD14/0xFD15), Net4CPC (0xFD20-0xFD23) */
     if (hi == 0xFD) {
         u8 lo = port & 0xFF;
+        if (cpc->symbiface_ide && (lo == 0x06 || (lo >= 0x08 && lo <= 0x0F))) {
+            ide_write(&cpc->ide_chip, lo, val); return;
+        }
         if (cpc->rtc) {
             if (lo == 0x15) { rtc_write_addr(&cpc->rtc_chip, val); return; }
             if (lo == 0x14) { rtc_write_data(&cpc->rtc_chip, val); return; }
@@ -174,6 +179,7 @@ int cpc_init(CPC *cpc, CpcModel model, const char *rom_os, const char *rom_basic
     disk_init(&cpc->drive[1]);
     fdc_init(&cpc->fdc, &cpc->drive[0], &cpc->drive[1]);
     rtc_init(&cpc->rtc_chip);
+    ide_init(&cpc->ide_chip);
     net4cpc_reset();
 
     cpc->bus.mem_read  = bus_mem_read;
@@ -206,6 +212,7 @@ void cpc_reset(CPC *cpc) {
     kbd_init(&cpc->kbd);
     fdc_reset(&cpc->fdc);
     rtc_init(&cpc->rtc_chip);
+    ide_reset(&cpc->ide_chip);  /* keeps image file open across warm reset */
     cpc->mem.lower_rom_enabled = true;
     cpc->mem.upper_rom_enabled = true;
     cpc->mem.ram_bank = 0;
@@ -220,6 +227,7 @@ void cpc_destroy(CPC *cpc) {
     if (cpc->audio_stream) SDL_DestroyAudioStream(cpc->audio_stream);
     disk_eject(&cpc->drive[0]);
     disk_eject(&cpc->drive[1]);
+    ide_close(&cpc->ide_chip);
     display_destroy(&cpc->display);
 }
 

--- a/src/cpc.h
+++ b/src/cpc.h
@@ -11,6 +11,7 @@
 #include "fdc.h"
 #include "disk.h"
 #include "rtc.h"
+#include "ide.h"
 
 typedef enum { MODEL_464, MODEL_6128 } CpcModel;
 
@@ -28,9 +29,11 @@ typedef struct {
     SDL_AudioStream *audio_stream;
     Disk       drive[2];    /* drive[0]=A, drive[1]=B */
     FDC        fdc;
-    bool       net4cpc;    /* Net4CPC W5100S Ethernet add-on present */
-    bool       rtc;        /* Real-time clock add-on present */
+    bool       net4cpc;       /* Net4CPC W5100S Ethernet add-on present */
+    bool       rtc;           /* Real-time clock add-on present */
     RTC        rtc_chip;
+    bool       symbiface_ide; /* SYMBiFACE II / Cyboard IDE add-on present */
+    IDE        ide_chip;
 
     /* Timing */
     int  cpu_clk_hz;      /* 4 MHz */

--- a/src/ide.c
+++ b/src/ide.c
@@ -1,0 +1,253 @@
+#define _POSIX_C_SOURCE 200112L
+#define _FILE_OFFSET_BITS 64
+#include "ide.h"
+#include <string.h>
+#include <stdio.h>
+#include <sys/types.h>
+
+/* ---- Helpers ---- */
+
+static u32 lba_addr(const IDE *ide) {
+    return (u32)ide->lba_low
+         | ((u32)ide->lba_mid   <<  8)
+         | ((u32)ide->lba_high  << 16)
+         | ((u32)(ide->device & 0x0F) << 24);
+}
+
+static void set_error(IDE *ide, u8 err) {
+    ide->error  = err;
+    ide->status = IDE_STATUS_DRDY | IDE_STATUS_ERR;
+}
+
+static bool load_sector(IDE *ide, u32 lba) {
+    if (!ide->fp || (u64)lba >= ide->num_sectors) {
+        set_error(ide, IDE_ERR_IDNF);
+        return false;
+    }
+    if (fseeko(ide->fp, (off_t)lba * 512, SEEK_SET) != 0 ||
+        fread(ide->buf, 512, 1, ide->fp) != 1) {
+        set_error(ide, IDE_ERR_ABRT);
+        return false;
+    }
+    return true;
+}
+
+static bool flush_sector(IDE *ide, u32 lba) {
+    if (!ide->fp || (u64)lba >= ide->num_sectors) {
+        set_error(ide, IDE_ERR_IDNF);
+        return false;
+    }
+    if (fseeko(ide->fp, (off_t)lba * 512, SEEK_SET) != 0 ||
+        fwrite(ide->buf, 512, 1, ide->fp) != 1) {
+        set_error(ide, IDE_ERR_ABRT);
+        return false;
+    }
+    fflush(ide->fp);
+    return true;
+}
+
+/* ---- IDENTIFY DEVICE response (512 bytes, ATA word layout) ---- */
+
+/* Write an ATA byte-swapped string into buf starting at word wstart (40-char field). */
+static void ata_str(u8 *buf, int wstart, const char *s, int nwords) {
+    for (int i = 0; i < nwords; i++) {
+        char c0 = s[2 * i]     ? s[2 * i]     : ' ';
+        char c1 = s[2 * i + 1] ? s[2 * i + 1] : ' ';
+        buf[2 * (wstart + i)]     = (u8)c1;  /* ATA: high byte = 1st char */
+        buf[2 * (wstart + i) + 1] = (u8)c0;
+    }
+}
+
+static void setw(u8 *buf, int word, u16 val) {
+    buf[2 * word]     = (u8)(val & 0xFF);
+    buf[2 * word + 1] = (u8)(val >> 8);
+}
+
+static void build_identify(IDE *ide) {
+    memset(ide->buf, 0, 512);
+
+    u32 nsec = (u32)(ide->num_sectors > 0x0FFFFFFFu ? 0x0FFFFFFFu : ide->num_sectors);
+    u32 cyls = nsec / (16u * 63u);
+    if (cyls < 1) cyls = 1;
+    if (cyls > 65535u) cyls = 65535u;
+
+    setw(ide->buf,  0, 0x0040);               /* non-removable ATA device */
+    setw(ide->buf,  1, (u16)cyls);            /* CHS cylinders */
+    setw(ide->buf,  3, 16);                   /* CHS heads */
+    setw(ide->buf,  6, 63);                   /* CHS sectors per track */
+
+    ata_str(ide->buf, 10, "1984EMULATORIDE     ", 10); /* serial (words 10-19) */
+    ata_str(ide->buf, 23, "1.0     ",             4);  /* firmware (words 23-26) */
+    ata_str(ide->buf, 27, "1984 IDE Drive                          ", 20); /* model */
+
+    setw(ide->buf, 49, 0x0200);               /* capabilities: LBA supported */
+    setw(ide->buf, 53, 0x0001);               /* words 54-58 valid */
+    setw(ide->buf, 54, (u16)cyls);
+    setw(ide->buf, 55, 16);
+    setw(ide->buf, 56, 63);
+    u32 chs_cap = cyls * 16u * 63u;
+    setw(ide->buf, 57, (u16)(chs_cap & 0xFFFFu));
+    setw(ide->buf, 58, (u16)(chs_cap >> 16));
+    setw(ide->buf, 60, (u16)(nsec & 0xFFFFu)); /* total LBA sectors low */
+    setw(ide->buf, 61, (u16)(nsec >> 16));      /* total LBA sectors high */
+    setw(ide->buf, 80, 0x0006);               /* ATA-1 / ATA-2 compatible */
+}
+
+/* ---- Command execution ---- */
+
+static void exec_cmd(IDE *ide, u8 cmd) {
+    ide->cmd     = cmd;
+    ide->error   = 0;
+    ide->buf_pos = 0;
+
+    switch (cmd) {
+    case 0x91:  /* INITIALIZE DRIVE PARAMETERS */
+    case 0xEF:  /* SET FEATURES */
+        ide->status = IDE_STATUS_DRDY;
+        break;
+
+    case 0xEC:  /* IDENTIFY DEVICE */
+        if (!ide->fp) { set_error(ide, IDE_ERR_ABRT); break; }
+        build_identify(ide);
+        ide->buf_pos      = 0;
+        ide->writing      = false;
+        ide->status       = IDE_STATUS_DRDY | IDE_STATUS_DRQ;
+        break;
+
+    case 0x20:  /* READ SECTORS (with retry) */
+    case 0x21:  /* READ SECTORS (without retry) */
+        ide->current_lba  = lba_addr(ide);
+        ide->sectors_left = ide->sector_count ? (int)ide->sector_count : 256;
+        ide->writing      = false;
+        if (load_sector(ide, ide->current_lba)) {
+            ide->buf_pos = 0;
+            ide->status  = IDE_STATUS_DRDY | IDE_STATUS_DRQ;
+        }
+        break;
+
+    case 0x30:  /* WRITE SECTORS (with retry) */
+    case 0x31:  /* WRITE SECTORS (without retry) */
+        ide->current_lba  = lba_addr(ide);
+        ide->sectors_left = ide->sector_count ? (int)ide->sector_count : 256;
+        ide->writing      = true;
+        ide->buf_pos      = 0;
+        ide->status       = IDE_STATUS_DRDY | IDE_STATUS_DRQ;
+        break;
+
+    default:
+        set_error(ide, IDE_ERR_ABRT);
+        break;
+    }
+}
+
+/* ---- Public API ---- */
+
+void ide_init(IDE *ide) {
+    memset(ide, 0, sizeof(*ide));
+    /* fp and num_sectors intentionally zeroed — caller must call ide_open */
+}
+
+void ide_reset(IDE *ide) {
+    /* Soft reset: preserve open file, reset ATA task-file */
+    FILE *fp  = ide->fp;
+    u64   ns  = ide->num_sectors;
+    memset(ide, 0, sizeof(*ide));
+    ide->fp          = fp;
+    ide->num_sectors = ns;
+    ide->status      = fp ? IDE_STATUS_DRDY : 0x00;
+}
+
+void ide_open(IDE *ide, const char *path) {
+    ide_close(ide);
+    ide->fp = fopen(path, "r+b");
+    if (!ide->fp) {
+        fprintf(stderr, "1984: IDE: cannot open image '%s'\n", path);
+        ide->status = 0x00;  /* drive not ready */
+        return;
+    }
+    fseeko(ide->fp, 0, SEEK_END);
+    off_t sz = ftello(ide->fp);
+    ide->num_sectors = (u64)(sz > 0 ? sz : 0) / 512;
+    ide->status      = IDE_STATUS_DRDY;
+}
+
+void ide_close(IDE *ide) {
+    if (ide->fp) {
+        fclose(ide->fp);
+        ide->fp = NULL;
+    }
+    ide->num_sectors = 0;
+    ide->status      = 0x00;
+}
+
+u8 ide_read(IDE *ide, u8 reg) {
+    switch (reg) {
+    case 0x06:  return ide->status;  /* alternate status — no side effects */
+    case 0x08:  /* data */
+        if (!(ide->status & IDE_STATUS_DRQ) || ide->writing) return 0xFF;
+        if (ide->buf_pos >= 512) return 0xFF;
+        {
+            u8 val = ide->buf[ide->buf_pos++];
+            if (ide->buf_pos == 512) {
+                if (ide->cmd == 0xEC) {
+                    ide->status = IDE_STATUS_DRDY;
+                } else {
+                    ide->current_lba++;
+                    ide->sectors_left--;
+                    if (ide->sectors_left > 0 && load_sector(ide, ide->current_lba)) {
+                        ide->buf_pos = 0;
+                    } else {
+                        ide->status = IDE_STATUS_DRDY;
+                    }
+                }
+            }
+            return val;
+        }
+    case 0x09:  return ide->error;
+    case 0x0A:  return ide->sector_count;
+    case 0x0B:  return ide->lba_low;
+    case 0x0C:  return ide->lba_mid;
+    case 0x0D:  return ide->lba_high;
+    case 0x0E:  return ide->device;
+    case 0x0F:  return ide->status;
+    default:    return 0xFF;
+    }
+}
+
+void ide_write(IDE *ide, u8 reg, u8 val) {
+    switch (reg) {
+    case 0x06:  /* device control */
+        ide->control = val;
+        if (val & 0x04) ide_reset(ide);  /* SRST */
+        break;
+    case 0x08:  /* data */
+        if (!(ide->status & IDE_STATUS_DRQ) || !ide->writing) return;
+        if (ide->buf_pos < 512) {
+            ide->buf[ide->buf_pos++] = val;
+            if (ide->buf_pos == 512) {
+                flush_sector(ide, ide->current_lba);
+                ide->current_lba++;
+                ide->sectors_left--;
+                if (ide->sectors_left > 0) {
+                    ide->buf_pos = 0;
+                    /* DRQ remains set; host writes next sector */
+                } else {
+                    ide->status = IDE_STATUS_DRDY;
+                }
+            }
+        }
+        break;
+    case 0x09:  ide->features     = val; break;
+    case 0x0A:  ide->sector_count = val; break;
+    case 0x0B:  ide->lba_low      = val; break;
+    case 0x0C:  ide->lba_mid      = val; break;
+    case 0x0D:  ide->lba_high     = val; break;
+    case 0x0E:  ide->device       = val; break;
+    case 0x0F:
+        if (ide->fp) exec_cmd(ide, val);
+        else set_error(ide, IDE_ERR_ABRT);
+        break;
+    default:
+        break;
+    }
+}

--- a/src/ide.h
+++ b/src/ide.h
@@ -1,0 +1,63 @@
+#pragma once
+#include "types.h"
+#include <stdio.h>
+
+/* DS12887-compatible IDE emulation for the SYMBiFACE II / Cyboard add-on.
+ *
+ * Port map (CPC I/O):
+ *   0xFD06  r/w  Data register (16-bit ATA word served as 2 consecutive bytes)
+ *   0xFD07  r    Error register   /  w  Features
+ *   0xFD08  r/w  Sector Count
+ *   0xFD09  r/w  LBA Low  (sector number)
+ *   0xFD0A  r/w  LBA Mid  (cylinder low)
+ *   0xFD0B  r/w  LBA High (cylinder high)
+ *   0xFD0C  r/w  Device/Head (bits 3-0 = LBA bits 27-24)
+ *   0xFD0D  r    Status  /  w  Command
+ *   0xFD0E  r    Alternate Status  /  w  Device Control
+ *
+ * Backend: raw disk image file (FAT16/FAT32 formatted).
+ * Only LBA addressing is supported.
+ */
+
+#define IDE_STATUS_BSY  0x80u
+#define IDE_STATUS_DRDY 0x40u
+#define IDE_STATUS_DRQ  0x08u
+#define IDE_STATUS_ERR  0x01u
+
+#define IDE_ERR_ABRT    0x04u
+#define IDE_ERR_IDNF    0x10u
+
+typedef struct {
+    /* ATA task-file registers */
+    u8  error;
+    u8  features;
+    u8  sector_count;
+    u8  lba_low;
+    u8  lba_mid;
+    u8  lba_high;
+    u8  device;
+    u8  status;
+    u8  control;
+    u8  cmd;
+
+    /* Sector transfer buffer */
+    u8  buf[512];
+    int buf_pos;
+
+    /* Multi-sector transfer state */
+    u32 current_lba;
+    int sectors_left;
+    bool writing;
+
+    /* Backend */
+    FILE *fp;
+    u64   num_sectors;
+} IDE;
+
+void ide_init(IDE *ide);    /* full init — does not touch fp/num_sectors */
+void ide_reset(IDE *ide);   /* soft reset — resets ATA state, keeps file open */
+void ide_open(IDE *ide, const char *path);
+void ide_close(IDE *ide);
+
+u8   ide_read(IDE *ide, u8 reg);     /* reg = lo byte of CPC port (0x06–0x0E) */
+void ide_write(IDE *ide, u8 reg, u8 val);

--- a/src/main.c
+++ b/src/main.c
@@ -152,8 +152,11 @@ int main(int argc, char *argv[]) {
         return 1;
     }
     cpc.mem.ram_size = cfg.memory_kb * 1024;
-    cpc.net4cpc = cfg.net4cpc;
-    cpc.rtc     = cfg.rtc;
+    cpc.net4cpc       = cfg.net4cpc;
+    cpc.rtc           = cfg.rtc;
+    cpc.symbiface_ide = cfg.symbiface_ide;
+    if (cfg.symbiface_ide && cfg.ide_image[0])
+        ide_open(&cpc.ide_chip, cfg.ide_image);
 
     /* Load AMSDOS ROM (non-fatal — 464 doesn't need it) */
     if (cfg.rom_amsdos[0])
@@ -337,8 +340,12 @@ int main(int argc, char *argv[]) {
                 ? "CPC 464  |  F4 = screenshot   F5 = reset   F8 = monitor   F9 = options   F11 = fullscreen"
                 : "CPC 6128  |  F4 = screenshot   F5 = reset   F8 = monitor   F9 = options   F11 = fullscreen";
             SDL_SetWindowTitle(cpc.display.window, title);
-            cpc.net4cpc = cfg.net4cpc;
-            cpc.rtc     = cfg.rtc;
+            cpc.net4cpc       = cfg.net4cpc;
+            cpc.rtc           = cfg.rtc;
+            cpc.symbiface_ide = cfg.symbiface_ide;
+            ide_close(&cpc.ide_chip);
+            if (cfg.symbiface_ide && cfg.ide_image[0])
+                ide_open(&cpc.ide_chip, cfg.ide_image);
             net4cpc_reset();
             cpc_reset(&cpc);
         }

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -25,7 +25,7 @@ static const char *const sec_labels[OV_SEC_COUNT] = {
     "General", "Storage", "Advanced"
 };
 static const int sec_x[OV_SEC_COUNT] = { 8, 74, 140 };
-static const int sec_row_count[OV_SEC_COUNT] = { 3, 2, 8 };
+static const int sec_row_count[OV_SEC_COUNT] = { 3, 2, 9 };
 
 /* ---- Drawing helpers ---- */
 
@@ -178,6 +178,16 @@ static void item_text(const Overlay *ov, int row,
             }
             break;
         }
+        case 8:
+            snprintf(lbl, lsz, "SYMBiFACE IDE");
+            if (ov->cfg->symbiface_ide && ov->cfg->ide_image[0]) {
+                char tmp[CONFIG_PATH_MAX];
+                snprintf(tmp, sizeof(tmp), "%s", ov->cfg->ide_image);
+                trunc_path(basename(tmp), val, vsz);
+            } else {
+                snprintf(val, vsz, "%s", ov->cfg->symbiface_ide ? "enabled" : "disabled");
+            }
+            break;
         }
         break;
 
@@ -267,6 +277,25 @@ static void activate_item(Overlay *ov) {
             ov->dirty = true;
             break;
         }
+        case 8:
+            if (!ov->cfg->symbiface_ide) {
+                /* Enabling: open file dialog to select a disk image */
+                ov->dialog_kind  = DIALOG_IDE;
+                ov->dialog_ready = false;
+                static const SDL_DialogFileFilter ide_filters[] = {
+                    { "Disk images", "img;IMG;hdf;HDF;raw;RAW" },
+                    { "All files",   "*"                       },
+                };
+                SDL_ShowOpenFileDialog(overlay_file_callback, ov,
+                    ov->cpc ? ov->cpc->display.window : NULL,
+                    ide_filters, 2, NULL, false);
+            } else {
+                /* Disabling: clear image path and disable */
+                ov->cfg->symbiface_ide = false;
+                ov->cfg->ide_image[0]  = '\0';
+                ov->dirty = true;
+            }
+            break;
         }
         break;
 
@@ -330,6 +359,10 @@ void overlay_tick(Overlay *ov) {
             mem_load_os(&ov->cpc->mem, ov->dialog_path);
         ov->needs_cold_boot = true;
         ov->dirty = true;
+    } else if (ov->dialog_kind == DIALOG_IDE) {
+        snprintf(ov->cfg->ide_image, CONFIG_PATH_MAX, "%s", ov->dialog_path);
+        ov->cfg->symbiface_ide = true;
+        ov->dirty = true;
     } else if (ov->dialog_kind == DIALOG_ROMSLOT && ov->dialog_slot >= 0) {
         int slot = ov->dialog_slot;
         ov->dialog_slot = -1;
@@ -369,11 +402,13 @@ bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
         case SDL_SCANCODE_KP_ENTER: {
             config_save(ov->cfg);
             /* cold boot needed if model, memory, DD1, or any ROM slot changed */
-            bool boot = (ov->cfg->model     != ov->saved.model)     ||
-                        (ov->cfg->memory_kb != ov->saved.memory_kb) ||
-                        (ov->cfg->dd1       != ov->saved.dd1)       ||
-                        (ov->cfg->net4cpc   != ov->saved.net4cpc)   ||
-                        strcmp(ov->cfg->rom_os, ov->saved.rom_os);
+            bool boot = (ov->cfg->model         != ov->saved.model)         ||
+                        (ov->cfg->memory_kb     != ov->saved.memory_kb)     ||
+                        (ov->cfg->dd1           != ov->saved.dd1)           ||
+                        (ov->cfg->net4cpc       != ov->saved.net4cpc)       ||
+                        (ov->cfg->symbiface_ide != ov->saved.symbiface_ide) ||
+                        strcmp(ov->cfg->ide_image, ov->saved.ide_image)     ||
+                        strcmp(ov->cfg->rom_os,    ov->saved.rom_os);
             if (!boot) {
                 for (int i = 0; i < ROM_EXT_COUNT; i++) {
                     if (strcmp(ov->cfg->rom_ext[i], ov->saved.rom_ext[i])) {

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -20,7 +20,8 @@ typedef enum {
     DIALOG_NONE      = 0,
     DIALOG_DISK      = 1,
     DIALOG_ROMSLOT   = 2,
-    DIALOG_LOWER_ROM = 3
+    DIALOG_LOWER_ROM = 3,
+    DIALOG_IDE       = 4
 } DialogKind;
 
 typedef struct {

--- a/src/types.h
+++ b/src/types.h
@@ -5,6 +5,7 @@
 typedef uint8_t  u8;
 typedef uint16_t u16;
 typedef uint32_t u32;
+typedef uint64_t u64;
 typedef int8_t   s8;
 typedef int16_t  s16;
 typedef int32_t  s32;


### PR DESCRIPTION
Implements ATA PIO mode IDE with a raw disk image (FAT16/FAT32) as backend, using the port mapping confirmed against HDCPM.ROM:
  0xFD06 = Alt Status / Device Control
  0xFD08 = Data, 0xFD09 = Error/Features, 0xFD0A = Sector Count
  0xFD0B-0xFD0D = LBA Low/Mid/High, 0xFD0E = Device, 0xFD0F = Status/Command

Supports IDENTIFY DEVICE (0xEC), READ (0x20/0x21), WRITE (0x30/0x31), multi-sector transfers, and soft reset via SRST bit. The open image file is preserved across warm CPC resets.

UI: new 'SYMBiFACE IDE' entry in the Advanced overlay section; enabling opens a file dialog to select the disk image; any change triggers a cold boot. Adds u64 typedef to types.h.