### PR TITLE
54 Title: Fix M4 networking stalls; enforce M4 ↔ Cyboard/Albireo exclusion; per-expansion docs

### DIFF
--- a/1984.spec
+++ b/1984.spec
@@ -30,8 +30,9 @@ Expansion peripherals emulated:
   * Net4CPC W5100S Ethernet (TCP/UDP via host sockets, static IP)
   * Albireo USB host (CH376 driven by UNIDOS for file ops, raw
     USB Bulk-Only Transport for SymbOS storage)
-  * M4 board (file API + ESP8266-style networking) — currently
-    unstable for the SymbOS netd-m4c.exe daemon, otherwise usable
+  * M4 board (file API + ESP8266-style networking) — cpc-sdcc demos
+    and SymbOS HTTP downloads (wget) work; SymbOS interactive telnet
+    stalls after the server banner (same on real Net4CPC hardware)
 
 DK'tronics-compatible RAM banking up to 576 KB and Yarek/RAM7
 extended banking to 1024 KB are both supported. The F8 memory

--- a/ALBIREO.md
+++ b/ALBIREO.md
@@ -1,0 +1,78 @@
+# Albireo
+
+The **Albireo** entry on the **Extensions** tab (F9 overlay) emulates the
+[Albireo USB host expansion](https://pulkomandy.github.io/shinra.github.io/albireo.html)
+— a CH376-based USB controller. With UNIDOS loaded, BASIC sees USB mass-storage
+volumes (Albireo's primary use); the same emulation also serves the raw USB
+Bulk-Only Transport path that SymbOS uses for storage.
+
+## Required ROMs
+
+Open **F9 → Extensions → ROM Slots** and load the following:
+
+| Slot | ROM           | Purpose                                                    |
+|-----:|---------------|------------------------------------------------------------|
+| 7    | `UNIDOS.ROM`  | DOS-node loader — must replace AMSDOS at slot 7            |
+| 8    | `ALBIREO.ROM` | UNIDOS node for the Albireo USB host (CH376)               |
+
+Slot 8 is the conventional adjacent placement; UNIDOS scans for nodes in slot
+order, so as long as `ALBIREO.ROM` sits just after `UNIDOS.ROM` it will be
+picked up.
+
+> **Note:** Slot 7 is normally AMSDOS. Replacing it with UNIDOS is expected —
+> UNIDOS provides the AMSDOS-equivalent disc-handling RSXes via its own command
+> set. Disk A/B (`.dsk` images via the µPD765 FDC) keep working through the OS
+> ROM regardless of slot 7's contents.
+
+## Coexisting with Cyboard
+
+Albireo and Cyboard are independent peripherals and can be enabled at the same
+time. They both rely on UNIDOS at slot 7 (a single instance covers both), and
+each one adds its own node ROM in a following slot.
+
+A workable layout when both are on:
+
+| Slot | ROM             |
+|-----:|-----------------|
+| 7    | `UNIDOS.ROM`    |
+| 8    | `ALBIREO.ROM`   |
+| 9    | `UNITOOLS.ROM`  |
+| 10   | `FATFS-P1.ROM`  |
+| 11   | `FATFS-P2.ROM` |
+
+UNIDOS does not require any specific ordering past slot 7 — it scans forward
+from there — so feel free to rearrange to suit your own setup. The key
+constraint is that `UNIDOS.ROM` must be at slot 7 and the node/tool ROMs must
+all sit at slots ≥ 8.
+
+## Incompatibility with M4
+
+The M4 board's `M4ROM.ROM` and UNIDOS both claim overlapping firmware territory
+and cannot coexist. The overlay enforces this mutual exclusion:
+
+- Enabling **Albireo** disables **M4** (and triggers a cold boot).
+- Enabling **M4** clears every expansion ROM override — including the slot-7
+  UNIDOS and any Albireo / Cyboard node ROMs — and disables both Albireo and
+  Cyboard's RTC, restoring the stock BASIC and AMSDOS defaults.
+
+## Where to obtain the ROMs
+
+| ROM           | Source                                                |
+|---------------|-------------------------------------------------------|
+| `UNIDOS.ROM`  | <https://unidos.cpcscene.net/>                        |
+| `ALBIREO.ROM` | Bundled with the UNIDOS distribution                  |
+
+## Verifying it works
+
+After enabling Albireo, loading the two ROMs, and booting:
+
+1. Attach a USB image to the Albireo entry (overlay file picker) — a raw FAT
+   image works.
+2. At the BASIC prompt, type `|HELP` — UNIDOS and the Albireo node should list
+   their RSX commands.
+3. Type `|DIR,"usb:"` (or whatever volume name your node advertises) to list
+   files on the attached image.
+
+If `|HELP` shows only the standard AMSDOS commands, the UNIDOS ROM did not load
+— double-check the slot 7 entry and confirm the file exists at the configured
+path.

--- a/ALBIREO.md
+++ b/ALBIREO.md
@@ -55,6 +55,12 @@ and cannot coexist. The overlay enforces this mutual exclusion:
   UNIDOS and any Albireo / Cyboard node ROMs — and disables both Albireo and
   Cyboard's RTC, restoring the stock BASIC and AMSDOS defaults.
 
+> **Note:** This Albireo ↔ M4 mutual exclusion is enforced only inside this
+> emulator, to keep the configuration clean while M4 support remains
+> experimental. It is not necessarily a real-hardware constraint — on actual
+> CPCs the boards may well coexist if the physical ROM slots and I/O ports
+> do not collide.
+
 ## Where to obtain the ROMs
 
 | ROM           | Source                                                |

--- a/CYBOARD.md
+++ b/CYBOARD.md
@@ -47,6 +47,11 @@ and cannot coexist. The overlay enforces this mutual exclusion:
 So a switch from one stack to the other never requires editing the config file
 by hand: pick the option you want and the other side is torn down for you.
 
+> **Note:** This mutual exclusion is enforced only inside this emulator, to
+> keep the configuration clean while M4 support remains experimental. It is
+> not necessarily a real-hardware constraint — on actual CPCs the boards may
+> well coexist if the physical ROM slots and I/O ports do not collide.
+
 ## Where to obtain the ROMs
 
 | ROM             | Source                                               |

--- a/CYBOARD.md
+++ b/CYBOARD.md
@@ -1,0 +1,74 @@
+# Cyboard
+
+The **Cyboard** option on the **Extensions** tab (F9 overlay) is a single-shot
+toggle that enables the full SYMBiFACE-compatible peripheral stack at once:
+
+- **Net4CPC** — W5100S Ethernet
+- **RTC** — DS12887 real-time clock
+- **SYMBiFACE IDE** — FAT16/FAT32 disk image
+- **SYMBiFACE Mouse** — PS/2 mouse via SDL relative capture
+
+Enabling the Cyboard pack covers the *hardware* side. To actually use it from
+BASIC and SymbOS you also need a matching ROM set in the expansion ROM slots,
+because the firmware that talks to this hardware (UNIDOS + tools + file-system
+nodes) lives in expansion ROMs — not in the stock OS/BASIC/AMSDOS bundle.
+
+## Required ROMs
+
+Open **F9 → Extensions → ROM Slots** and load the following:
+
+| Slot | ROM             | Purpose                                                        |
+|-----:|-----------------|----------------------------------------------------------------|
+| 7    | `UNIDOS.ROM`    | DOS-node loader — must replace AMSDOS at slot 7               |
+| 8    | `UNITOOLS.ROM`  | UNIDOS command-line tools (`|DIR`, `|CD`, `|TYPE`, etc.)      |
+| 9    | `FATFS-P1.ROM`  | FAT file-system node, part 1                                  |
+| 10   | `FATFS-P2.ROM` | FAT file-system node, part 2                                  |
+
+Slots 8–10 are the conventional adjacent placements; UNIDOS scans for nodes in
+slot order, so as long as the tools and FAT nodes sit just after `UNIDOS.ROM`
+they will be picked up. If you have additional UNIDOS nodes (e.g. another
+file-system or device), drop them in slots 11, 12, … in the same order.
+
+> **Note:** Slot 7 is normally AMSDOS. Replacing it with UNIDOS is expected —
+> UNIDOS provides the AMSDOS-equivalent disc-handling RSXes via its own command
+> set. Disk A/B (`.dsk` images via the µPD765 FDC) keep working through the OS
+> ROM regardless of slot 7's contents.
+
+## Incompatibility with M4
+
+The M4 board's `M4ROM.ROM` and UNIDOS both claim overlapping firmware territory
+and cannot coexist. The overlay enforces this mutual exclusion:
+
+- Enabling **Cyboard** disables **M4** (and triggers a cold boot).
+- Enabling **M4** disables **Cyboard's RTC** and clears every expansion ROM
+  override — including the slot-7 UNIDOS — restoring the stock BASIC and AMSDOS
+  defaults.
+
+So a switch from one stack to the other never requires editing the config file
+by hand: pick the option you want and the other side is torn down for you.
+
+## Where to obtain the ROMs
+
+| ROM             | Source                                               |
+|-----------------|------------------------------------------------------|
+| `UNIDOS.ROM`    | <https://unidos.cpcscene.net/>                       |
+| `UNITOOLS.ROM`  | Bundled with the UNIDOS distribution                 |
+| `FATFS-P1.ROM`  | Bundled with the UNIDOS distribution                 |
+| `FATFS-P2.ROM` | Bundled with the UNIDOS distribution                 |
+
+Download the UNIDOS distribution archive from the project site above; the
+package contains `UNIDOS.ROM` plus the standard tool and node ROMs ready to
+drop into the slots listed above.
+
+## Verifying it works
+
+After enabling Cyboard, loading the three ROMs, and booting:
+
+1. At the BASIC prompt, type `|HELP` — UNIDOS and any loaded node ROMs should
+   list their RSX commands.
+2. Type `|DIR` — UNITOOLS should list files on the active FAT volume.
+3. Switch volumes with `|CD,"path"` if you have multiple file systems mounted.
+
+If `|HELP` shows only the standard AMSDOS commands, the UNIDOS ROM did not load
+— double-check the slot 7 entry and confirm the file exists at the configured
+path.

--- a/M4.md
+++ b/M4.md
@@ -1,0 +1,76 @@
+# M4 board
+
+The **M4** entry on the **Extensions** tab (F9 overlay) emulates the
+[M4 board](https://www.cpcwiki.eu/index.php/M4_Board) — an SD-card +
+ESP8266-style Wi-Fi/networking expansion sitting in upper-ROM slot 6.
+With `M4ROM.ROM` paged in, BASIC sees the FAT card as a `|DRIVE`, and
+`cpc-sdcc` networking demos (TCPTEST, NTP, TELNET, WGET) run end-to-end
+against the host's TCP/IP stack. Backed by `src/m4.c`.
+
+> M4 emulation is labelled **experimental** in the overlay. Most paths
+> work; the SymbOS `netd-m4c.exe` interactive telnet session stalls
+> shortly after the server banner — that same stall reproduces on real
+> Net4CPC hardware, so it appears to be a SymbOS-side limitation
+> rather than an emulator bug.
+
+## Required ROMs
+
+M4 is self-contained — the only ROM you need is the bundled `M4ROM.ROM`,
+which the overlay loads into slot 6 automatically when you enable M4 and
+pick an SD-card image. The stock BASIC and AMSDOS at slots 0/7 are kept
+intact for everyday BASIC use.
+
+| Slot | ROM         | Purpose                                          |
+|-----:|-------------|--------------------------------------------------|
+| 6    | `M4ROM.ROM` | M4 firmware — set up automatically by the overlay |
+
+## Incompatibility with Cyboard and Albireo
+
+M4ROM is incompatible with UNIDOS and the SYMBiFACE pack. The overlay
+enforces this mutual exclusion in both directions:
+
+- Enabling **M4** disables **Cyboard** (Net4CPC, RTC, IDE, Mouse) and
+  **Albireo**, clears every expansion ROM override (so any UNIDOS,
+  Albireo node, FATFS node, etc. is removed), and restores the stock
+  BASIC + AMSDOS defaults — then triggers a cold boot.
+- Enabling **Cyboard** or **Albireo** disables **M4** and triggers a
+  cold boot.
+
+Switching between stacks therefore never requires editing the config
+file by hand.
+
+## Using M4 with SymbOS
+
+SymbOS's network daemon (`netd-m4c.exe`) runs against the M4 emulation,
+but with one important caveat:
+
+> **Do not add `netd-m4c.exe` to SymbOS autostart.** When launched from
+> autostart the daemon appears to suffer state corruption — symptoms
+> include "Offline" status, sockets that never connect, and (in some
+> setups) the desktop hanging shortly after login. Start the daemon by
+> hand from the application launcher (or a shell) after boot has fully
+> completed and it works as expected. The root cause has not been
+> isolated; this note is documented as a workaround.
+
+Once started manually, the daemon resolves hosts, opens TCP/UDP
+connections, and serves HTTP downloads via `wget`. Interactive telnet
+sessions stall after the server banner — see the note above; the same
+behaviour is observed on real Net4CPC hardware.
+
+## Verifying it works
+
+After enabling M4 and picking an SD-card image:
+
+1. At the BASIC prompt, type `|DRIVE` — the M4ROM extension should list
+   the active drive.
+2. `CAT` should list files on the FAT image.
+3. From SymbOS (booted from a separate `.dsk`), launch
+   `netd-m4c.exe` **by hand**; the status panel should switch to
+   "Online" within a few seconds.
+4. Run `wget` (e.g. `wget http://192.168.x.x:8080/test.txt`) — the
+   download should complete and the file should appear on the M4's FAT
+   image.
+
+If `|DRIVE` is missing from `|HELP`, M4ROM did not load — double-check
+that the Roms Board toggle (General tab) is enabled and that M4 itself
+is enabled (Extensions tab).

--- a/M4.md
+++ b/M4.md
@@ -39,6 +39,12 @@ enforces this mutual exclusion in both directions:
 Switching between stacks therefore never requires editing the config
 file by hand.
 
+> **Note:** This M4 ↔ Cyboard / Albireo mutual exclusion is enforced
+> only inside this emulator, to keep the configuration clean while M4
+> support remains experimental. It is not necessarily a real-hardware
+> constraint — on actual CPCs the boards may well coexist if the
+> physical ROM slots and I/O ports do not collide.
+
 ## Using M4 with SymbOS
 
 SymbOS's network daemon (`netd-m4c.exe`) runs against the M4 emulation,

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A cycle-stepped Amstrad CPC 464/6128 emulator written in C with SDL3.
 
 Boots to Locomotive BASIC. Commercial games and standard software run well. Demos and other software that rely on undocumented hardware behaviour or cycle-exact CRTC tricks are untested and may not work correctly.
 
-**M4 board emulation is unstable.** The ROM signature, FAT file API, single-image SAVE/LOAD/CAT, DNS resolution, and TCP connect plus the cpc-sdcc network examples (TCPTEST, NTP, TELNET) all work. SymbOS's `netd-m4c.exe` launches and resolves hosts but TCP sessions stall shortly after the initial server banner — multi-socket scenarios and long telnet sessions are not yet reliable.
+**M4 board emulation is partial.** The ROM signature, FAT file API, single-image SAVE/LOAD/CAT, DNS resolution, and TCP connect plus the cpc-sdcc network examples (TCPTEST, NTP, TELNET, WGET) all work. SymbOS's `netd-m4c.exe` launches, resolves hosts, and HTTP downloads via `wget` complete end-to-end. SymbOS interactive telnet sessions stall shortly after the initial server banner — the same stall is observed on real Net4CPC hardware, so this appears to be a SymbOS-side limitation rather than an emulator bug.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Pre-built Linux and Windows binaries are attached to each [GitHub Release](https
 - **[USAGE.md](USAGE.md)** — command-line options, keyboard shortcuts, joystick mapping, options overlay (F9), memory monitor (F8), config file format
 - **[Development.md](Development.md)** — architecture, render pipeline, hardware emulation details, CI, port-specific notes (Haiku / NetBSD / Windows)
 
+Per-expansion guides:
+
+- **[M4.md](M4.md)** — M4 board (SD card + Wi-Fi networking); SymbOS netd-m4c.exe autostart caveat
+- **[CYBOARD.md](CYBOARD.md)** — Cyboard pack (Net4CPC + RTC + SYMBiFACE IDE/Mouse); UNIDOS + UNITOOLS + FATFS ROM layout
+- **[ALBIREO.md](ALBIREO.md)** — Albireo USB host (CH376); UNIDOS + ALBIREO.ROM layout; coexistence with Cyboard
+
 ## Acknowledgements
 
 - **[ColinPitrat/caprice32](https://github.com/ColinPitrat/caprice32)** — well-maintained CPC emulator; hardware colour palette RGB values used in `src/gate_array.c` were derived from Caprice32's colour table.

--- a/src/config.c
+++ b/src/config.c
@@ -337,6 +337,15 @@ int config_load(Config *cfg) {
     if (cfg->memory_kb == 0)
         cfg->memory_kb = 128;
 
+    /* M4ROM is incompatible with UNIDOS/Albireo tooling and with the
+     * Cyboard RTC. Older configs may have both enabled — keep M4 and
+     * disable the conflicting peripherals so the runtime starts in a
+     * clean scenario that matches the overlay's mutual-exclusion rule. */
+    if (cfg->m4) {
+        if (cfg->rtc)     cfg->rtc = false;
+        if (cfg->albireo) { cfg->albireo = false; cfg->albireo_image[0] = '\0'; }
+    }
+
     return rc;
 }
 

--- a/src/cpc.c
+++ b/src/cpc.c
@@ -43,7 +43,7 @@ static u8 bus_mem_read(void *ctx, u16 addr) {
             v = cpc->m4_card.bus_mem[addr - 0xE800];
         else if (addr >= 0xF400 && addr < 0xF500)
             v = cpc->m4_card.cfg_mem[addr - 0xF400];
-        else if (addr >= 0xFE00 && addr < 0xFE50)
+        else if (addr >= 0xFE00 && addr < 0xFF00)
             v = cpc->m4_card.sock_mem[addr - 0xFE00];
         else
             hit = false;

--- a/src/m4.c
+++ b/src/m4.c
@@ -263,6 +263,24 @@ static void sync_sock_mem(M4 *m, int s) {
     memcpy(&p[4], m->sockets[s].peer_ip, 4);
     p[8]  = (u8)(m->sockets[s].peer_port & 0xFF);
     p[9]  = (u8)(m->sockets[s].peer_port >> 8);
+
+    /* SymbOS netd-m4c.exe workaround: when only one TCP socket is open,
+     * mirror its 16-byte sock_info into every other slot (5..15) so the
+     * daemon's wrong-slot reads (caused by m4csct returning garbage A in
+     * 0..15) still see correct status/rx_count and keep polling. */
+    int active = -1;
+    for (int i = 1; i < M4_NSOCKS; i++) {
+        if (m->sockets[i].fd < 0) continue;
+        if (active >= 0) { active = -1; break; }  /* >1 open: don't broadcast */
+        active = i;
+    }
+    if (active >= 0) {
+        u8 *src = &m->sock_mem[active * 16];
+        for (int slot = 0; slot < 16; slot++) {
+            if (slot == active) continue;
+            memcpy(&m->sock_mem[slot * 16], src, 16);
+        }
+    }
 }
 
 static void net_close_socket(M4 *m, int s) {

--- a/src/m4.h
+++ b/src/m4.h
@@ -97,7 +97,16 @@ typedef struct {
      *   0xF400-0xF4FF: rom_config — jump_vec, init_count, runfile_ptr, etc. */
     u8      bus_mem[0xC00]; /* covers 0xE800-0xF3FF — full rom_response area */
     u8      cfg_mem[0x100]; /* covers 0xF400-0xF4FF — rom_config area */
-    u8      sock_mem[0x50]; /* covers 0xFE00-0xFE4F — sock_info (5 × 16 bytes) */
+    /* 0xFE00-0xFEFF — sock_info. Real layout is 5 × 16 bytes, but the
+     * SymbOS netd-m4c.exe daemon's m4csct (socket-translation lookup)
+     * intermittently returns garbage in A; the caller m4csta does
+     * `add a *4 ; ld iy,(m4cromsoc); add iy,bc` and reads 16 bytes from
+     * an unintended slot, which the daemon then trusts. Extending the
+     * window to a full 16 slots and broadcasting the active TCP socket's
+     * bytes to every slot (see broadcast_sock_mem) keeps polling alive
+     * for any garbage A in 0..15. A >= 16 puts the read into plain CPC
+     * RAM and we can't intercept it. */
+    u8      sock_mem[0x100];
 
     /* Network state — host POSIX sockets backing the M4's WiFi sockets. */
     M4Socket sockets[M4_NSOCKS];

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -418,10 +418,34 @@ static void activate_item(Overlay *ov) {
                         ch376_close(&ov->cpc->ch376);
                     }
                 }
+                /* Tear down the full Cyboard pack (matches what
+                 * toggling Cyboard off does) — Net4CPC, RTC, IDE, Mouse. */
+                if (ov->cfg->net4cpc) ov->cfg->net4cpc = false;
                 if (ov->cfg->rtc) {
                     ov->cfg->rtc = false;
                     if (ov->cpc) ov->cpc->rtc = false;
                 }
+                if (ov->cfg->symbiface_ide) {
+                    ov->cfg->symbiface_ide = false;
+                    ov->cfg->ide_image[0]  = '\0';
+                }
+                if (ov->cfg->symbiface_mouse) ov->cfg->symbiface_mouse = false;
+                /* Drop every non-default expansion ROM so nothing
+                 * (UNIDOS, custom utilities, etc.) interferes with
+                 * M4ROM. Also restore the stock BASIC + AMSDOS so slots
+                 * 0 and 7 fall back to clean defaults. */
+                for (int i = 0; i < ROM_EXT_COUNT; i++) {
+                    if (!ov->cfg->rom_ext[i][0]) continue;
+                    ov->cfg->rom_ext[i][0] = '\0';
+                    if (ov->cpc) mem_unload_rom_ext(&ov->cpc->mem, i);
+                }
+                config_default_basic(ov->cfg->model,
+                                     ov->cfg->rom_basic, sizeof(ov->cfg->rom_basic));
+                if (!ov->cfg->rom_amsdos[0])
+                    config_default_amsdos(ov->cfg->rom_amsdos,
+                                          sizeof(ov->cfg->rom_amsdos));
+                if (ov->cpc)
+                    mem_load_amsdos(&ov->cpc->mem, ov->cfg->rom_amsdos);
                 /* Enable: open file picker to select SD card image (raw FAT) */
                 ov->dialog_kind  = DIALOG_M4_IMAGE;
                 ov->dialog_ready = false;
@@ -560,6 +584,20 @@ static void activate_item(Overlay *ov) {
             bool all = ov->cfg->net4cpc && ov->cfg->rtc &&
                        ov->cfg->symbiface_ide && ov->cfg->symbiface_mouse;
             bool enable = !all;
+            /* Cyboard pack is incompatible with M4ROM — enabling forces
+             * a clean scenario by disabling M4 (mirrors the M4 enable
+             * path in case 0). */
+            if (enable && ov->cfg->m4) {
+                ov->cfg->m4 = false;
+                ov->cfg->m4_image[0] = '\0';
+                ov->cfg->rom_ext[M4_ROM_SLOT][0] = '\0';
+                if (ov->cpc) {
+                    ov->cpc->m4 = false;
+                    m4_set_image(&ov->cpc->m4_card, "");
+                    mem_unload_rom_ext(&ov->cpc->mem, M4_ROM_SLOT);
+                }
+                ov->needs_cold_boot = true;
+            }
             ov->cfg->net4cpc         = enable;
             ov->cfg->rtc             = enable;
             ov->cfg->symbiface_ide   = enable;

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -183,7 +183,7 @@ static void item_text(const Overlay *ov, int row,
     case OV_ADVANCED:
         switch (row) {
         case 0:
-            snprintf(lbl, lsz, "M4 (unstable)");
+            snprintf(lbl, lsz, "M4 (experimental)");
             if (!ov->cfg->rom_board) {
                 snprintf(val, vsz, "[needs Roms Board]");
                 *readonly = true;
@@ -406,7 +406,10 @@ static void activate_item(Overlay *ov) {
         switch (ov->row) {
         case 0:
             if (!ov->cfg->m4) {
-                /* Mutually exclusive with Albireo (both claim port 0xFExx). */
+                /* Mutually exclusive with Albireo (both claim port 0xFExx)
+                 * and with the Cyboard RTC — M4ROM is incompatible with
+                 * UNIDOS/Albireo tooling, so enabling M4 forces a clean
+                 * scenario by disabling both. */
                 if (ov->cfg->albireo) {
                     ov->cfg->albireo = false;
                     ov->cfg->albireo_image[0] = '\0';
@@ -414,6 +417,10 @@ static void activate_item(Overlay *ov) {
                         ov->cpc->albireo = false;
                         ch376_close(&ov->cpc->ch376);
                     }
+                }
+                if (ov->cfg->rtc) {
+                    ov->cfg->rtc = false;
+                    if (ov->cpc) ov->cpc->rtc = false;
                 }
                 /* Enable: open file picker to select SD card image (raw FAT) */
                 ov->dialog_kind  = DIALOG_M4_IMAGE;
@@ -447,6 +454,20 @@ static void activate_item(Overlay *ov) {
             break;
         case 3:
             ov->cfg->rtc = !ov->cfg->rtc;
+            /* Cyboard RTC is incompatible with M4ROM — enabling RTC
+             * disables M4 for a clean scenario (mirrors the reverse
+             * forced by case 0). */
+            if (ov->cfg->rtc && ov->cfg->m4) {
+                ov->cfg->m4 = false;
+                ov->cfg->m4_image[0] = '\0';
+                ov->cfg->rom_ext[M4_ROM_SLOT][0] = '\0';
+                if (ov->cpc) {
+                    ov->cpc->m4 = false;
+                    m4_set_image(&ov->cpc->m4_card, "");
+                    mem_unload_rom_ext(&ov->cpc->mem, M4_ROM_SLOT);
+                }
+                ov->needs_cold_boot = true;
+            }
             ov->dirty = true;
             break;
         case 4:


### PR DESCRIPTION
## Summary
- M4 sock_info window extended to 256 bytes (16 slots) with active TCP socket
  broadcast across all slots — SymbOS netd-m4c.exe HTTP downloads via wget now
  complete end-to-end. (The interactive-telnet stall remains; same behaviour
  reproduces on real Net4CPC hardware.)
- Overlay: enforce M4 ↔ Cyboard/Albireo mutual exclusion in both directions.
  Enabling M4 tears down the whole Cyboard pack (Net4CPC + RTC + IDE + Mouse)
  and clears every expansion ROM override; enabling Cyboard or Albireo
  disables M4. All transitions trigger a cold boot.
- Config: sanitise legacy configs on load — if m4=true together with
  rtc/albireo=true, keep M4 and clear the conflicting peripherals.
- Overlay label: "M4 (unstable)" → "M4 (experimental)" to match docs.
- Per-expansion docs: M4.md, CYBOARD.md, ALBIREO.md; README "Documentation"
  section linked to all three. Each notes that the mutual-exclusion rule is
  emulator-imposed, not a real-hardware constraint.
- M4.md also documents the SymbOS workaround: do NOT autostart netd-m4c.exe;
  launch it by hand after boot.

## Test plan
- [x] cpc-sdcc TCPTEST/NTP/TELNET/WGET still pass
- [x] SymbOS wget downloads a small file from a python http.server end-to-end
- [x] Overlay: enabling M4 clears RTC/IDE/Mouse/Net4CPC + all rom_ext slots
- [x] Overlay: enabling Cyboard or Albireo disables M4 and cold-boots
- [x] Stale config (m4=true + rtc=true) sanitised on load