### PR TITLE
m4: install helper-shim at boot; protect daemon stack from bus_mem by…

### DIFF
--- a/src/cpc.c
+++ b/src/cpc.c
@@ -39,7 +39,16 @@ static u8 bus_mem_read(void *ctx, u16 addr) {
                        && cpc->mem.upper_rom_select == M4_ROM_SLOT;
     if (cpc->m4 && (bypass_slot || cpc->m4_card.ram_mode)) {
         u8 v = 0; bool hit = true;
-        if (addr >= 0xE800 && addr < 0xF400)
+        /* Skip the bypass for likely stack POP/RET reads (addr matches SP
+         * or SP+1). The SymbOS netd-m4c.exe daemon places its stack at
+         * ~0xF076 — inside our bus_mem mapping — and without this guard
+         * RET would pop bus_mem bytes (zeros / response garbage) instead
+         * of the real return address, derailing m4cred/m4crcv. */
+        bool is_stack_pop = (addr == cpc->cpu.sp) || (addr == (u16)(cpc->cpu.sp + 1));
+        if (is_stack_pop) {
+            hit = false;
+        }
+        else if (addr >= 0xE800 && addr < 0xF400)
             v = cpc->m4_card.bus_mem[addr - 0xE800];
         else if (addr >= 0xF400 && addr < 0xF500)
             v = cpc->m4_card.cfg_mem[addr - 0xF400];

--- a/src/m4.c
+++ b/src/m4.c
@@ -405,7 +405,7 @@ u8 m4_dataport_read(M4 *m) {
 #define M4_HSEND_TRAP_ADDR 0xF300u
 #define M4_HRECV_TRAP_ADDR 0xF310u
 
-static void m4_install_helper_shim(M4 *m, Mem *mem) {
+void m4_install_helper_shim(M4 *m, Mem *mem) {
     if (!mem || !mem->rom_ext_present[M4_ROM_SLOT]) return;
     u8 *rom = mem->rom_ext[M4_ROM_SLOT];
     /* M4ROM helper-pointer table lives at 0xE430 (file offset 0x2430).
@@ -457,13 +457,6 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
      * response via the FD30 FIFO, not bus_mem, so it doesn't need this. */
     if (cmd == 0x4321 || (cmd >= 0x4331 && cmd <= 0x433C)) {
         m->ram_mode = true;
-        /* The daemon's m4cred reads at most 16 bytes (sock_info ldir) plus
-         * a few header bytes (typically 3). 24 covers both with no margin
-         * for stray reads — important because the daemon's m4cscktrn
-         * translation table appears to live in its transfer area at an
-         * address inside our sock_mem bypass range, and any extra
-         * bypassed reads after the actual response read corrupt the
-         * daemon's view of m4cscktrn for subsequent commands. */
         m->ram_mode_reads = 24;
     } else {
         m->ram_mode = false;

--- a/src/m4.h
+++ b/src/m4.h
@@ -129,6 +129,13 @@ typedef struct {
 void m4_init(M4 *m, const char *root);
 void m4_set_image(M4 *m, const char *image_path);
 void m4_reset(M4 *m);
+
+/* Install the helper-shim trap stubs into M4ROM + bus_mem. Must be called
+ * after M4ROM is loaded into an upper-ROM slot, before any CPU code reads
+ * the helper-pointer table — otherwise daemons that copy the unpatched
+ * addresses (e.g. SymbOS netd-m4c.exe's m4crom step) will bypass our
+ * trap entirely and the bulk transfers will go nowhere. */
+void m4_install_helper_shim(M4 *m, Mem *mem);
 /* Called once per frame: refreshes sock_info for any in-flight TCP work
  * (non-blocking connect completion, byte counts, remote-close detection). */
 void m4_tick(M4 *m);

--- a/src/main.c
+++ b/src/main.c
@@ -267,6 +267,12 @@ int main(int argc, char *argv[]) {
         memcpy(cpc.m4_card.cfg_mem,
                &cpc.mem.rom_ext[M4_ROM_SLOT][0xF400 - 0xC000],
                sizeof(cpc.m4_card.cfg_mem));
+        /* Patch M4ROM's helper-pointer table NOW so SymbOS netd-m4c.exe's
+         * m4crom routine picks up our trap addresses on its first read.
+         * Without this the daemon copies the original M4ROM helper entries
+         * and bypasses our trap, breaking the bulk transfer needed by
+         * GETNETWORK and every TCP send/recv. */
+        m4_install_helper_shim(&cpc.m4_card, &cpc.mem);
     }
 
     /* Apply --rom-slot=N:PATH overrides from CLI */
@@ -524,6 +530,7 @@ int main(int argc, char *argv[]) {
                 memcpy(cpc.m4_card.cfg_mem,
                        &cpc.mem.rom_ext[M4_ROM_SLOT][0xF400 - 0xC000],
                        sizeof(cpc.m4_card.cfg_mem));
+                m4_install_helper_shim(&cpc.m4_card, &cpc.mem);
             }
             const char *title = (cpc.model == MODEL_464)
                 ? TITLE_NORMAL_464 : TITLE_NORMAL_6128;


### PR DESCRIPTION
…pass

Two correctness fixes to the M4 emulation surfaced while debugging the SymbOS netd-m4c.exe + soundd.exe interaction:

1. The helper-shim trap stub addresses (0xF300/0xF310) were patched into M4ROM's helper-pointer table only on the first command ACK. This is fine for typical CPC use (M4ROM init issues ACKs early), but late loaders like SymbOS netd-m4c.exe run their own m4crom that copies the table before any ACK has fired, ending up with the original (real M4ROM) helper addresses and bypassing our trap entirely. Move the patch to M4ROM load time so it's in place before any CPU read.

2. The bus_mem bypass at 0xE800-0xF3FF used to intercept *every* read in that range whenever M4ROM was the active upper ROM. That collided with the SymbOS daemon's stack (placed at ~0xF076): a RET after the GETNETWORK ACK would pop bus_mem bytes instead of the real return address, derail the daemon partway through init, and prevent m4cred/m4crcv from running. Detect likely stack pops (addr == SP or SP+1) and let those fall through to actual RAM. Confirmed via trace that m4cred and m4crcv now both dispatch.

Doesn't fully fix the visible-mixer / missing-tray-icon symptom (which appears to be a deeper SymbOS-side daemon-registration issue), but removes two genuine emulation defects exposed by the investigation.