### PR TITLE
fix: load AMSDOS on 464→6128 model switch; add Real CRT stub

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -498,9 +498,12 @@ int main(int argc, char *argv[]) {
             cpc.model = cfg.model;
             cpc.mem.ram_size = cfg.memory_kb * 1024;
             mem_load_rom(&cpc.mem, cfg.rom_os, cfg.rom_basic);
-            if (cfg.rom_amsdos[0] && cfg.dd1)
+            /* AMSDOS is built-in on 6128 and supplied by DDI-1 on the 464;
+             * config_set_model / config_apply_dd1 already nail rom_amsdos
+             * to the right value, so just mirror it into the live ROM map. */
+            if (cfg.rom_amsdos[0])
                 mem_load_amsdos(&cpc.mem, cfg.rom_amsdos);
-            else if (!cfg.dd1 && cpc.model == MODEL_464)
+            else
                 mem_unload_amsdos(&cpc.mem);
             /* First unload every slot — covers the rom_board=true→false
              * transition. The cfg.rom_ext paths stay intact so the next

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -31,7 +31,7 @@ static const int sec_x[OV_SEC_COUNT] = { 8, 80, 160, 248 };
  * "External Tape" toggle, only meaningful on the 6128 since the 464 has
  * the cassette deck built in). Other sections are fixed.
  * The Advanced tab (OV_TINKER) is hidden unless cfg->tinker is enabled. */
-static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 11, 1 };
+static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 11, 2 };
 
 static int ov_section_rows(const Overlay *ov, OvSection s) {
     if (s == OV_GENERAL && ov->cfg->model == MODEL_6128) return 8;
@@ -302,6 +302,11 @@ static void item_text(const Overlay *ov, int row,
             snprintf(lbl, lsz, "Smoothing");
             snprintf(val, vsz, "%s",
                      ov->cfg->fullscreen_smoothing ? "smooth" : "sharp");
+            break;
+        case 1:
+            snprintf(lbl, lsz, "Real CRT");
+            snprintf(val, vsz, "[unimplemented]");
+            *readonly = true;
             break;
         }
         break;


### PR DESCRIPTION
The cold-boot path required cfg.dd1 to load AMSDOS, but dd1 only applies to the 464's DDI-1 — on 6128 it stays false, so after a 464→6128 switch AMSDOS never re-loaded and CAT fell through to the tape handler. Mirror the boot path: load whenever rom_amsdos is set, unload when it isn't. config_set_model and config_apply_dd1 already nail rom_amsdos to the correct value per model.

Also add a 'Real CRT' row to the Advanced tab (read-only, marked unimplemented) as a UI placeholder for upcoming monitor-side rendering work for demos.