### PR TITLE
display: add drive-activity LED bar below the CPC screen

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ bin_PROGRAMS = 1984
 	src/ide.c \
 	src/fat.c \
 	src/ch376.c \
+	src/leds.c \
 	src/m4.c \
 	src/symbnet.c \
 	src/mouse.c \
@@ -42,6 +43,7 @@ noinst_HEADERS = \
 	src/ide.h \
 	src/joy.h \
 	src/kbd.h \
+	src/leds.h \
 	src/m4.h \
 	src/mem.h \
 	src/monitor.h \

--- a/src/ch376.c
+++ b/src/ch376.c
@@ -1,4 +1,5 @@
 #include "ch376.h"
+#include "leds.h"
 #include <string.h>
 #include <strings.h>
 #include <stdlib.h>
@@ -600,11 +601,13 @@ static void execute(CH376 *ch) {
         u32 n = (u32)p[0] | ((u32)p[1] << 8);
         ch->bytes_remaining = n;
         ch->reading = true;
+        leds_ping(LED_USB);
         raise_int(ch, do_byte_read(ch));
         break;
     }
 
     case 0x3B: /* BYTE_RD_GO */
+        leds_ping(LED_USB);
         raise_int(ch, do_byte_read(ch));
         break;
 
@@ -612,6 +615,7 @@ static void execute(CH376 *ch) {
         u32 n = (u32)p[0] | ((u32)p[1] << 8);
         ch->bytes_remaining = n;
         ch->writing = true;
+        leds_ping(LED_USB);
         if (!ch->file) raise_int(ch, USB_INT_DISK_ERR);
         else           raise_int(ch, USB_INT_DISK_WRITE);
         break;
@@ -688,12 +692,14 @@ static void execute(CH376 *ch) {
         ch->resp_len = 65;
         ch->resp_pos = 0;
         ch->sec_pos = 64;
+        leds_ping(LED_USB);
         raise_int(ch, USB_INT_DISK_READ);
         break;
     }
 
     case 0x55: { /* DISK_RD_GO — next 64-byte chunk */
         if (!ch->sec_reading) { raise_int(ch, USB_INT_DISK_ERR); break; }
+        leds_ping(LED_USB);
         if (ch->sec_pos >= 512) {
             /* Sector consumed — advance. */
             ch->sec_remaining--;
@@ -733,6 +739,7 @@ static void execute(CH376 *ch) {
         ch->sec_pos = 0;
         ch->sec_writing = true;
         memset(ch->sec_buf, 0, 512);
+        leds_ping(LED_USB);
         raise_int(ch, USB_INT_DISK_WRITE);
         break;
     }

--- a/src/display.c
+++ b/src/display.c
@@ -1,11 +1,12 @@
 #include "display.h"
+#include "leds.h"
 #include <string.h>
 #include <stdio.h>
 
 int display_init(Display *d, const char *title) {
     memset(d, 0, sizeof(*d));
 
-    d->window = SDL_CreateWindow(title, WINDOW_W, WINDOW_H, SDL_WINDOW_RESIZABLE);
+    d->window = SDL_CreateWindow(title, WINDOW_W, WINDOW_H_TOTAL, SDL_WINDOW_RESIZABLE);
     if (!d->window) {
         fprintf(stderr, "SDL_CreateWindow: %s\n", SDL_GetError());
         return -1;
@@ -64,14 +65,28 @@ void display_vsync(Display *d) {
 void display_upload(Display *d) {
     int ww, wh;
     SDL_GetWindowSize(d->window, &ww, &wh);
-    /* Fit 768×272 into the window maintaining 4:3 (WINDOW_W:WINDOW_H) ratio */
+
+    /* Reserve a fixed-pixel strip at the bottom for the drive-activity LED
+     * bar. The bar is not scaled with the window — it just sits under the
+     * CPC area. */
+    int bar_h = LED_BAR_HEIGHT;
+    if (bar_h > wh / 4) bar_h = wh / 4;          /* sanity cap for tiny windows */
+    int cpc_area_h = wh - bar_h;
+    if (cpc_area_h < 1) cpc_area_h = 1;
+
+    /* Fit 768×272 into (ww × cpc_area_h) maintaining 4:3 (WINDOW_W:WINDOW_H) */
     int dst_w = ww;
-    int dst_h = wh;
+    int dst_h = cpc_area_h;
     if (dst_w * WINDOW_H > dst_h * WINDOW_W)
         dst_w = dst_h * WINDOW_W / WINDOW_H;
     else
         dst_h = dst_w * WINDOW_H / WINDOW_W;
-    SDL_FRect dst = { (float)(ww - dst_w) / 2, (float)(wh - dst_h) / 2, (float)dst_w, (float)dst_h };
+    SDL_FRect dst = {
+        (float)(ww - dst_w) / 2,
+        (float)(cpc_area_h - dst_h) / 2,
+        (float)dst_w,
+        (float)dst_h
+    };
 
     SDL_UpdateTexture(d->texture, NULL, d->pixels, CPC_SCREEN_W * sizeof(u32));
     /* Force the clear colour to opaque black before clearing — the overlay
@@ -81,6 +96,7 @@ void display_upload(Display *d) {
     SDL_SetRenderDrawColor(d->renderer, 0, 0, 0, 255);
     SDL_RenderClear(d->renderer);
     SDL_RenderTexture(d->renderer, d->texture, NULL, &dst);
+    leds_render(d->renderer, 0, wh - bar_h, ww, bar_h);
 }
 
 void display_flip(Display *d) {

--- a/src/display.h
+++ b/src/display.h
@@ -14,6 +14,8 @@
 #define CPC_SCREEN_H    272
 #define WINDOW_W        768   /* 4:3 display width */
 #define WINDOW_H        576   /* 4:3 display height (768 × 3/4) */
+#define LED_BAR_HEIGHT  22    /* drive-activity LED strip below the CPC area */
+#define WINDOW_H_TOTAL  (WINDOW_H + LED_BAR_HEIGHT)
 
 typedef struct {
     SDL_Window   *window;

--- a/src/fdc.c
+++ b/src/fdc.c
@@ -1,4 +1,5 @@
 #include "fdc.h"
+#include "leds.h"
 #include <string.h>
 
 /* Command byte counts (total bytes including the command byte itself).
@@ -136,6 +137,7 @@ static void exec_cmd(FDC *fdc) {
     case 0x06:
     case 0x0C: {
         int      drv  = fdc->cmd[1] & 0x01;
+        leds_ping(drv ? LED_FDC_B : LED_FDC_A);
         int      side = (fdc->cmd[1] >> 2) & 0x01;
         uint8_t  C    = fdc->cmd[2];
         uint8_t  H    = fdc->cmd[3];
@@ -231,6 +233,7 @@ static void exec_cmd(FDC *fdc) {
     case 0x05:
     case 0x09: {
         int drv  = fdc->cmd[1] & 0x01;
+        leds_ping(drv ? LED_FDC_B : LED_FDC_A);
         int side = (fdc->cmd[1] >> 2) & 0x01;
         uint8_t C = fdc->cmd[2], H = fdc->cmd[3];
         uint8_t R = fdc->cmd[4], N = fdc->cmd[5];

--- a/src/ide.c
+++ b/src/ide.c
@@ -1,6 +1,7 @@
 #define _POSIX_C_SOURCE 200112L
 #define _FILE_OFFSET_BITS 64
 #include "ide.h"
+#include "leds.h"
 #include <string.h>
 #include <stdio.h>
 #include <sys/types.h>
@@ -29,6 +30,7 @@ static bool load_sector(IDE *ide, u32 lba) {
         set_error(ide, IDE_ERR_ABRT);
         return false;
     }
+    leds_ping(LED_IDE);
     return true;
 }
 
@@ -43,6 +45,7 @@ static bool flush_sector(IDE *ide, u32 lba) {
         return false;
     }
     fflush(ide->fp);
+    leds_ping(LED_IDE);
     return true;
 }
 

--- a/src/leds.c
+++ b/src/leds.c
@@ -1,0 +1,72 @@
+#include "leds.h"
+#include <stdint.h>
+#include <string.h>
+
+typedef struct {
+    uint8_t dr, dg, db;   /* idle (dark)  colour */
+    uint8_t br, bg, bb;   /* active (bright) colour */
+} LedPalette;
+
+static const LedPalette palette[LED_COUNT] = {
+    [LED_FDC_A] = { 70, 18, 18,  255,  70,  70 },
+    [LED_FDC_B] = { 70, 18, 18,  255,  70,  70 },
+    [LED_IDE]   = { 18, 70, 18,   80, 255,  80 },
+    [LED_USB]   = { 25, 50,110,   90, 160, 255 },
+    [LED_SD]    = { 25, 50,110,   90, 160, 255 },
+};
+
+static bool   g_enabled[LED_COUNT];
+static Uint64 g_last_ms[LED_COUNT];
+
+void leds_set_enabled(LedId id, bool enabled) {
+    if ((unsigned)id < LED_COUNT) g_enabled[id] = enabled;
+}
+
+void leds_ping(LedId id) {
+    if ((unsigned)id < LED_COUNT) g_last_ms[id] = SDL_GetTicks();
+}
+
+void leds_render(SDL_Renderer *r, int x, int y, int w, int h) {
+    /* Bar background */
+    SDL_SetRenderDrawColor(r, 18, 18, 18, 255);
+    SDL_FRect bg = { (float)x, (float)y, (float)w, (float)h };
+    SDL_RenderFillRect(r, &bg);
+
+    /* Top hairline separator */
+    SDL_SetRenderDrawColor(r, 50, 50, 50, 255);
+    SDL_FRect line = { (float)x, (float)y, (float)w, 1.0f };
+    SDL_RenderFillRect(r, &line);
+
+    /* Count enabled LEDs to centre them in the bar */
+    int n = 0;
+    for (int i = 0; i < LED_COUNT; i++) if (g_enabled[i]) n++;
+    if (n == 0) return;
+
+    const int led_w   = 24;
+    const int led_h   = 10;
+    const int pad     = 8;
+    const int total_w = n * led_w + (n - 1) * pad;
+    int       cx      = x + (w - total_w) / 2;
+    const int cy      = y + (h - led_h) / 2;
+
+    Uint64 now = SDL_GetTicks();
+    for (int i = 0; i < LED_COUNT; i++) {
+        if (!g_enabled[i]) continue;
+        const LedPalette *p = &palette[i];
+        Uint64 dt = now - g_last_ms[i];
+        bool active = g_last_ms[i] != 0 && dt < LED_GLOW_MS;
+        uint8_t R = active ? p->br : p->dr;
+        uint8_t G = active ? p->bg : p->dg;
+        uint8_t B = active ? p->bb : p->db;
+
+        SDL_SetRenderDrawColor(r, R, G, B, 255);
+        SDL_FRect led = { (float)cx, (float)cy, (float)led_w, (float)led_h };
+        SDL_RenderFillRect(r, &led);
+
+        /* 1-px dark outline to give the LED a defined edge against the bar */
+        SDL_SetRenderDrawColor(r, 0, 0, 0, 255);
+        SDL_RenderRect(r, &led);
+
+        cx += led_w + pad;
+    }
+}

--- a/src/leds.h
+++ b/src/leds.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <SDL3/SDL.h>
+#include <stdbool.h>
+
+/* Drive-activity LED bar rendered below the CPC screen.
+ *
+ * Categories (color coded):
+ *   FDC drives (A, B)      - dark red / bright red
+ *   IDE (Symbiface/Cyboard) - dark green / bright green
+ *   USB/SD (Albireo, M4)   - dark blue / bright blue
+ *
+ * Activity is signalled by leds_ping_*() from the device emulation; the LED
+ * glows bright for LED_GLOW_MS milliseconds after each ping, then fades to
+ * its dark "idle" colour.
+ */
+
+#define LED_BAR_H     22
+#define LED_GLOW_MS   120
+
+typedef enum {
+    LED_FDC_A = 0,
+    LED_FDC_B,
+    LED_IDE,
+    LED_USB,
+    LED_SD,
+    LED_COUNT
+} LedId;
+
+/* Configure which LEDs to display in the bar. Call after reading config. */
+void leds_set_enabled(LedId id, bool enabled);
+
+/* Signal one frame of activity for the given LED. */
+void leds_ping(LedId id);
+
+/* Render the LED bar across (x,y,w,h). The caller has already cleared the
+ * renderer and drawn the CPC screen above this rect. */
+void leds_render(SDL_Renderer *r, int x, int y, int w, int h);

--- a/src/m4.c
+++ b/src/m4.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #include "compat_win.h"   /* sockets/fnmatch/statvfs shims; Winsock before windows.h */
 #include "m4.h"
+#include "leds.h"
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -826,6 +827,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_READ: {
+        leds_ping(LED_SD);
         /* Request:  data[0]=fd, data[1..2]=size
          * Response: resp+3 = result (0=OK)
          *           resp+4 onwards = exactly `size` bytes (zero-padded on EOF).
@@ -864,6 +866,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_READ2: {
+        leds_ping(LED_SD);
         /* Same as C_READ but skips AMSDOS header detection. Used by
          * char_in for unbuffered reads.
          * Request:  data[0]=fd, data[1..2]=size
@@ -908,6 +911,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_WRITE: {
+        leds_ping(LED_SD);
         if (plen < 1) { err = M4_ERR_IO; break; }
         u8 fd = p[0];
         if (!valid_fd(m, fd)) { err = M4_ERR_BADFD; break; }
@@ -922,6 +926,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_WRITE2: {
+        leds_ping(LED_SD);
         if (plen < 2) { err = M4_ERR_IO; break; }
         u8 fd = p[0];
         u8 ch = p[1];
@@ -1024,6 +1029,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_SDREAD: {
+        leds_ping(LED_SD);
         /* Raw block read from the SD card image.
          * Request:  data[0..3]=LBA (little-endian 32-bit), data[4]=num sectors
          * Response: resp+3 = status (0=OK, 3=not ready, 4=invalid param)
@@ -1057,6 +1063,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_SDWRITE: {
+        leds_ping(LED_SD);
         /* Raw block write to the SD card image.
          * Request:  data[0..3]=LBA, data[4]=num sectors, data[5..]=sector data
          * Response: resp+3 = status (0=OK, 1=R/W err, 2=write-protected). */

--- a/src/main.c
+++ b/src/main.c
@@ -13,9 +13,22 @@
 #include "joy.h"
 #include "net4cpc.h"
 #include "monitor.h"
+#include "leds.h"
 #include "shutter_wav.h"
 #include "compat_win.h"   /* net_compat_init() — WSAStartup on Windows */
 #include "startup_debug.h"   /* SD_INIT()/SD_LOG() — no-ops unless -DSTARTUP_DEBUG */
+
+static void apply_led_enables(const Config *cfg) {
+    /* Floppies: shown when an FDC is wired (6128 has it built-in; 464 needs DDI-1). */
+    bool fdc_present = (cfg->model == MODEL_6128) || cfg->dd1;
+    leds_set_enabled(LED_FDC_A, fdc_present);
+    leds_set_enabled(LED_FDC_B, fdc_present);
+    /* MX4 expansions need both rom_board and the expansion toggle. */
+    bool mx4 = cfg->rom_board;
+    leds_set_enabled(LED_IDE, mx4 && cfg->symbiface_ide);
+    leds_set_enabled(LED_USB, mx4 && cfg->albireo);
+    leds_set_enabled(LED_SD,  mx4 && cfg->m4);
+}
 
 #define TITLE_NORMAL_464  "CPC 464  |  F4=screenshot  F5=reset  F8=monitor  F9=options  F11=fullscreen"
 #define TITLE_NORMAL_6128 "CPC 6128  |  F4=screenshot  F5=reset  F8=monitor  F9=options  F11=fullscreen"
@@ -235,6 +248,7 @@ int main(int argc, char *argv[]) {
         cpc.m4 = false;
         cfg.m4 = false;
     }
+    apply_led_enables(&cfg);
     /* Cassette: always wired on 464, requires the external_tape toggle on 6128. */
     if (cfg.tape[0] &&
             (cpc.model == MODEL_464 ||
@@ -560,6 +574,7 @@ int main(int argc, char *argv[]) {
                 cpc.m4 = false;
                 cfg.m4 = false;
             }
+            apply_led_enables(&cfg);
             tape_eject(&cpc.tape);
             if (cfg.tape[0] &&
                     (cpc.model == MODEL_464 ||


### PR DESCRIPTION
Adds a 22 px strip beneath the CPC display area with colour-coded activity LEDs: red for FDC drives A/B, green for IDE (Symbiface/ Cyboard), blue for USB (Albireo) and SD (M4). Each LED glows bright for 120 ms after a read/write and fades back to its idle colour. The bar grows the window taller — it never steals pixels from the CPC area — and only shows LEDs for hardware enabled in the current config.