### PR TITLE
crtc: R5 vertical adjust, status register, continuous R7 comparator

### DIFF
--- a/src/cpc.c
+++ b/src/cpc.c
@@ -76,7 +76,9 @@ static u8 bus_io_read(void *ctx, u16 port) {
     /* CRTC read: A14=0 (hi & ~0x40 → 0xBF area) */
     if (!(hi & 0x40)) {
         u8 func = (port >> 8) & 0x03;
-        result = (func == 0x03) ? crtc_read(&cpc->crtc) : 0xFF;
+        if (func == 0x03)      result = crtc_read(&cpc->crtc);
+        else if (func == 0x02) result = crtc_read_status(&cpc->crtc);
+        else                   result = 0xFF;
     }
     /* PPI: A11=0 selects PPI (0xF4xx/0xF5xx/0xF6xx/0xF7xx) */
     else if (!(hi & 0x08)) {

--- a/src/crtc.c
+++ b/src/crtc.c
@@ -31,6 +31,13 @@ u8 crtc_read(CRTC *c) {
     return (c->selected >= 12 && c->selected <= 17) ? c->reg[c->selected] : 0;
 }
 
+u8 crtc_read_status(CRTC *c) {
+    /* Type 1/3/4 status register: bit 6 = LPEN strobe (unimplemented),
+     * bit 5 = VSYNC active. Demos poll this to time effects without the
+     * 2-line GA→PPI VSYNC delay. */
+    return (c->vsync ? 0x20 : 0x00);
+}
+
 void crtc_tick(CRTC *c) {
     /* Horizontal counter advances; MA tracks along the row */
     c->hcc++;
@@ -60,30 +67,53 @@ void crtc_tick(CRTC *c) {
                 c->vsync = false;
         }
 
-        /* Raster line within character row */
-        c->vlc++;
-        if (c->vlc > c->reg[9]) {
-            /* New character row: advance row start address */
-            c->vlc = 0;
-            c->vcc++;
-            c->ma_row_start += c->reg[1];
-
-            /* VSYNC trigger */
-            if (c->vcc == c->reg[7] && !c->vsync) {
-                c->vsync = true;
-                c->vsc = 0;
-            }
-
-            /* V total: new frame */
-            if (c->vcc > c->reg[4]) {
+        if (c->in_vadjust) {
+            /* Vertical-adjust period (R5 raster lines after the last char row).
+             * Per ACCC §6.1.1: when C5 reaches R5, the frame restarts with
+             * C4=C5=C9=0 and MA reloaded from R12/R13. */
+            c->vac++;
+            if (c->vac > c->reg[5]) {
+                c->in_vadjust = false;
+                c->vac = 0;
                 c->vcc = 0;
                 c->vlc = 0;
                 c->ma_row_start = ((u16)(c->reg[12] << 8) | c->reg[13]) & 0x3FFF;
+            }
+        } else {
+            /* Raster line within character row */
+            c->vlc++;
+            if (c->vlc > c->reg[9]) {
+                /* New character row: advance row start address */
+                c->vlc = 0;
+                c->vcc++;
+                c->ma_row_start += c->reg[1];
+
+                /* V total reached: either enter R5 vertical-adjust or
+                 * restart the frame immediately if R5 is 0. */
+                if (c->vcc > c->reg[4]) {
+                    if (c->reg[5]) {
+                        c->in_vadjust = true;
+                        c->vac = 0;
+                    } else {
+                        c->vcc = 0;
+                        c->vlc = 0;
+                        c->ma_row_start = ((u16)(c->reg[12] << 8) | c->reg[13]) & 0x3FFF;
+                    }
+                }
             }
         }
 
         /* Reload MA to the row start for the next scan line */
         c->ma = c->ma_row_start;
+    }
+
+    /* Continuous R7 comparator: real CRTC starts VSYNC the moment C4
+     * matches R7, not only at the next row-boundary. Demos that re-time
+     * VSYNC by writing R7 mid-frame (HBL effects, second-VSYNC tricks)
+     * depend on this. */
+    if (c->vcc == c->reg[7] && !c->vsync) {
+        c->vsync = true;
+        c->vsc = 0;
     }
 
     c->display_enable = (c->hcc < c->reg[1]) && (c->vcc < c->reg[6]);

--- a/src/crtc.h
+++ b/src/crtc.h
@@ -15,11 +15,13 @@ typedef struct {
     u8  selected;          /* address register */
 
     /* Internal counters */
-    u16 hcc;               /* horizontal character counter */
-    u16 vcc;               /* vertical character counter */
-    u16 vlc;               /* vertical line counter (scan line within char row) */
-    u16 vsc;               /* vertical sync counter */
-    u16 hsc;               /* horizontal sync counter */
+    u16 hcc;               /* C0: horizontal character counter */
+    u16 vcc;               /* C4: vertical character counter */
+    u16 vlc;               /* C9: vertical line counter (scan line within char row) */
+    u16 vsc;               /* C3h: vertical sync counter */
+    u16 hsc;               /* C3l: horizontal sync counter */
+    u16 vac;               /* C5: vertical-adjust raster counter (R5) */
+    bool in_vadjust;       /* true while we're in the R5 vertical-adjust period */
 
     u16 ma;                /* memory address */
     u16 ma_row_start;
@@ -33,6 +35,7 @@ void crtc_init(CRTC *c);
 void crtc_select(CRTC *c, u8 reg);
 void crtc_write(CRTC *c, u8 val);
 u8   crtc_read(CRTC *c);
+u8   crtc_read_status(CRTC *c);     /* &BE00 — type 1/3/4 status register */
 void crtc_tick(CRTC *c);       /* one character clock (1 MHz) */
 
 /* Derived helpers */


### PR DESCRIPTION
Three fidelity improvements pulled from Longshot's ACCC compendium (docs/ACCC1.9-EN.pdf):

- R5 + C5 vertical-adjust period (§6.1.1, §11). After C4 reaches R4 we now enter a vertical-adjust period that ticks C5 up to R5 raster lines before reloading MA from R12/R13. R5=0 still restarts the frame immediately. Standard 6128 framing now produces the real 312-line frame instead of 288 + missing 24 lines.

- Status register at &BE00 (§4.3, type 1/3/4 read). Bit 5 reflects the live VSYNC pin so demos polling &BE00 skip the 2-line GA→PPI VSYNC delay.

- Continuous R7 comparator (§6.1.2). VSYNC starts the moment C4 matches R7 evaluated every character clock, not only at row boundaries — mid-frame R7 writes (second-VSYNC tricks) now take effect on the same tick.

Note: this branch does NOT fix the HBL 2026 demo's mid-band corruption. That demo manipulates R2/R3 per scan line to shift HSYNC position (classic HBL effect); reproducing it requires monitor-side rendering (time-based horizontal positioning with PLL clamp) rather than our "reset raster_x on HSYNC fall" model — a renderer rewrite, not a CRTC fix. The CRTC writes are getting through correctly; the renderer can't represent the analog flyback that real monitors apply.