### PR TITLE
fdc: gate port 0xFBxx writes on lo-byte bit 7 to fix CP/M 2.2 boot

### DIFF
--- a/src/cpc.c
+++ b/src/cpc.c
@@ -231,8 +231,12 @@ static void bus_io_write(void *ctx, u16 port, u8 val) {
     }
     /* FDC motor: hi=0xFA, write */
     if (hi == 0xFA) { fdc_motor_write(&cpc->fdc, val); return; }
-    /* FDC data: hi=0xFB, write */
-    if (hi == 0xFB) { fdc_write_data(&cpc->fdc, val); return; }
+    /* FDC data: hi=0xFB, lo bit 7 = 0, write */
+    if (hi == 0xFB) {
+        u8 lo = port & 0xFF;
+        if (!(lo & 0x80)) fdc_write_data(&cpc->fdc, val);
+        return;
+    }
     /* hi=0xFD: IDE (0xFD06, 0xFD08-0xFD0F), RTC (0xFD14/0xFD15), Net4CPC (0xFD20-0xFD23) */
     if (cpc->mx4 && hi == 0xFD) {
         u8 lo = port & 0xFF;
@@ -493,15 +497,20 @@ void cpc_frame(CPC *cpc) {
             cpc->tape_audio_cycles -= cpc->cpu_clk_hz;
         }
 
-        /* CRTC ticks at 1 MHz = every 4 CPU cycles */
-        for (int i = 0; i < t; i += 4) {
+        /* CRTC ticks at 1 MHz = every 4 CPU cycles. Track leftover cycles so we
+         * don't over-tick across instructions whose cycle count isn't a multiple
+         * of 4 (Caprice32 uses CPC-rounded cycles per opcode; we use raw Z80
+         * cycle counts and accumulate the remainder here). */
+        cpc->crtc_cycle_acc += t;
+        while (cpc->crtc_cycle_acc >= 4) {
+            cpc->crtc_cycle_acc -= 4;
             crtc_tick(&cpc->crtc);
 
             bool new_hsync = crtc_hsync(&cpc->crtc);
             bool new_vsync = crtc_vsync(&cpc->crtc);
 
-            /* GA interrupt counter on hsync rising edge */
-            if (new_hsync && !cpc->prev_hsync)
+            /* GA interrupt counter on hsync falling edge (matches Caprice32) */
+            if (!new_hsync && cpc->prev_hsync)
                 ga_hsync(&cpc->ga);
 
             ppi_set_vsync(&cpc->ppi, new_vsync);

--- a/src/cpc.h
+++ b/src/cpc.h
@@ -60,6 +60,7 @@ typedef struct {
     int  cpu_clk_hz;      /* 4 MHz */
     int  cycles_per_frame;
     int  cycle_debt;      /* leftover cycles from previous frame */
+    int  crtc_cycle_acc;  /* accumulated cycles for CRTC tick (4-cycle alignment) */
 
     /* Raster position (in character-clock units; 16 output pixels each) */
     int  raster_x;        /* 0 = first char after hsync end */

--- a/src/fdc.c
+++ b/src/fdc.c
@@ -31,6 +31,14 @@ uint8_t fdc_read_status(FDC *fdc) {
         /* idle or mid-command: ready to accept bytes */
         return FDC_MSR_RQM | (fdc->cmd_pos > 0 ? FDC_MSR_BUSY : 0);
     case FDC_PHASE_EXEC:
+        /* First status read after a read/write command returns BUSY without
+         * RQM (matches Caprice32 / real µPD765A behaviour: the FDC needs one
+         * status poll worth of "settling" before signalling data ready).
+         * The Amstrad CP/M 2.2 boot relies on seeing this pre-EXEC BUSY. */
+        if (fdc->read_status_delay) {
+            fdc->read_status_delay--;
+            return FDC_MSR_BUSY;
+        }
         if (!fdc->exec_write)   /* FDC → CPU */
             return FDC_MSR_RQM | FDC_MSR_DIO | FDC_MSR_NDM | FDC_MSR_BUSY;
         else                    /* CPU → FDC */
@@ -193,8 +201,14 @@ static void exec_cmd(FDC *fdc) {
                 last_R = EOT;
             }
             fdc->phase = FDC_PHASE_EXEC;
-            /* store result for after exec */
-            fdc->result[0] = (uint8_t)(FDC_ST0_IC_OK | drv);
+            fdc->read_status_delay = 1;
+            /* store result for after exec. Match Caprice32 / µPD765 behavior:
+             * when a READ DATA terminates at EOT (single-sector or multi-sector),
+             * ST0.AT (0x40) is also set along with ST1.EN. Many CPC boot loaders
+             * (including Amstrad CP/M 2.2's |cpm) test ST0 bits 6:7 (interrupt
+             * code field) to distinguish "more sectors to read" from "end of
+             * track reached". */
+            fdc->result[0] = (uint8_t)(FDC_ST0_IC_AT | drv);
             fdc->result[1] = st1;
             fdc->result[2] = st2;
             fdc->result[3] = last_C;

--- a/src/fdc.h
+++ b/src/fdc.h
@@ -63,6 +63,7 @@ typedef struct {
     bool     seek_done;     /* pending result for SENSE INTERRUPT STATUS */
 
     bool     motor;
+    int      read_status_delay;  /* first status read after data-ready returns BUSY (matches Caprice32) */
 
     Disk    *drive[2];      /* drive[0]=A, drive[1]=B */
 } FDC;

--- a/src/main.c
+++ b/src/main.c
@@ -355,8 +355,8 @@ int main(int argc, char *argv[]) {
     if (fullscreen)
         SDL_SetWindowFullscreen(cpc.display.window, true);
 
-    /* Frames to wait before injecting autostart text; 200 ≈ 4 s at 50 Hz */
-    int autostart_countdown = (autostart || paste_arg) ? 200 : 0;
+    /* Frames to wait before injecting autostart text (matches caprice32 timing) */
+    int autostart_countdown = (autostart || paste_arg) ? 42 : 0;
 
     /* 50 Hz frame pacer — audio is pushed every 20 ms, matching the CPC's PAL rate.
      * VSync is off; we sleep for any leftover time in each 20 ms budget. */


### PR DESCRIPTION
Real µPD765 FDC data register is only addressed when port lo-byte bit 7 is clear (0xFB7E / 0xFB7F). Our bus_io_write matched any 0xFBxx, so AMSDOS writes to 0xFB80+ during normal operation were being mis-routed as FDC commands, scrambling the µPD765 state machine. This crashed the CP/M 2.2 boot loader after the first two sector reads.

Adds the missing lo-byte gate (matches caprice32).

Bundles a few related fixes uncovered while bisecting against caprice32:
- CRTC cycle accumulator (do not over-tick on opcodes whose Z80 cycle count is not a multiple of 4)
- GA interrupt counter advances on hsync falling edge (caprice32 behaviour)
- FDC READ DATA sets ST0.AT and ST1.EN on EOT termination
- FDC first MSR poll in EXEC returns BUSY-only (settling delay)
- autostart paste delay tightened from 200 frames to 42

How it was diagnosed: instrumented both emulators to log Z80 PC at every FDC port write, drove caprice32 to A> on the same disk, diffed. Caprice32 wrote every FDC byte from PC=0xC96D. Ours had stray writes from PC=0xC3B3 — a different AMSDOS routine issuing OUTs to 0xFB80+.

Test plan:
- [x] ./1984 --6128 --disk-a=disks/Cpm2.2.dsk --paste=|cpm\n reaches A> prompt
- [ ] Other disk-heavy workloads still work
- [ ] Non-disk paths unaffected