### PR TITLE
ui: cold-boot on SYMBiFACE Mouse toggle; capture only on SymbIface

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -293,7 +293,7 @@ The IDE emulator implements ATA PIO mode compatible with the SYMBiFACE II and Cy
 
 ## SYMBiFACE II PS/2 Mouse (`src/mouse.c`)
 
-The mouse emulator implements the SYMBiFACE II protocol at port 0xFD10 (read-only). It is enabled via `symbiface_mouse=true` in `1984.conf` (or Advanced → SYMBiFACE Mouse in the overlay). The toggle does not require a cold boot.
+The mouse emulator implements the SYMBiFACE II protocol at port 0xFD10 (read-only). It is enabled via `symbiface_mouse=true` in `1984.conf` (or Advanced → SYMBiFACE Mouse in the overlay). The toggle triggers a cold boot on save — SymbOS's input drivers only re-probe the hardware at boot, so toggling without a reset would leave the guest unaware of the change.
 
 **Protocol.** The CPC reads port 0xFD10 in a tight polling loop until it receives `0x00` (no more data for this cycle). The port only emits packets for data that has actually changed since the last burst, which means a stationary mouse with no button activity returns `0x00` immediately.
 
@@ -310,6 +310,8 @@ The mouse emulator implements the SYMBiFACE II protocol at port 0xFD10 (read-onl
 **SDL integration.** When captured, `SDL_EVENT_MOUSE_MOTION` delivers `xrel`/`yrel` (relative deltas; SDL Y is positive-downward, so Y is negated before storing). `SDL_EVENT_MOUSE_BUTTON_DOWN/UP` update the button state and set `btn_changed`. `SDL_EVENT_MOUSE_WHEEL` accumulates `wheel.y` into `dz`.
 
 **Capture flow.** Clicking the emulator window calls `SDL_SetWindowRelativeMouseMode(win, true)`, hides the cursor, and updates the window title. Pressing **Ctrl+Enter** releases capture. Opening the overlay (F9) also releases capture automatically before the overlay takes focus.
+
+**Capture gating.** Mouse capture engages only when `symbiface_mouse` is enabled. Albireo on its own does not arm the capture trigger — in the current build SymbOS's USB-HID enumeration on Albireo fails at the SETUP transfer (we return `USB_INT_DISCONNECT` since no real USB HID descriptor stack is emulated), so SymbOS falls back to its joystick-as-mouse driver. Capturing the host pointer for an Albireo-only setup would trap it without driving any guest mouse input.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Time and date registers (seconds, minutes, hours, day-of-week, day, month, year,
 
 Supported ATA commands: IDENTIFY DEVICE (0xEC), READ SECTORS (0x20/0x21), WRITE SECTORS (0x30/0x31), INITIALIZE DRIVE PARAMETERS (0x91), SET FEATURES (0xEF). Multi-sector transfers and software reset (SRST via Device Control) are supported. The open image file is preserved across warm resets (F5); only a cold boot closes and reopens it. Enabling, disabling, or changing the image triggers a cold boot.
 
-**SYMBiFACE Mouse** (Advanced → SYMBiFACE Mouse): enables emulation of the SYMBiFACE II PS/2 mouse interface at port 0xFD10. When enabled, clicking inside the emulator window captures the host mouse (cursor hidden, relative mode). While captured, host mouse movement and button presses drive the emulated PS/2 mouse. Press **Ctrl+Enter** to release the mouse; the window title shows the current capture state. The toggle does **not** trigger a cold boot. Immediately usable by SymbOS without any additional drivers.
+**SYMBiFACE Mouse** (Advanced → SYMBiFACE Mouse): enables emulation of the SYMBiFACE II PS/2 mouse interface at port 0xFD10. When enabled, clicking inside the emulator window captures the host mouse (cursor hidden, relative mode). While captured, host mouse movement and button presses drive the emulated PS/2 mouse. Press **Ctrl+Enter** to release the mouse; the window title shows the current capture state. The toggle triggers a cold boot on save so SymbOS's input drivers re-probe the hardware. Immediately usable by SymbOS without any additional drivers. Mouse capture is gated on this toggle — enabling Albireo on its own does not engage capture.
 
 The port returns a variable-length burst of packets terminated by `0x00` (no more data). Only fields that actually changed are included in each burst:
 
@@ -273,7 +273,7 @@ Implemented CH376 commands: `GET_IC_VER`, `RESET_ALL`, `CHECK_EXIST`, `SET_USB_M
 
 **Cyboard** (Advanced → Cyboard): convenience toggle that enables or disables Net4CPC, RTC, SYMBiFACE IDE, and SYMBiFACE Mouse all at once. Shows `enabled` when all four are on, `disabled` when all four are off, and `partial` when mixed. Disabling also clears the IDE image path.
 
-Changes to the model, RAM size, DD1 toggle, any ROM slot, lower ROM, SYMBiFACE IDE, or Albireo image trigger an automatic cold boot so the new configuration takes effect immediately. The machine re-boots without needing to quit and restart.
+Changes to the model, RAM size, DD1 toggle, any ROM slot, lower ROM, SYMBiFACE IDE, SYMBiFACE Mouse, or Albireo image trigger an automatic cold boot so the new configuration takes effect immediately. The machine re-boots without needing to quit and restart.
 
 ### Memory monitor / debugger (F8)
 

--- a/src/main.c
+++ b/src/main.c
@@ -347,23 +347,23 @@ int main(int argc, char *argv[]) {
                 }
             }
 
-            /* Click in emulator window captures mouse when any mouse path is
-             * active (SYMBiFACE II PS/2 at 0xFD10 or Albireo USB HID at
-             * 0xFE80/0xFE81). Ctrl+Enter releases capture for either. */
-            if (!mouse_captured && (cpc.symbiface_mouse || cpc.albireo) &&
+            /* Click in emulator window captures mouse only when the
+             * SYMBiFACE II PS/2 mouse is enabled. Albireo on its own
+             * doesn't drive a usable mouse path in the current build
+             * (SymbOS abandons USB HID after SETUP returns DISCONNECT),
+             * so capturing for it would just trap the host pointer for
+             * nothing. Ctrl+Enter releases capture. */
+            if (!mouse_captured && cpc.symbiface_mouse &&
                 !overlay.visible &&
                 ev.type == SDL_EVENT_MOUSE_BUTTON_DOWN &&
                 ev.button.windowID == SDL_GetWindowID(cpc.display.window)) {
                 set_mouse_capture(cpc.display.window, true,
                                   &mouse_captured, cpc.model);
-                /* Also feed this button press into the mouse state */
                 int btn = (ev.button.button == SDL_BUTTON_LEFT)   ? 0 :
                           (ev.button.button == SDL_BUTTON_RIGHT)  ? 1 :
                           (ev.button.button == SDL_BUTTON_MIDDLE) ? 2 : -1;
-                if (btn >= 0) {
-                    if (cpc.symbiface_mouse) mouse_button(&cpc.mouse, btn, true);
-                    if (cpc.albireo)         ch376_mouse_button(&cpc.ch376, btn, true);
-                }
+                if (btn >= 0)
+                    mouse_button(&cpc.mouse, btn, true);
                 continue;
             }
 

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -580,6 +580,7 @@ bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
                         (ov->cfg->dd1           != ov->saved.dd1)           ||
                         (ov->cfg->net4cpc       != ov->saved.net4cpc)       ||
                         (ov->cfg->symbiface_ide != ov->saved.symbiface_ide) ||
+                        (ov->cfg->symbiface_mouse != ov->saved.symbiface_mouse) ||
                         strcmp(ov->cfg->ide_image, ov->saved.ide_image)     ||
                         (ov->cfg->albireo       != ov->saved.albireo)       ||
                         strcmp(ov->cfg->albireo_image, ov->saved.albireo_image) ||


### PR DESCRIPTION
Two related fixes to the input config layer:

- Toggling SYMBiFACE Mouse in the Advanced overlay now triggers a cold boot on save, matching the behaviour of SYMBiFACE IDE and Albireo. SymbOS probes its input hardware at boot only, so toggling without a reset would leave the guest unaware of the change.

- Mouse capture is now gated strictly on `symbiface_mouse`. Previously a click would also capture when Albireo alone was enabled, on the assumption that Albireo's USB-HID mouse path would deliver SDL deltas to SymbOS. In practice SymbOS's USB enumeration fails at the SETUP transfer (the committed code returns USB_INT_DISCONNECT, having no real USB descriptor emulation behind it), so SymbOS falls back to its joystick- as-mouse driver. Capturing the host pointer in that case would just trap it without driving any guest input.

README and Development updated accordingly.