### PR TITLE
build: Haiku port — link libnetwork for sockets

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -584,3 +584,26 @@ IRQs do fire in the m4csct/m4ctrx critical path. Best hypotheses: SymbOS's ISR m
 - `src/m4.c` / `src/m4.h` — command dispatcher, socket state, helper shim install
 - `src/fat.c` / `src/fat.h` — minimal FAT16/FAT32 image accessor
 - `src/symbnet.c` / `src/symbnet.h` — synthetic SymbOS network port at `0xFD30/0xFD31`; routes guest-side bytes through the M4 dispatcher. Companion daemon source in `~/Dev/symsys-networkdaemon-1984/` (paused).
+
+## Building on Haiku
+
+1984 builds and runs on Haiku (tested on the 32-bit nightly). Three environment
+quirks to be aware of:
+
+1. **Use the modern GCC, not the legacy BeOS-compat one.** Haiku ships both
+   `gcc2` (binary-compat with BeOS R5) and a modern GCC 13 side by side. The
+   default `cc` may point to `gcc2`, which does not support C11. Switch shells
+   with `setarch x86` (or `setarch x86_64` on 64-bit Haiku) before running
+   `autoreconf`/`configure`/`make`.
+
+2. **Secondary-arch pkg-config path.** On 32-bit Haiku the SDL3 package is
+   `libsdl3_x86` / `libsdl3_x86_devel`, and its `sdl3.pc` lives under
+   `/boot/system/develop/lib/x86/pkgconfig/`, which `pkg-config` does not search
+   by default. Export it before configuring:
+   ```sh
+   export PKG_CONFIG_PATH=/boot/system/develop/lib/x86/pkgconfig
+   ```
+
+3. **Sockets are in `libnetwork`, not libc.** Handled automatically by the
+   `AC_SEARCH_LIBS([socket], [network socket])` probes in `configure.ac`; no
+   manual `LDFLAGS` needed.

--- a/configure
+++ b/configure
@@ -4818,6 +4818,143 @@ esac
 fi
 
 
+# Sockets live in libnetwork on Haiku, libsocket on Solaris/illumos,
+# and libc on Linux/BSD/macOS.
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing socket" >&5
+printf %s "checking for library containing socket... " >&6; }
+if test ${ac_cv_search_socket+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char socket (void);
+int
+main (void)
+{
+return socket ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' network socket
+do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_search_socket=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext
+  if test ${ac_cv_search_socket+y}
+then :
+  break
+fi
+done
+if test ${ac_cv_search_socket+y}
+then :
+
+else case e in #(
+  e) ac_cv_search_socket=no ;;
+esac
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_socket" >&5
+printf "%s\n" "$ac_cv_search_socket" >&6; }
+ac_res=$ac_cv_search_socket
+if test "$ac_res" != no
+then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing getsockopt" >&5
+printf %s "checking for library containing getsockopt... " >&6; }
+if test ${ac_cv_search_getsockopt+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char getsockopt (void);
+int
+main (void)
+{
+return getsockopt ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' network socket
+do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_search_getsockopt=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext
+  if test ${ac_cv_search_getsockopt+y}
+then :
+  break
+fi
+done
+if test ${ac_cv_search_getsockopt+y}
+then :
+
+else case e in #(
+  e) ac_cv_search_getsockopt=no ;;
+esac
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_getsockopt" >&5
+printf "%s\n" "$ac_cv_search_getsockopt" >&6; }
+ac_res=$ac_cv_search_getsockopt
+if test "$ac_res" != no
+then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+fi
+
+
 ac_config_files="$ac_config_files Makefile"
 
 cat >confcache <<\_ACEOF

--- a/configure.ac
+++ b/configure.ac
@@ -18,5 +18,10 @@ PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES([SDL3], [sdl3], [], [AC_MSG_ERROR([SDL3 not found])])
 AC_CHECK_LIB([m], [sqrt], [], [AC_MSG_ERROR([libm not found])])
 
+# Sockets live in libnetwork on Haiku, libsocket on Solaris/illumos,
+# and libc on Linux/BSD/macOS.
+AC_SEARCH_LIBS([socket], [network socket])
+AC_SEARCH_LIBS([getsockopt], [network socket])
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
On Haiku the BSD socket API lives in libnetwork rather than libc, so getsockopt/socket fail to link without -lnetwork. Probe via AC_SEARCH_LIBS so Linux/BSD/macOS pick them up from libc as before and Solaris/illumos pick them up from libsocket.

Document the Haiku build prerequisites (modern GCC via setarch, secondary-arch PKG_CONFIG_PATH for libsdl3_x86_devel) in Development.md.