### PR TITLE
gate_array: VSYNC-locked IRQ resync, deferred mode change, IRQ ack bi…

### DIFF
--- a/src/cpc.c
+++ b/src/cpc.c
@@ -491,6 +491,7 @@ void cpc_frame(CPC *cpc) {
             /* VSYNC rising edge → start of new frame */
             if (new_vsync && !cpc->prev_vsync) {
                 cpc->raster_y = -VSYNC_TO_DISPLAY_LINES;
+                ga_vsync_start(&cpc->ga);
                 display_upload(&cpc->display);
             }
 
@@ -529,6 +530,7 @@ void cpc_frame(CPC *cpc) {
         /* Deliver pending Gate Array interrupt */
         if (cpc->ga.interrupt_pending) {
             cpc->ga.interrupt_pending = false;
+            ga_irq_ack(&cpc->ga);
             z80_interrupt(&cpc->cpu);
         }
 

--- a/src/gate_array.c
+++ b/src/gate_array.c
@@ -19,6 +19,7 @@ void ga_init(GateArray *ga) {
     ga->lower_rom = true;
     ga->upper_rom = true;
     ga->screen_mode = 1;
+    ga->requested_mode = 1;
     /* Power-on default inks */
     for (int i = 0; i < GA_NUM_INKS; i++)
         ga->ink[i] = 0;
@@ -38,7 +39,11 @@ void ga_write(GateArray *ga, u8 val) {
             }
             break;
         case 0x02:   /* Screen mode + ROM control */
-            ga->screen_mode = val & 0x03;
+            /* Mode change is latched: real hardware only adopts the new mode
+             * at the next HSYNC, so mid-line writes don't tear the current
+             * character. Demos with raster mode-splits (and the firmware's
+             * mode-set sequence) rely on this to avoid flicker. */
+            ga->requested_mode = val & 0x03;
             ga->lower_rom   = !(val & 0x04);
             ga->upper_rom   = !(val & 0x08);
             if (val & 0x10) {
@@ -56,9 +61,33 @@ u8 ga_mode(GateArray *ga) {
 }
 
 void ga_hsync(GateArray *ga) {
+    /* Latch the requested mode at start of new scan line */
+    ga->screen_mode = ga->requested_mode;
     ga->interrupt_counter++;
     if (ga->interrupt_counter >= 52) {
         ga->interrupt_counter = 0;
         ga->interrupt_pending = true;
     }
+    /* VSYNC IRQ resync: 2 HSYNCs after VSYNC begins, if counter >= 32 raise a
+     * compensating IRQ, then reset counter. Locks the 300 Hz raster IRQ to
+     * VSYNC so the firmware's frame-flyback ticker (INK/BORDER flashing,
+     * SOUND queue, etc.) advances at a steady cadence. */
+    if (ga->vsync_delay) {
+        if (--ga->vsync_delay == 0) {
+            if (ga->interrupt_counter >= 32)
+                ga->interrupt_pending = true;
+            ga->interrupt_counter = 0;
+        }
+    }
+}
+
+void ga_vsync_start(GateArray *ga) {
+    ga->vsync_delay = 2;
+}
+
+void ga_irq_ack(GateArray *ga) {
+    /* On IRQ acknowledge the GA clears bit 5 of the line counter, so a value
+     * of ≥32 at ack time drops below the next-IRQ threshold and the firmware
+     * gets one IRQ per request instead of two. */
+    ga->interrupt_counter &= 0x1F;
 }

--- a/src/gate_array.h
+++ b/src/gate_array.h
@@ -16,10 +16,12 @@
 typedef struct {
     u8  ink[GA_NUM_INKS];    /* hardware colour index (0-31) */
     u8  selected_pen;        /* current pen register (bit 4 = border) */
-    u8  screen_mode;         /* 0/1/2 */
+    u8  screen_mode;         /* 0/1/2 — active mode (latched on HSYNC) */
+    u8  requested_mode;      /* mode written via ga_write; copied to screen_mode on next HSYNC */
     bool lower_rom;          /* OS ROM mapped at 0x0000 */
     bool upper_rom;          /* BASIC ROM mapped at 0xC000 */
     u8  interrupt_counter;   /* counts HSYNCs, fires IRQ at 52 */
+    u8  vsync_delay;         /* VSYNC→IRQ-resync countdown (2 HSYNCs); 0 = idle */
     bool interrupt_pending;
 } GateArray;
 
@@ -30,3 +32,5 @@ void ga_init(GateArray *ga);
 void ga_write(GateArray *ga, u8 val);   /* port 0x7F (A15=0) */
 u8   ga_mode(GateArray *ga);
 void ga_hsync(GateArray *ga);           /* called by CRTC on each HSYNC */
+void ga_vsync_start(GateArray *ga);     /* called on CRTC VSYNC rising edge */
+void ga_irq_ack(GateArray *ga);         /* called by Z80 on IRQ acknowledge */


### PR DESCRIPTION
…t5 clear

Three fidelity fixes pulled from caprice32 and xcpc:

- VSYNC IRQ resynchronisation: 2 HSYNCs after VSYNC rising edge, raise a compensating IRQ if the 52-line counter is >= 32 and reset it to 0. Locks the 300 Hz raster IRQ to VSYNC so the firmware's frame-flyback ticker (BORDER/INK flashing, SOUND queue) advances on a steady cadence — fixes BORDER c1,c2 not flashing.

- Mode changes latched on next HSYNC instead of taking effect mid-character. Demos with raster mode-splits and the firmware's mode-set sequence rely on this; without it, mid-line mode writes tear the current character.

- On IRQ acknowledge, clear bit 5 of the line counter so the firmware gets one IRQ per request instead of a spurious back-to-back pair when the ISR runs past the next IRQ point.