### PR TITLE
fix: net4cpc — soft reset, per-port bind, broadcast UDP, --trace-net4cpc

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -313,6 +313,22 @@ The mouse emulator implements the SYMBiFACE II protocol at port 0xFD10 (read-onl
 
 ---
 
+## Net4CPC W5100S Ethernet (`src/net4cpc.c`)
+
+The Net4CPC expansion exposes a WIZnet **W5100S** at four CPC I/O ports (`0xFD20`–`0xFD23`) in indirect-bus mode. The driver implements the full 64 KB W5100S register/buffer space (`regs[65536]`), four hardware sockets with their own 2 KB TX and 2 KB RX ring buffers, and the chip-level commands `OPEN`, `CONNECT`, `LISTEN`, `SEND`, `RECV`, `DISCON`, `CLOSE`. Socket operations are backed by host POSIX sockets.
+
+**Port map and indirect addressing.** The host accesses the chip via two registers — `IDM_ARH` / `IDM_ARL` form a 16-bit address pointer, and `IDM_DR` reads or writes the data byte at that address. When MR bit 1 (AI, Address Auto-Increment) is set, `idm_ar` increments after every `IDM_DR` access — that's the only way to write multi-byte registers like `SHAR` (MAC, 6 bytes) or `SIPR` (4 bytes) without doing six separate `IDM_AR` writes.
+
+**Software reset (MR.RST).** Writing `0x80` to `MR` (either via the direct shortcut at `0xFD20` or through `IDM_DR` with `idm_ar = 0x0000`) triggers a soft reset: every socket is closed (host-side `close(2)`), the entire register space is zeroed, then `MR` is set back to `0x03` (IND + AI). The post-reset MR value matters: real silicon mirrors the `BUS_SEL` pin's "indirect" state and leaves AI on by default, so the host can immediately write multi-byte registers afterwards. SymbOS's N4C daemon issues a soft reset as its first step and then polls `MR` until bit 7 clears; if we left `MR` at `0x00` after reset, every subsequent multi-byte write would silently clobber the same address (SHAR becomes `??:??:??:??:??:??` with only the last byte stored).
+
+**Socket OPEN binds correctly.** SymbOS configures `Sn_PORT` (the local port) before issuing `OPEN`. The OPEN handler binds the host socket to `(SIPR or INADDR_ANY, Sn_PORT)`, sets `SO_REUSEADDR` so we can coexist with the host's own services if there's an overlap, and sets `SO_BROADCAST` on UDP sockets so `sendto(255.255.255.255)` is permitted (required for DHCP DISCOVER). Bind failures fall back to ephemeral port 0 rather than killing the socket.
+
+**Limitations — no DHCP.** Because the emulator runs as a regular user-space process accessing the network through POSIX sockets rather than a raw L2 interface, broadcast DHCP exchanges cannot fully complete. We can *send* DHCP DISCOVER (with `SO_BROADCAST`), but server replies addressed to the emulated MAC and offered IP land at the host kernel, which silently drops them — the kernel doesn't own that IP. Use a **static IP configuration** with the N4C daemon (and any other Net4CPC consumer) until TUN/TAP support is added. With static config, DNS lookups over UDP, TCP connects, TCP send/receive, and HTTP fetches all work — verified end-to-end against `time.akamai.com` from SymbOS.
+
+**Tracing.** `--trace-net4cpc` enables `net4cpc_trace = 1`. Every register access is logged with its decoded name (`MR`, `SHAR`, `SIPR`, `Sn_MR`, `Sn_DIPR`, etc.) and socket index where applicable. Socket commands are logged with mnemonic (`OPEN`, `CONNECT`, `SEND`, `RECV`, `CLOSE`). TX/RX ring-buffer accesses are summarised as `burst R/W [start..end] N bytes` to avoid spamming one line per byte. The MR shortcut read at `0xFD20` and `MR.RST` events get their own labelled lines.
+
+---
+
 ## Albireo CH376 USB host (`src/ch376.c`)
 
 The Albireo CPC expansion exposes a WCH **CH376** USB host controller. It is enabled via `albireo=true` in `1984.conf` (or Advanced → Albireo in the overlay). Enabling it from the overlay opens a file picker to choose a FAT16/FAT32 image; the path is stored in `albireo_image`. The backend is `src/fat.c` (shared with the M4 file API), so directory enumeration, open/read/write/seek, and free-space queries all go through the same FAT layer.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ fullscreen=false
 | `--trace-input` | Log keyboard and joystick events to stderr (row 9 scans, gamepad/joystick events, key up/down) |
 | `--trace-m4` | Log every M4 board command/response to stderr (M4 emulation is unstable — see Status) |
 | `--trace-albireo` | Log every Albireo (CH376) command/response to stderr |
+| `--trace-net4cpc` | Log every Net4CPC (W5100S) register read/write and socket command to stderr |
 | `-h`, `--help` | Print this option summary and exit |
 
 Passing an unrecognised option prints the usage summary to stderr and exits with code 1.
@@ -211,7 +212,11 @@ Switching the model automatically sets the matching ROM paths and RAM size.
 | 0xFD22 | IDM_ARL | Low byte of the 16-bit indirect address register |
 | 0xFD23 | IDM_DR | Data register — read/write to the W5100S register space at the current address; auto-increments when MR bit 1 (AI) is set |
 
-Socket operations (TCP connect/send/receive, UDP sendto) are backed by host POSIX sockets. Four sockets (0–3) are available, each with 2 KB TX and 2 KB RX ring buffers. This is compatible with the Z80 driver in the [N4C-NETTOOLS](https://github.com/salvogendut/n4c-nettools) library. The toggle triggers a cold boot on save.
+Socket operations (TCP connect/send/receive, UDP sendto) are backed by host POSIX sockets. Four sockets (0–3) are available, each with 2 KB TX and 2 KB RX ring buffers. This is compatible with the Z80 driver in the [N4C-NETTOOLS](https://github.com/salvogendut/n4c-nettools) library and with the SymbOS N4C network daemon. The toggle triggers a cold boot on save.
+
+**Use a static IP — DHCP does not work.** Because the emulator runs as a regular host process and accesses the network through ordinary POSIX sockets rather than a raw L2 interface, broadcast DHCP exchanges cannot fully complete: a `DHCPDISCOVER` to `255.255.255.255` is sent (`SO_BROADCAST` is enabled), but server `DHCPOFFER` replies are addressed to the emulated MAC + offered IP — addresses the host kernel doesn't own and therefore silently drops. Configure the SymbOS daemon (or any other Net4CPC consumer) with a fixed IP, subnet mask, gateway, and DNS server. Proper DHCP support would require TUN/TAP networking so the emulator can present its own L2 interface to the host — planned as a future enhancement.
+
+For debugging, `--trace-net4cpc` logs every W5100S register read/write (decoded with register names and socket index), every socket command (`OPEN`, `CONNECT`, `SEND`, `RECV`, `CLOSE`), and TX/RX buffer access summaries.
 
 **RTC** (Advanced → RTC): enables emulation of a DS12887 real-time clock compatible with the Cyboard and Symbiface II add-on boards. Time is sourced from the host OS via `localtime()` and is always current. Two I/O ports are exposed at:
 

--- a/src/main.c
+++ b/src/main.c
@@ -43,6 +43,7 @@ static void usage(const char *prog, int code) {
         "                      May be specified multiple times\n"
         "  --trace-m4          Log every M4 board command and response to stderr\n"
         "  --trace-albireo     Log every Albireo (CH376) command and response to stderr\n"
+        "  --trace-net4cpc     Log every Net4CPC (W5100S) register access and socket command to stderr\n"
         "                      (M4 emulation is currently unstable — see README.md)\n"
         "  --autostart=NAME    After boot, types run\"NAME into BASIC\n"
         "  --paste=TEXT        After boot, types TEXT verbatim (\\n becomes Enter)\n"
@@ -139,6 +140,8 @@ int main(int argc, char *argv[]) {
             m4_trace = 1;
         } else if (strcmp(argv[i], "--trace-albireo") == 0) {
             ch376_trace = 1;
+        } else if (strcmp(argv[i], "--trace-net4cpc") == 0) {
+            net4cpc_trace = 1;
         } else if (strncmp(argv[i], "--screenshot-at=", 16) == 0 && argv[i][16] != '\0') {
             const char *arg = argv[i] + 16;
             char *colon = strchr(arg, ':');

--- a/src/net4cpc.c
+++ b/src/net4cpc.c
@@ -22,10 +22,13 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <netinet/in.h>
+#include <stdio.h>
 #include <string.h>
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <unistd.h>
+
+int net4cpc_trace = 0;
 
 /* ---------------------------------------------------------------------------
  * W5100S register-space constants
@@ -214,15 +217,34 @@ static void handle_command(int s, u8 cmd) {
             int flags = fcntl(sock_fd[s], F_GETFL, 0);
             fcntl(sock_fd[s], F_SETFL, flags | O_NONBLOCK);
 
-            /* Bind to the source IP the CPC configured in SIPR (0x000F–0x0012) */
+            /* SO_REUSEADDR so two sockets can share the local port if
+             * needed (the host may already have its own DHCP client on
+             * port 68 etc. — at least don't error out instantly). */
+            int one = 1;
+            setsockopt(sock_fd[s], SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+            /* SO_BROADCAST so UDP sendto(255.255.255.255) is permitted —
+             * required for DHCP DISCOVER/REQUEST. */
+            if (mode == SMODE_UDP)
+                setsockopt(sock_fd[s], SOL_SOCKET, SO_BROADCAST, &one, sizeof(one));
+
+            /* Bind to (SIPR, Sn_PORT). SymbOS configures Sn_PORT before
+             * OPEN — DHCP client uses port 68, NTP uses an ephemeral
+             * client port, etc. Binding to that port lets server replies
+             * actually reach our socket. */
             u32 sipr = ((u32)regs[0x000F] << 24) | ((u32)regs[0x0010] << 16) |
                        ((u32)regs[0x0011] <<  8) |  (u32)regs[0x0012];
-            if (sipr != 0) {
-                struct sockaddr_in src;
-                memset(&src, 0, sizeof(src));
-                src.sin_family      = AF_INET;
-                src.sin_port        = 0;
-                src.sin_addr.s_addr = htonl(sipr);
+            u16 sport = get16(SOCK_BASE[s] + 0x04);   /* Sn_PORT */
+            struct sockaddr_in src;
+            memset(&src, 0, sizeof(src));
+            src.sin_family      = AF_INET;
+            src.sin_port        = htons(sport);
+            src.sin_addr.s_addr = sipr ? htonl(sipr) : INADDR_ANY;
+            /* Best-effort: if the host already owns this port, fall back
+             * to a random one rather than killing the socket. */
+            if (bind(sock_fd[s], (struct sockaddr *)&src, sizeof(src)) < 0 &&
+                    sport != 0) {
+                src.sin_port = 0;
                 bind(sock_fd[s], (struct sockaddr *)&src, sizeof(src));
             }
 
@@ -317,26 +339,166 @@ static void handle_command(int s, u8 cmd) {
 }
 
 /* ---------------------------------------------------------------------------
+ * Trace helpers
+ * ------------------------------------------------------------------------- */
+
+/* Decode the W5100S internal address to a human-readable register name plus
+ * an optional socket index. Returns a pointer to a static string. */
+static const char *reg_name(u16 addr, int *sock_out) {
+    *sock_out = -1;
+    /* Common register block (0x0000-0x002F) */
+    switch (addr) {
+    case 0x0000: return "MR";
+    case 0x0001: case 0x0002: case 0x0003: case 0x0004: return "GAR";
+    case 0x0005: case 0x0006: case 0x0007: case 0x0008: return "SUBR";
+    case 0x0009: case 0x000A: case 0x000B: case 0x000C: case 0x000D: case 0x000E: return "SHAR";
+    case 0x000F: case 0x0010: case 0x0011: case 0x0012: return "SIPR";
+    case 0x0015: return "IR";
+    case 0x0016: return "IMR";
+    case 0x0017: case 0x0018: return "RTR";
+    case 0x0019: return "RCR";
+    case 0x001A: return "RMSR";
+    case 0x001B: return "TMSR";
+    }
+    /* Socket registers (0x0400-0x07FF) */
+    for (int s = 0; s < 4; s++) {
+        if (addr >= SOCK_BASE[s] && addr < SOCK_BASE[s] + 0x100) {
+            *sock_out = s;
+            u16 off = (u16)(addr - SOCK_BASE[s]);
+            switch (off) {
+            case 0x00: return "Sn_MR";
+            case 0x01: return "Sn_CR";
+            case 0x02: return "Sn_IR";
+            case 0x03: return "Sn_SR";
+            case 0x04: case 0x05: return "Sn_PORT";
+            case 0x06: case 0x07: case 0x08: case 0x09: case 0x0A: case 0x0B: return "Sn_DHAR";
+            case 0x0C: case 0x0D: case 0x0E: case 0x0F: return "Sn_DIPR";
+            case 0x10: case 0x11: return "Sn_DPORT";
+            case 0x12: case 0x13: return "Sn_MSSR";
+            case 0x15: return "Sn_TOS";
+            case 0x16: return "Sn_TTL";
+            case 0x20: case 0x21: return "Sn_TX_FSR";
+            case 0x22: case 0x23: return "Sn_TX_RD";
+            case 0x24: case 0x25: return "Sn_TX_WR";
+            case 0x26: case 0x27: return "Sn_RX_RSR";
+            case 0x28: case 0x29: return "Sn_RX_RD";
+            }
+            return "Sn_?";
+        }
+    }
+    /* TX / RX buffer regions */
+    for (int s = 0; s < 4; s++) {
+        if (addr >= TX_BASE[s] && addr < TX_BASE[s] + 0x800) { *sock_out = s; return "TX_buf"; }
+        if (addr >= RX_BASE[s] && addr < RX_BASE[s] + 0x800) { *sock_out = s; return "RX_buf"; }
+    }
+    return "?";
+}
+
+static const char *scmd_name(u8 cmd) {
+    switch (cmd) {
+    case SCMD_OPEN:    return "OPEN";
+    case SCMD_CONNECT: return "CONNECT";
+    case SCMD_DISCON:  return "DISCON";
+    case SCMD_CLOSE:   return "CLOSE";
+    case SCMD_SEND:    return "SEND";
+    case SCMD_RECV:    return "RECV";
+    case 0x02:         return "LISTEN";
+    default:           return "?";
+    }
+}
+
+/* Coalesce TX/RX buffer accesses — log the start of each burst rather than
+ * every byte. A "burst" is a run of consecutive addresses inside the same
+ * buffer region. */
+static u16 burst_first;
+static int burst_len;
+static char burst_kind;   /* 'R' = read, 'W' = write, 0 = idle */
+
+static void burst_flush(void) {
+    if (burst_kind && burst_len > 0)
+        fprintf(stderr, "[net4cpc] burst %c [%04X..%04X] %d bytes\n",
+                burst_kind, burst_first,
+                (u16)(burst_first + burst_len - 1), burst_len);
+    burst_kind = 0;
+    burst_len = 0;
+}
+
+static bool is_buffer_addr(u16 addr) {
+    return addr >= 0x4000 && addr < 0x8000;
+}
+
+static void trace_access(u16 addr, u8 val, bool is_write) {
+    if (is_buffer_addr(addr)) {
+        char kind = is_write ? 'W' : 'R';
+        if (burst_kind == kind && burst_first + burst_len == addr)
+            burst_len++;
+        else {
+            burst_flush();
+            burst_kind = kind;
+            burst_first = addr;
+            burst_len = 1;
+        }
+        return;
+    }
+    burst_flush();
+    int s; const char *n = reg_name(addr, &s);
+    if (s >= 0) {
+        if (is_write && (addr & 0xFF) == SR_CR)
+            fprintf(stderr, "[net4cpc] S%d CMD=%02X (%s)\n", s, val, scmd_name(val));
+        else
+            fprintf(stderr, "[net4cpc] %s %04X %s/S%d = %02X\n",
+                    is_write ? "W" : "R", addr, n, s, val);
+    } else {
+        fprintf(stderr, "[net4cpc] %s %04X %s = %02X\n",
+                is_write ? "W" : "R", addr, n, val);
+    }
+}
+
+/* ---------------------------------------------------------------------------
  * Register read/write with side-effects
  * ------------------------------------------------------------------------- */
 
 static u8 reg_read(u16 addr) {
+    u8 val;
     for (int s = 0; s < 4; s++) {
         if (addr == SOCK_BASE[s] + SR_SR) {
             poll_connect(s);
-            return regs[addr];
+            val = regs[addr];
+            if (net4cpc_trace) trace_access(addr, val, false);
+            return val;
         }
         /* Reading either byte of RX_RSR triggers a receive poll */
         if (addr == SOCK_BASE[s] + SR_RX_RSR ||
             addr == (u16)(SOCK_BASE[s] + SR_RX_RSR + 1)) {
             poll_rx(s);
-            return regs[addr];
+            val = regs[addr];
+            if (net4cpc_trace) trace_access(addr, val, false);
+            return val;
         }
     }
-    return regs[addr];
+    val = regs[addr];
+    if (net4cpc_trace) trace_access(addr, val, false);
+    return val;
 }
 
 static void reg_write(u16 addr, u8 val) {
+    if (net4cpc_trace) trace_access(addr, val, true);
+    /* MR.RST (bit 7): software reset. Real silicon clears all regs and
+     * the RST bit auto-clears within ~10us. The Net4CPC board ties the
+     * BUS_SEL pin to indirect-bus mode, so MR comes back as 0x03 (IND +
+     * AI). Clearing MR to 0x00 here disables auto-increment, which
+     * breaks every multi-byte register write SymbOS makes afterward. */
+    if (addr == 0x0000 && (val & 0x80)) {
+        for (int s = 0; s < 4; s++) {
+            close_sock(s);
+            rx_wr[s] = 0;
+        }
+        memset(regs, 0, sizeof(regs));
+        regs[0x0000] = 0x03;
+        if (net4cpc_trace)
+            fprintf(stderr, "[net4cpc]     soft reset complete; MR -> 03 (IND+AI)\n");
+        return;
+    }
     regs[addr] = val;
     for (int s = 0; s < 4; s++) {
         if (addr == SOCK_BASE[s] + SR_CR && val != 0) {
@@ -363,23 +525,29 @@ void net4cpc_reset(void) {
 }
 
 u8 net4cpc_in(u8 reg_sel) {
+    u8 val;
     switch (reg_sel & 0x03) {
-    case 0: return regs[0x0000];           /* MR direct shortcut */
+    case 0:
+        val = regs[0x0000];                /* MR direct shortcut at port 0xFD20 */
+        if (net4cpc_trace)
+            fprintf(stderr, "[net4cpc] IN  FD20 MR_shortcut = %02X\n", val);
+        return val;
     case 1: return (u8)(idm_ar >> 8);      /* IDM_ARH */
     case 2: return (u8)(idm_ar & 0xFF);    /* IDM_ARL */
-    case 3: {                              /* IDM_DR */
-        u8 val = reg_read(idm_ar);
+    case 3:                                /* IDM_DR */
+        val = reg_read(idm_ar);
         if (regs[0x0000] & 0x02) idm_ar++;
         return val;
-    }
     default: return 0xFF;
     }
 }
 
 void net4cpc_out(u8 reg_sel, u8 val) {
     switch (reg_sel & 0x03) {
-    case 0:                                /* MR */
-        regs[0x0000] = val;
+    case 0:                                /* MR (direct shortcut) */
+        if (net4cpc_trace)
+            fprintf(stderr, "[net4cpc] OUT FD20 MR = %02X\n", val);
+        reg_write(0x0000, val);            /* shares MR.RST handling */
         break;
     case 1:                                /* IDM_ARH */
         idm_ar = (u16)((idm_ar & 0x00FFu) | ((u16)val << 8));

--- a/src/net4cpc.h
+++ b/src/net4cpc.h
@@ -12,6 +12,8 @@
 #pragma once
 #include "types.h"
 
+extern int net4cpc_trace;            /* set by --trace-net4cpc */
+
 void net4cpc_reset(void);
 u8   net4cpc_in(u8 reg_sel);         /* reg_sel = port_low & 0x03 */
 void net4cpc_out(u8 reg_sel, u8 val);


### PR DESCRIPTION
SymbOS's N4C network daemon would refuse to start on the emulator while plain-CPC BASIC network tools worked. Three distinct W5100S behaviours were missing or wrong:

1. **MR.RST (soft reset).** SymbOS's first action is to write MR = 0x80 to soft-reset the chip, then poll MR until bit 7 clears. We stored 0x80 verbatim and never cleared it, so the daemon spun forever on the very first step. Writing MR.RST now closes all sockets, zeroes the register space, and sets MR back to 0x03 (IND + AI) — the post-reset state on real silicon where BUS_SEL is tied to indirect mode. Leaving MR at 0x00 would disable auto-increment and silently corrupt every multi-byte register write that follows (SHAR ends up as one byte, DIPR ends up as 255.0.0.0, etc.). Reproduced this exact failure mode in the trace before the fix; SHAR went to 0x0009 six times, never advancing.

2. **Sn_PORT bind.** SymbOS configures Sn_PORT (the local port, e.g. 68 for DHCP client, ephemeral for NTP/HTTP) before issuing OPEN. The OPEN handler used to bind only to SIPR with port=0 (random), so server replies to the expected port landed elsewhere on the host. OPEN now binds to (SIPR or INADDR_ANY, Sn_PORT). SO_REUSEADDR is set so we can coexist with the host's services on the same port; a bind failure falls back to ephemeral port 0 rather than killing the socket.

3. **SO_BROADCAST on UDP.** Linux refuses sendto(255.255.255.255) without SO_BROADCAST. SymbOS's DHCP path was silently failing at this step. UDP sockets now get SO_BROADCAST at OPEN time.

DHCP still does not work — UDP broadcast replies addressed to the emulated MAC + offered IP are silently dropped by the host kernel because that IP isn't ours. Documented in README and Development as "use a static IP until TUN/TAP is added". Verified end-to-end with static IP: SymbOS resolves DNS over UDP and fetches HTTP from time.akamai.com over TCP cleanly.

Also adds:

- `--trace-net4cpc` — logs every W5100S register access (with decoded names: MR, SHAR, SIPR, Sn_CR, Sn_DIPR, …), every socket command (OPEN/CONNECT/SEND/RECV/CLOSE), TX/RX ring-buffer accesses summarised as bursts, and the MR_shortcut read at port 0xFD20. This was the primary debugging signal used to find all three bugs above.