### PR TITLE
m4: signal EOF on partial C_READ2 so BASIC ASCII .BAS load completes

### DIFF
--- a/src/m4.c
+++ b/src/m4.c
@@ -897,7 +897,12 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
         }
         size_p[0] = n & 0xFF;
         size_p[1] = n >> 8;
-        if (n == 0) *status_p = 20;  /* EOF */
+        /* Partial reads (n < count) imply we hit EOF mid-block. AMSDOS
+         * and BASIC's ASCII-tokenise loop both rely on the EOF status
+         * to stop processing — without it BASIC continues reading the
+         * uninitialised tail of the buffer and raises a spurious BREAK
+         * after each ASCII .BAS load. */
+        if (n < count) *status_p = 20;  /* EOF */
         err = M4_OK;
         break;
     }


### PR DESCRIPTION
C_READ2 was returning status=0 (OK) whenever any bytes were read, even on the partial read that hits end-of-file. AMSDOS/BASIC's ASCII tokenise loop reads in 2 KB chunks and only stops when it sees status=20 (EOF) — without that signal, it keeps walking past the actual file data into zero-padding and raises a spurious BREAK ("Broken in") right after the load. After this fix, RUN\"foo.bas\" runs the program instead of erroring.