### PR TITLE
rtc: default register B to binary mode so HDCPM |TIME/|DATE work cold

### DIFF
--- a/src/rtc.c
+++ b/src/rtc.c
@@ -4,7 +4,14 @@
 
 void rtc_init(RTC *r) {
     memset(r, 0, sizeof(*r));
-    r->regb = 0x02; /* 24h mode, BCD — avoids PM-bit confusion on first read */
+    /* Register B default: bit2=DM (1=binary), bit1=24h (1=24-hour).
+     * 0x06 = binary, 24-hour.  The Symbiface software ecosystem (SymbOS and
+     * the HDCPM ROM's |TIME/|DATE commands) expects the clock registers in
+     * binary form — HDCPM double-dabbles each byte binary->BCD for display
+     * and computes the year as century*100+year, both of which only work in
+     * binary mode.  Defaulting to BCD here made |TIME/|DATE print garbage on
+     * a cold boot until SymbOS reprogrammed register B to binary. */
+    r->regb = 0x06; /* binary, 24-hour */
 }
 
 void rtc_write_addr(RTC *r, u8 addr) {


### PR DESCRIPTION
The DS12887 register B controls whether the clock registers are returned in BCD or binary form. rtc_init defaulted it to BCD (0x02), but the Symbiface software ecosystem expects binary: the HDCPM ROM's |TIME/|DATE commands double-dabble each byte binary->BCD for display and compute the year as century*100+year, both of which only produce correct results in binary mode.

With the BCD default, |TIME/|DATE printed garbage on a cold boot and only worked after SymbOS reprogrammed register B to binary (a write we honor, which then persisted). Defaulting register B to 0x06 (binary, 24-hour) makes the commands read correctly straight from a cold start.