### PR TITLE
overlay: add Tinker toggle and Advanced tab with Smoothing control

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -66,6 +66,8 @@ void config_defaults(Config *cfg) {
     cfg->scale     = 2;
     cfg->mx4       = true;   /* expansion bus connected by default */
     cfg->rom_board = true;   /* ROM Board fitted by default */
+    cfg->fullscreen_smoothing = true;  /* preserve historic linear-scale behaviour */
+    cfg->tinker    = false;
     config_set_model(cfg, MODEL_6128);  /* sets model, memory, OS, BASIC, AMSDOS */
 }
 
@@ -185,6 +187,12 @@ static void config_create_default(const char *path, const char *home) {
         "scale=2\n"
         "# Start in fullscreen mode: true or false\n"
         "fullscreen=false\n"
+        "# Smooth (linear) vs sharp (nearest) texture scaling\n"
+        "fullscreen_smoothing=true\n"
+        "\n"
+        "[advanced]\n"
+        "# Enable the Advanced overlay tab with low-level toggles\n"
+        "tinker=false\n"
     );
 
     fclose(f);
@@ -321,6 +329,16 @@ int config_load(Config *cfg) {
                 bool b;
                 if (parse_bool(val, &b)) cfg->fullscreen = b;
                 else { fprintf(stderr, "1984.conf:%d: fullscreen must be true/false\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "fullscreen_smoothing")) {
+                bool b;
+                if (parse_bool(val, &b)) cfg->fullscreen_smoothing = b;
+                else { fprintf(stderr, "1984.conf:%d: fullscreen_smoothing must be true/false\n", lineno); rc = -1; }
+            }
+        } else if (!strcmp(section, "advanced")) {
+            if (!strcmp(key, "tinker")) {
+                bool b;
+                if (parse_bool(val, &b)) cfg->tinker = b;
+                else { fprintf(stderr, "1984.conf:%d: tinker must be true/false\n", lineno); rc = -1; }
             }
         }
     }
@@ -413,7 +431,10 @@ int config_save(const Config *cfg) {
         "albireo_image=%s\n\n"
         "[display]\n"
         "scale=%d\n"
-        "fullscreen=%s\n",
+        "fullscreen=%s\n"
+        "fullscreen_smoothing=%s\n\n"
+        "[advanced]\n"
+        "tinker=%s\n",
         cfg->disk_a,
         cfg->disk_b,
         cfg->tape,
@@ -434,7 +455,9 @@ int config_save(const Config *cfg) {
         cfg->albireo          ? "true" : "false",
         cfg->albireo_image,
         cfg->scale,
-        cfg->fullscreen ? "true" : "false"
+        cfg->fullscreen ? "true" : "false",
+        cfg->fullscreen_smoothing ? "true" : "false",
+        cfg->tinker     ? "true" : "false"
     );
 
     fclose(f);

--- a/src/config.h
+++ b/src/config.h
@@ -43,6 +43,10 @@ typedef struct {
     /* [display] */
     int  scale;             /* 1, 2, or 3 */
     bool fullscreen;
+    bool fullscreen_smoothing; /* linear (smooth) vs nearest (sharp) texture scale */
+
+    /* [advanced] */
+    bool tinker;             /* enable Advanced overlay tab with low-level toggles */
 } Config;
 
 /* Load ~/.config/1984/1984.conf into cfg. Missing file = silent defaults.

--- a/src/display.c
+++ b/src/display.c
@@ -33,6 +33,12 @@ int display_init(Display *d, const char *title) {
     return 0;
 }
 
+void display_set_smoothing(Display *d, bool smooth) {
+    if (d->texture)
+        SDL_SetTextureScaleMode(d->texture,
+            smooth ? SDL_SCALEMODE_LINEAR : SDL_SCALEMODE_NEAREST);
+}
+
 void display_destroy(Display *d) {
     if (d->texture)  SDL_DestroyTexture(d->texture);
     if (d->renderer) SDL_DestroyRenderer(d->renderer);

--- a/src/display.h
+++ b/src/display.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "types.h"
 #include <SDL3/SDL.h>
+#include <stdbool.h>
 
 /*
  * SDL3 display layer.
@@ -31,3 +32,6 @@ void display_vsync(Display *d);
 void display_upload(Display *d);   /* update texture + blit to renderer (no flip) */
 void display_flip(Display *d);     /* SDL_RenderPresent */
 void display_save_ppm(Display *d, const char *path);
+
+/* Switch texture scaling between linear (smooth) and nearest (sharp). */
+void display_set_smoothing(Display *d, bool smooth);

--- a/src/main.c
+++ b/src/main.c
@@ -330,6 +330,7 @@ int main(int argc, char *argv[]) {
 
     bool fullscreen     = cfg.fullscreen;
     bool mouse_captured = false;
+    display_set_smoothing(&cpc.display, cfg.fullscreen_smoothing);
     if (fullscreen)
         SDL_SetWindowFullscreen(cpc.display.window, true);
 

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -24,16 +24,17 @@ static void overlay_file_callback(void *userdata, const char * const *files, int
 #define ROMSLOT_TOTAL   (ROM_EXT_COUNT + 1)
 
 static const char *const sec_labels[OV_SEC_COUNT] = {
-    "General", "Media", "Extensions"
+    "General", "Media", "Extensions", "Advanced"
 };
-static const int sec_x[OV_SEC_COUNT] = { 8, 80, 160 };
-/* General has 6 rows on CPC 464, 7 on 6128 (the extra one is the
+static const int sec_x[OV_SEC_COUNT] = { 8, 80, 160, 248 };
+/* General has 7 rows on CPC 464, 8 on 6128 (the extra one is the
  * "External Tape" toggle, only meaningful on the 6128 since the 464 has
- * the cassette deck built in). Other sections are fixed. */
-static const int sec_row_count[OV_SEC_COUNT] = { 6, 3, 11 };
+ * the cassette deck built in). Other sections are fixed.
+ * The Advanced tab (OV_TINKER) is hidden unless cfg->tinker is enabled. */
+static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 11, 1 };
 
 static int ov_section_rows(const Overlay *ov, OvSection s) {
-    if (s == OV_GENERAL && ov->cfg->model == MODEL_6128) return 7;
+    if (s == OV_GENERAL && ov->cfg->model == MODEL_6128) return 8;
     return sec_row_count[s];
 }
 
@@ -131,6 +132,10 @@ static void item_text(const Overlay *ov, int row,
             trunc_path(basename(tmp), val, vsz);
             break;
         }
+        case 7:
+            snprintf(lbl, lsz, "Tinker");
+            snprintf(val, vsz, "%s", ov->cfg->tinker ? "enabled" : "disabled");
+            break;
         }
         break;
     }
@@ -291,6 +296,16 @@ static void item_text(const Overlay *ov, int row,
         }
         break;
 
+    case OV_TINKER:
+        switch (row) {
+        case 0:
+            snprintf(lbl, lsz, "Smoothing");
+            snprintf(val, vsz, "%s",
+                     ov->cfg->fullscreen_smoothing ? "smooth" : "sharp");
+            break;
+        }
+        break;
+
     default:
         break;
     }
@@ -363,6 +378,15 @@ static void activate_item(Overlay *ov) {
                 rom_filters, 2, NULL, false);
             break;
         }
+        case 7:
+            ov->cfg->tinker = !ov->cfg->tinker;
+            /* Don't leave the cursor parked on a tab that just disappeared. */
+            if (!ov->cfg->tinker && ov->section == OV_TINKER) {
+                ov->section = OV_GENERAL;
+                ov->row = 0;
+            }
+            ov->dirty = true;
+            break;
         }
         break;
     }
@@ -622,6 +646,18 @@ static void activate_item(Overlay *ov) {
             }
             break;
         }
+        }
+        break;
+
+    case OV_TINKER:
+        switch (ov->row) {
+        case 0:
+            ov->cfg->fullscreen_smoothing = !ov->cfg->fullscreen_smoothing;
+            if (ov->cpc)
+                display_set_smoothing(&ov->cpc->display,
+                                      ov->cfg->fullscreen_smoothing);
+            ov->dirty = true;
+            break;
         }
         break;
 
@@ -898,12 +934,14 @@ bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
         break;
     case SDL_SCANCODE_LEFT:
         do { ov->section = (OvSection)((ov->section + OV_SEC_COUNT - 1) % OV_SEC_COUNT); }
-        while (ov->section == OV_ADVANCED && !ov->cfg->mx4);
+        while ((ov->section == OV_ADVANCED && !ov->cfg->mx4) ||
+               (ov->section == OV_TINKER   && !ov->cfg->tinker));
         ov->row = 0;
         break;
     case SDL_SCANCODE_RIGHT:
         do { ov->section = (OvSection)((ov->section + 1) % OV_SEC_COUNT); }
-        while (ov->section == OV_ADVANCED && !ov->cfg->mx4);
+        while ((ov->section == OV_ADVANCED && !ov->cfg->mx4) ||
+               (ov->section == OV_TINKER   && !ov->cfg->tinker));
         ov->row = 0;
         break;
     case SDL_SCANCODE_UP:
@@ -1009,20 +1047,23 @@ void overlay_render(const Overlay *ov, SDL_Renderer *r) {
     /* ---- Top bar ---- */
     fill_rect(r, 0, 0, lw, BAR_H, 20, 20, 50, 230);
 
+    /* Tabs are laid out left-to-right; hidden tabs collapse the gap. */
+    float tx = (float)sec_x[0];
     for (int i = 0; i < OV_SEC_COUNT; i++) {
         /* Extensions tab is hidden entirely when MX4 is disabled. */
         if (i == OV_ADVANCED && !ov->cfg->mx4) continue;
+        if (i == OV_TINKER   && !ov->cfg->tinker) continue;
         bool sel = (ov->section == (OvSection)i);
-        float tx = sec_x[i];
         float ty = (BAR_H - FONT_H) / 2.0f;
+        float lw_tab = strlen(sec_labels[i]) * FONT_W;
 
         if (sel) {
-            float hw = strlen(sec_labels[i]) * FONT_W + 4.0f;
-            fill_rect(r, tx - 2, 1, hw, BAR_H - 2, 70, 90, 200, 255);
+            fill_rect(r, tx - 2, 1, lw_tab + 4.0f, BAR_H - 2, 70, 90, 200, 255);
             draw_text(r, tx, ty, sec_labels[i], 255, 255, 255);
         } else {
             draw_text(r, tx, ty, sec_labels[i], 150, 150, 175);
         }
+        tx += lw_tab + 16.0f;   /* gutter between tabs */
     }
 
     /* ---- Dropdown ---- */

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -7,7 +7,8 @@ typedef enum {
     OV_GENERAL  = 0,
     OV_STORAGE  = 1,
     OV_ADVANCED = 2,
-    OV_SEC_COUNT = 3
+    OV_TINKER   = 3,
+    OV_SEC_COUNT = 4
 } OvSection;
 
 typedef enum {


### PR DESCRIPTION
A 'Tinker' toggle in General gates a new 'Advanced' overlay tab. The first (currently only) Advanced entry is 'Smoothing', which flips texture scaling between linear (smooth) and nearest (sharp) at runtime via SDL_SetTextureScaleMode. Both settings persist under [display] and [advanced] in 1984.conf.

Tab bar layout is now dynamic: hidden tabs (Extensions when !mx4, Advanced when !tinker) collapse the gap instead of leaving a hole.