### PR TITLE
Albireo: config toggle to disable raw DISK_READ as workaround for SymbOS text-render corruption

### DIFF
--- a/ALBIREO.md
+++ b/ALBIREO.md
@@ -82,3 +82,40 @@ After enabling Albireo, loading the two ROMs, and booting:
 If `|HELP` shows only the standard AMSDOS commands, the UNIDOS ROM did not load
 — double-check the slot 7 entry and confirm the file exists at the configured
 path.
+
+## Known issue: SymbOS text rendering vs app loading
+
+SymbOS booted off the Albireo path currently cannot work fully in this
+emulator. Either on-screen text (icon labels, menu items) is correct *or*
+applications launch — never both at once. UNIDOS / BASIC use is unaffected.
+
+The CH376 raw-sector `DISK_READ` path is needed by the SymbOS-side FAT driver
+to load apps. With it enabled (default), all on-screen text gets corrupted
+into a "first-character-repeated" pattern (e.g. `S S S S S S` under what
+should be `Sym-Commander`). Chunk-level traces show our emulation delivers
+byte-perfect data to the right memory bank at the documented icon-name offset
+— the rendering bug is downstream, in a part of the SymbOS desktop manager we
+cannot currently isolate from this side of the chip.
+
+Disabling raw `DISK_READ` makes SymbOS fall back to the chip's built-in FS
+(`FILE_OPEN` / `BYTE_READ`) which renders text correctly but cannot load any
+application (every launch fails with "disc error" code 26 from
+[symbos.org/err.htm#026](https://symbos.org/err.htm#026)). The same trade-off
+appears in ACE-DL when configured with a host-directory drive — that backend
+also exposes only the chip-FS path.
+
+Real Albireo hardware exhibits neither failure mode, so this is an emulator
+bug that has not yet been root-caused.
+
+### Workaround toggle
+
+`~/.config/1984/1984.conf`, under `[hardware]`:
+
+```ini
+albireo_disable_disk_read=false   # default — apps launch, text broken
+albireo_disable_disk_read=true    # text correct, apps fail with disc error
+```
+
+The toggle gates only CH376 cmd `0x54` and has no effect when Albireo is
+disabled. Toggle into "text correct" mode when using SymbOS purely as a
+desktop; leave at the default for app/development work.

--- a/src/ch376.c
+++ b/src/ch376.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 
 int ch376_trace = 0;
+int ch376_disable_disk_read = 0;
 
 /* CH376 USB host controller — partial emulation for Albireo.
  *
@@ -664,6 +665,10 @@ static void execute(CH376 *ch) {
     case 0x54: { /* DISK_READ — start raw sector read.
                   * Params: LBA[4] LE + count[1]. After this, host loops
                   * RD_USB_DATA0 (64 bytes) + DISK_RD_GO until status=SUCCESS. */
+        if (ch376_disable_disk_read) {
+            raise_int(ch, USB_INT_DISK_ERR);
+            break;
+        }
         u32 lba = (u32)p[0] | ((u32)p[1] << 8) | ((u32)p[2] << 16) | ((u32)p[3] << 24);
         u8  count = p[4];
         if (!ch->fp || count == 0) { raise_int(ch, USB_INT_DISK_ERR); break; }

--- a/src/ch376.h
+++ b/src/ch376.h
@@ -115,6 +115,11 @@ typedef struct {
 
 extern int ch376_trace;
 
+/* When set, DISK_READ (cmd 0x54) returns DISK_ERR so SymbOS falls back to
+ * the chip's FS path via FILE_OPEN/BYTE_READ. Workaround for a rendering
+ * regression where SymbOS-FAT-on-raw-DISK_READ corrupts on-screen text. */
+extern int ch376_disable_disk_read;
+
 void ch376_init(CH376 *ch);
 void ch376_reset(CH376 *ch);
 void ch376_open(CH376 *ch, const char *path);

--- a/src/config.c
+++ b/src/config.c
@@ -181,6 +181,7 @@ static void config_create_default(const char *path, const char *home) {
         "symbnet=false\n"
         "albireo=false\n"
         "albireo_image=\n"
+        "albireo_disable_disk_read=false\n"
         "\n"
         "[display]\n"
         "# Window scale factor: 1, 2, or 3\n"
@@ -319,6 +320,9 @@ int config_load(Config *cfg) {
                 else { fprintf(stderr, "1984.conf:%d: albireo must be true/false\n", lineno); rc = -1; }
             } else if (!strcmp(key, "albireo_image")) {
                 if (val[0]) expand_path(val, cfg->albireo_image, sizeof(cfg->albireo_image));
+            } else if (!strcmp(key, "albireo_disable_disk_read")) {
+                if (parse_bool(val, &b)) cfg->albireo_disable_disk_read = b;
+                else { fprintf(stderr, "1984.conf:%d: albireo_disable_disk_read must be true/false\n", lineno); rc = -1; }
             }
         } else if (!strcmp(section, "display")) {
             if (!strcmp(key, "scale")) {
@@ -428,7 +432,8 @@ int config_save(const Config *cfg) {
         "symbiface_mouse=%s\n"
         "symbnet=%s\n"
         "albireo=%s\n"
-        "albireo_image=%s\n\n"
+        "albireo_image=%s\n"
+        "albireo_disable_disk_read=%s\n\n"
         "[display]\n"
         "scale=%d\n"
         "fullscreen=%s\n"
@@ -454,6 +459,7 @@ int config_save(const Config *cfg) {
         cfg->symbnet          ? "true" : "false",
         cfg->albireo          ? "true" : "false",
         cfg->albireo_image,
+        cfg->albireo_disable_disk_read ? "true" : "false",
         cfg->scale,
         cfg->fullscreen ? "true" : "false",
         cfg->fullscreen_smoothing ? "true" : "false",

--- a/src/config.h
+++ b/src/config.h
@@ -39,6 +39,12 @@ typedef struct {
     bool symbnet;     /* 1984 emulator synthetic SymbOS network port (0xFD30/31) */
     bool albireo;
     char albireo_image[CONFIG_PATH_MAX];
+    /* If true, the CH376 emulation refuses raw-sector DISK_READ commands so
+     * SymbOS falls back to the chip's built-in FS via FILE_OPEN/BYTE_READ.
+     * Works around a current rendering bug where SymbOS-FAT-driver-via-raw-
+     * DISK_READ corrupts on-screen text (icon labels, menus). The fallback
+     * path renders correctly but apps fail to load with "disc error". */
+    bool albireo_disable_disk_read;
 
     /* [display] */
     int  scale;             /* 1, 2, or 3 */

--- a/src/main.c
+++ b/src/main.c
@@ -229,6 +229,7 @@ int main(int argc, char *argv[]) {
     cpc.albireo = cfg.albireo && cfg.rom_board;
     if (cpc.albireo && cfg.albireo_image[0])
         ch376_open(&cpc.ch376, cfg.albireo_image);
+    ch376_disable_disk_read = cfg.albireo_disable_disk_read ? 1 : 0;
     /* M4 and Albireo share the 0xFExx port range — Albireo wins if both set. */
     if (cpc.albireo && cpc.m4) {
         cpc.m4 = false;
@@ -554,6 +555,7 @@ int main(int argc, char *argv[]) {
             ch376_close(&cpc.ch376);
             if (cpc.albireo && cfg.albireo_image[0])
                 ch376_open(&cpc.ch376, cfg.albireo_image);
+            ch376_disable_disk_read = cfg.albireo_disable_disk_read ? 1 : 0;
             if (cpc.albireo && cpc.m4) {
                 cpc.m4 = false;
                 cfg.m4 = false;


### PR DESCRIPTION
## Summary

- Adds `albireo_disable_disk_read` toggle under `[hardware]` in `1984.conf` (default false)
- When true, CH376 emulation returns `DISK_ERR` for cmd `0x54` so SymbOS falls back to chip-FS via FILE_OPEN / BYTE_READ
- Workaround only — does not fix the underlying rendering bug

## Background

SymbOS running off Albireo on this emulator corrupts all on-screen text (icon labels, menus) with a "first-character-repeated" pattern (`S S S S S S` under what should be `Sym-Commander`). Investigation in this branch eliminated every emulator subsystem we could probe: CH376 chunk delivery (byte-perfect), port decode / INI / Z80 IN, RAM banking (stable, symmetric), destination memory contents (labels land at the documented `data_area+1296` offset), partition handling, `SYMBOS.INI` format (bit-identical to a working real-HW image), and even a different emulator (ACE-DL with a host-directory drive shows the same labels-OK / apps-broken trade-off via the chip-FS path).

The runtime CPC Albireo driver was extracted from RAM and decoded — its 32×`INI`+`INC B` chunk reader, busy-poll, and DISK_RD_GO loop are textbook CH376 protocol. Bytes reach the destination buffer in bank 5 exactly as on real hardware, yet SymbOS's desktop renderer mis-reads them. Bisecting against commit `b1d436a` (pre-DISK_READ) confirmed labels worked there because SymbOS fell back to chip-FS — same path this toggle exposes.

Real Albireo hardware is currently the only setup where both DISK_READ-driven apps AND text rendering work; ACE-DL ships only the chip-FS path. This toggle gives users the same choice ACE-DL effectively makes, without removing the DISK_READ implementation that current SymbOS app loading depends on.

## Test plan

- [ ] Default config: SymbOS desktop loads, text broken, apps launch normally — no regression
- [ ] `albireo_disable_disk_read=true` under `[hardware]`: SymbOS desktop loads, text correct, app launches fail with disc error — matches b1d436a / ACE-DL
- [ ] Toggle has no effect when Albireo disabled
- [ ] Setting persists through `config_save` round-trip