### PR TITLE
Per-board ROM groupings + cached disk images (#103)

### DIFF
--- a/ALBIREO.md
+++ b/ALBIREO.md
@@ -19,6 +19,12 @@ Slot 8 is the conventional adjacent placement; UNIDOS scans for nodes in slot
 order, so as long as `ALBIREO.ROM` sits just after `UNIDOS.ROM` it will be
 picked up.
 
+> **Tip — tag these slots `albireo`.** Hover the slot row and press **Ins**
+> to tag it with a comma-separated board list (`m4`, `albireo`, or `cyboard`).
+> When the Albireo extension is toggled on later, every slot tagged `albireo`
+> gets its ROM loaded automatically; toggling it off clears those slots. The
+> tag is stored as `[board:albireo]` in `1984.conf` and survives across runs.
+
 > **Note:** Slot 7 is normally AMSDOS. Replacing it with UNIDOS is expected —
 > UNIDOS provides the AMSDOS-equivalent disc-handling RSXes via its own command
 > set. Disk A/B (`.dsk` images via the µPD765 FDC) keep working through the OS

--- a/CYBOARD.md
+++ b/CYBOARD.md
@@ -29,6 +29,13 @@ slot order, so as long as the tools and FAT nodes sit just after `UNIDOS.ROM`
 they will be picked up. If you have additional UNIDOS nodes (e.g. another
 file-system or device), drop them in slots 11, 12, … in the same order.
 
+> **Tip — tag these slots `cyboard`.** With each slot focused, press **Ins**
+> to add the `cyboard` board tag (comma-separated if you want to share with
+> another board, e.g. `cyboard,albireo` for UNIDOS). Toggling SYMBiFACE IDE
+> on in the Extensions tab will then load every `cyboard`-tagged ROM into
+> the matching slot automatically; toggling it off clears those slots and
+> triggers a cold boot. Stored as `[board:cyboard]` in `1984.conf`.
+
 > **Note:** Slot 7 is normally AMSDOS. Replacing it with UNIDOS is expected —
 > UNIDOS provides the AMSDOS-equivalent disc-handling RSXes via its own command
 > set. Disk A/B (`.dsk` images via the µPD765 FDC) keep working through the OS

--- a/M4.md
+++ b/M4.md
@@ -24,6 +24,11 @@ intact for everyday BASIC use.
 |-----:|-------------|--------------------------------------------------|
 | 6    | `M4ROM.ROM` | M4 firmware — set up automatically by the overlay |
 
+> The Extensions → ROM Slots menu also accepts an `m4` board tag (press
+> **Ins** on a populated slot) if you want extra ROMs to load alongside
+> `M4ROM.ROM` whenever M4 is enabled. Tagged ROMs are stored as
+> `[board:m4]` in `1984.conf` and loaded automatically on M4 toggle.
+
 ## Incompatibility with Cyboard and Albireo
 
 M4ROM is incompatible with UNIDOS and the SYMBiFACE pack. The overlay

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Boots to Locomotive BASIC. Commercial games and standard software run well. Demo
 
 **Input** — keyboard, host-clipboard paste, USB/Bluetooth joystick and gamepad with hot-plug.
 
-**Extensions** — DDI-1 floppy interface (464), DS12887 RTC (Cyboard / SYMBiFACE II), SYMBiFACE II / Cyboard IDE (FAT16/FAT32 disk images), SYMBiFACE II PS/2 mouse, Albireo USB mass-storage (CH376 host controller, driven by UNIDOS), **Net4CPC Ethernet (W5100S) with one-click TAP backend on Linux — auto-creates the tap device, runs a built-in DHCP server, DNS proxy, and NAT to the host network. The CPC is fully on the LAN: pingable from the host, accepts inbound connections, and DHCP works end-to-end (verified in HDCPM + SymbOS)**, Amstrad Diagnostics ROM as a one-click toggle.
+**Extensions** — DDI-1 floppy interface (464), DS12887 RTC (Cyboard / SYMBiFACE II), SYMBiFACE II / Cyboard IDE (FAT16/FAT32 disk images), SYMBiFACE II PS/2 mouse, Albireo USB mass-storage (CH376 host controller, driven by UNIDOS), **Net4CPC Ethernet (W5100S) with one-click TAP backend on Linux — auto-creates the tap device, runs a built-in DHCP server, DNS proxy, and NAT to the host network. The CPC is fully on the LAN: pingable from the host, accepts inbound connections, and DHCP works end-to-end (verified in HDCPM + SymbOS)**, Amstrad Diagnostics ROM as a one-click toggle. Per-board ROM groupings (`Ins` in the ROM Slots menu) tag each slot with the boards that need it — M4 / Albireo / Cyboard — so enabling a board auto-loads its ROMs and cached disk image; disabling clears them. No re-prompt for paths between sessions.
 
 ## Supported platforms
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -243,6 +243,25 @@ amsdos=~/.config/1984/roms/AMSDOS.ROM   # 6128 only; cleared automatically for 4
 # Slot 0 = BASIC fallback, slot 7 = AMSDOS fallback; all slots can be overridden.
 # Example: slot_5=~/.config/1984/roms/TOOLKIT.ROM
 
+# Per-board conf templates — when a board is enabled in [hardware] below,
+# the slot paths AND the image path listed under its [board:NAME] section
+# are loaded into the live config automatically; when the board is
+# disabled, the live slots clear but the [board:NAME] template stays
+# parked for the next enable (no re-prompt for the image path).
+# Whitelisted board names: m4, albireo, cyboard. Slot tags via the
+# overlay (Options → Extensions → ROM Slots → Ins on a populated slot).
+# The image is captured automatically the first time you pick a disk
+# image for that board. Press Del on the M4 / Symbiface IDE / Albireo
+# row in the Extensions tab to clear the cached image. The same ROM
+# can belong to multiple boards (multi-board coexistence). Conflict
+# resolution: last-active-board wins, stderr warning names the slot.
+# [board:cyboard]
+# slot_1=~/.config/1984/roms/HDCPM.ROM
+# image=~/Disks/cpcplus.img
+# [board:albireo]
+# slot_7=~/.config/1984/roms/UNIDOS.ROM
+# image=~/Disks/usb-stick.img
+
 [hardware]
 mx4=true          # MX4 expansion bus — when false, every extension peripheral
                   # below (M4, Net4CPC, RTC, SYMBiFACE, Albireo, …) is

--- a/src/config.c
+++ b/src/config.c
@@ -279,6 +279,28 @@ int config_load(Config *cfg) {
                 if (slot >= 0 && slot < ROM_EXT_COUNT && val[0])
                     expand_path(val, cfg->rom_ext[slot], sizeof(cfg->rom_ext[slot]));
             }
+        } else if (strncmp(section, "board:", 6) == 0) {
+            const char *board = section + 6;
+            char (*tbl)[CONFIG_PATH_MAX] = config_board_slots(cfg, board);
+            if (tbl && strncmp(key, "slot_", 5) == 0) {
+                int slot = atoi(key + 5);
+                if (slot >= 0 && slot < ROM_EXT_COUNT && val[0]) {
+                    expand_path(val, tbl[slot], sizeof(tbl[slot]));
+                    /* Add board name to the slot's board CSV, dedup'd. */
+                    if (!config_boards_contains(cfg->rom_ext_boards[slot], board)) {
+                        size_t cur = strlen(cfg->rom_ext_boards[slot]);
+                        size_t need = cur + (cur ? 1 : 0) + strlen(board) + 1;
+                        if (need <= sizeof(cfg->rom_ext_boards[slot])) {
+                            if (cur) cfg->rom_ext_boards[slot][cur++] = ',';
+                            strcpy(cfg->rom_ext_boards[slot] + cur, board);
+                        }
+                    }
+                }
+            } else if (!strcmp(key, "image")) {
+                char *img = config_board_image(cfg, board);
+                if (img && val[0])
+                    expand_path(val, img, CONFIG_PATH_MAX);
+            }
         } else if (!strcmp(section, "storage")) {
             if (!strcmp(key, "drive_a"))
                 expand_path(val, cfg->disk_a, sizeof(cfg->disk_a));
@@ -440,6 +462,32 @@ int config_save(const Config *cfg) {
             fprintf(f, "slot_%d=%s\n", i, cfg->rom_ext[i]);
     }
 
+    /* [board:NAME] sections — per-board conf templates: ROM slot
+     * paths the board needs, plus a cached disk-image path for boards
+     * that have one (m4 SD card, albireo USB drive, cyboard IDE).
+     * Toggling the board on populates the live cfg fields from here;
+     * toggling off keeps the templates so the next enable doesn't
+     * re-prompt. See config_apply_boards() and the overlay activate
+     * handlers in src/overlay.c. */
+    for (int b = 0; b < CONFIG_BOARDS_COUNT; b++) {
+        const char *board = CONFIG_BOARDS[b];
+        char (*tbl)[CONFIG_PATH_MAX] = config_board_slots((Config *)cfg, board);
+        char *img = config_board_image((Config *)cfg, board);
+        if (!tbl && !img) continue;
+        bool any_slot = false;
+        for (int i = 0; tbl && i < ROM_EXT_COUNT; i++)
+            if (tbl[i][0]) { any_slot = true; break; }
+        bool any_img = img && img[0];
+        if (!any_slot && !any_img) continue;
+        fprintf(f, "\n[board:%s]\n", board);
+        for (int i = 0; tbl && i < ROM_EXT_COUNT; i++) {
+            if (tbl[i][0])
+                fprintf(f, "slot_%d=%s\n", i, tbl[i]);
+        }
+        if (any_img)
+            fprintf(f, "image=%s\n", img);
+    }
+
     fprintf(f,
         "\n[storage]\n"
         "drive_a=%s\n"
@@ -554,4 +602,167 @@ void config_default_m4rom(char *out, size_t sz) {
 
 void config_default_diag(char *out, size_t sz) {
     rom_cfg_path(ROM_FILE_DIAG, out, sz);
+}
+
+/* ---------------------------------------------------------------
+ * Per-board ROM tagging — see Config.rom_ext_boards in config.h.
+ * --------------------------------------------------------------- */
+
+char (*config_board_slots(Config *cfg, const char *board))[CONFIG_PATH_MAX] {
+    if (!cfg || !board) return NULL;
+    if (!strcmp(board, "m4"))      return cfg->board_m4_slot;
+    if (!strcmp(board, "albireo")) return cfg->board_albireo_slot;
+    if (!strcmp(board, "cyboard")) return cfg->board_cyboard_slot;
+    return NULL;
+}
+
+char *config_board_image(Config *cfg, const char *board) {
+    if (!cfg || !board) return NULL;
+    if (!strcmp(board, "m4"))      return cfg->board_m4_image;
+    if (!strcmp(board, "albireo")) return cfg->board_albireo_image;
+    if (!strcmp(board, "cyboard")) return cfg->board_cyboard_image;
+    return NULL;
+}
+
+bool config_boards_contains(const char *csv, const char *board) {
+    if (!csv || !board || !csv[0]) return false;
+    size_t bl = strlen(board);
+    const char *p = csv;
+    while (*p) {
+        while (*p == ' ' || *p == ',') p++;
+        const char *start = p;
+        while (*p && *p != ',') p++;
+        size_t len = (size_t)(p - start);
+        /* trim trailing spaces */
+        while (len > 0 && start[len - 1] == ' ') len--;
+        if (len == bl && strncmp(start, board, bl) == 0) return true;
+    }
+    return false;
+}
+
+void config_normalize_boards(const char *in, char *out, size_t out_sz) {
+    if (!out || out_sz == 0) return;
+    out[0] = '\0';
+    if (!in) return;
+    size_t out_len = 0;
+    const char *p = in;
+    while (*p) {
+        while (*p == ' ' || *p == ',' || *p == '\t') p++;
+        if (!*p) break;
+        const char *start = p;
+        while (*p && *p != ',') p++;
+        size_t len = (size_t)(p - start);
+        while (len > 0 && (start[len - 1] == ' ' || start[len - 1] == '\t')) len--;
+        if (!len) continue;
+        /* lowercase into a stack buffer for compare */
+        char tok[32];
+        if (len >= sizeof(tok)) { /* too long → reject */
+            fprintf(stderr, "1984: ROM board tag '%.*s' too long, ignored\n", (int)len, start);
+            continue;
+        }
+        for (size_t i = 0; i < len; i++)
+            tok[i] = (start[i] >= 'A' && start[i] <= 'Z') ? (char)(start[i] + 32) : start[i];
+        tok[len] = '\0';
+        /* whitelist check */
+        bool known = false;
+        for (int b = 0; b < CONFIG_BOARDS_COUNT; b++)
+            if (!strcmp(tok, CONFIG_BOARDS[b])) { known = true; break; }
+        if (!known) {
+            fprintf(stderr, "1984: unknown ROM board tag '%s' (allowed: m4, albireo, cyboard)\n", tok);
+            continue;
+        }
+        /* dedupe */
+        if (config_boards_contains(out, tok)) continue;
+        size_t need = out_len + (out_len ? 1 : 0) + strlen(tok) + 1;
+        if (need > out_sz) {
+            fprintf(stderr, "1984: ROM board tag list overflow, '%s' dropped\n", tok);
+            continue;
+        }
+        if (out_len) out[out_len++] = ',';
+        strcpy(out + out_len, tok);
+        out_len += strlen(tok);
+    }
+}
+
+/* Look up the path for `slot` under `board`. NULL if board unknown
+ * or slot has no template path under that board. */
+static const char *board_template_path(Config *cfg, const char *board, int slot) {
+    char (*tbl)[CONFIG_PATH_MAX] = config_board_slots(cfg, board);
+    if (!tbl) return NULL;
+    if (slot < 0 || slot >= ROM_EXT_COUNT) return NULL;
+    return tbl[slot][0] ? tbl[slot] : NULL;
+}
+
+/* Maps a board name to whether its hardware bool is currently on. */
+static bool board_is_active(const Config *cfg, const char *board) {
+    if (!strcmp(board, "m4"))      return cfg->m4;
+    if (!strcmp(board, "albireo")) return cfg->albireo;
+    if (!strcmp(board, "cyboard")) return cfg->symbiface_ide;
+    return false;
+}
+
+/* Maps a board name to the live cfg disk-image field (NOT the cached
+ * board_*_image), or NULL if board has no image concept. */
+static char *board_live_image(Config *cfg, const char *board) {
+    if (!strcmp(board, "m4"))      return cfg->m4_image;
+    if (!strcmp(board, "albireo")) return cfg->albireo_image;
+    if (!strcmp(board, "cyboard")) return cfg->ide_image;
+    return NULL;
+}
+
+int config_apply_boards(Config *cfg) {
+    int changed = 0;
+    /* Image sync: for each ACTIVE board, copy its cached image into
+     * the live cfg field if the live field is empty (so a user-pinned
+     * image isn't overwritten). For each INACTIVE board, do nothing
+     * to the live field — disabling a board doesn't blow away its
+     * image unless the user explicitly clears it via Del. */
+    for (int b = 0; b < CONFIG_BOARDS_COUNT; b++) {
+        const char *board = CONFIG_BOARDS[b];
+        if (!board_is_active(cfg, board)) continue;
+        char *cached = config_board_image(cfg, board);
+        char *live   = board_live_image(cfg, board);
+        if (cached && live && cached[0] && !live[0]) {
+            snprintf(live, CONFIG_PATH_MAX, "%s", cached);
+            changed++;
+        }
+    }
+    for (int slot = 0; slot < ROM_EXT_COUNT; slot++) {
+        const char *csv = cfg->rom_ext_boards[slot];
+        if (!csv[0]) continue;  /* user-pinned; leave alone */
+        /* Find the last (alphabetically: m4 < albireo < cyboard) active
+         * board for this slot. Last-wins on multi-board conflicts; warn
+         * if more than one active claims this slot. */
+        const char *winner = NULL;
+        const char *winner_path = NULL;
+        int active_count = 0;
+        for (int b = 0; b < CONFIG_BOARDS_COUNT; b++) {
+            const char *board = CONFIG_BOARDS[b];
+            if (!config_boards_contains(csv, board)) continue;
+            if (!board_is_active(cfg, board)) continue;
+            const char *p = board_template_path(cfg, board, slot);
+            if (!p) continue;
+            active_count++;
+            if (winner_path && strcmp(winner_path, p) != 0)
+                fprintf(stderr, "1984: slot %d conflict — board '%s' wants '%s', "
+                                "overrides earlier '%s' from '%s'\n",
+                        slot, board, p, winner_path, winner ? winner : "?");
+            winner = board;
+            winner_path = p;
+        }
+        if (winner_path) {
+            if (strcmp(cfg->rom_ext[slot], winner_path) != 0) {
+                snprintf(cfg->rom_ext[slot], sizeof(cfg->rom_ext[slot]),
+                         "%s", winner_path);
+                changed++;
+            }
+        } else {
+            /* No active board for this slot — clear it. */
+            if (cfg->rom_ext[slot][0]) {
+                cfg->rom_ext[slot][0] = '\0';
+                changed++;
+            }
+        }
+    }
+    return changed;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -16,6 +16,27 @@ typedef struct {
 
     /* [expansion_roms] — slot_0 … slot_31 */
     char rom_ext[ROM_EXT_COUNT][CONFIG_PATH_MAX];
+    /* Per-slot board membership, comma-separated. Set via the overlay
+     * ROM menu's `Ins` key, validated against the whitelist
+     * {m4, albireo, cyboard}. Sourced from `[board:NAME]` sections in
+     * 1984.conf. When a board's matching hardware bool flips on (m4,
+     * albireo, or symbiface_ide for cyboard), every slot tagged with
+     * that board's name gets its template path loaded into rom_ext[].
+     * Empty string = the slot is user-pinned, not board-managed. */
+    char rom_ext_boards[ROM_EXT_COUNT][64];
+    /* Per-board conf templates. Each `[board:NAME]` section in
+     * 1984.conf holds the slot_N=PATH and image=PATH entries the
+     * board needs to function. When the matching hardware toggle
+     * flips on, the overlay copies these into the live cfg
+     * (rom_ext[] + ide_image/albireo_image/m4_image) so the user
+     * doesn't have to re-pick paths on every enable cycle.
+     * Cleared per-field by pressing Del on the relevant row. */
+    char board_m4_slot[ROM_EXT_COUNT][CONFIG_PATH_MAX];
+    char board_albireo_slot[ROM_EXT_COUNT][CONFIG_PATH_MAX];
+    char board_cyboard_slot[ROM_EXT_COUNT][CONFIG_PATH_MAX];
+    char board_m4_image[CONFIG_PATH_MAX];        /* SD-card image */
+    char board_albireo_image[CONFIG_PATH_MAX];   /* USB drive image */
+    char board_cyboard_image[CONFIG_PATH_MAX];   /* IDE (SymbIface) image */
 
     /* [storage] */
     char disk_a[CONFIG_PATH_MAX];
@@ -87,6 +108,33 @@ void config_set_model(Config *cfg, CpcModel model);
 
 /* Enable or disable the DDI-1 on a CPC 464 (sets/clears rom_amsdos). */
 void config_apply_dd1(Config *cfg, bool enabled);
+
+/* Whitelist of board names usable as ROM-slot tags. */
+#define CONFIG_BOARDS  (const char *[]){"m4", "albireo", "cyboard"}
+#define CONFIG_BOARDS_COUNT 3
+
+/* Returns the per-board template-paths table for `board`, or NULL if
+ * board isn't a known name. Pointer is into the supplied Config. */
+char (*config_board_slots(Config *cfg, const char *board))[CONFIG_PATH_MAX];
+
+/* Returns the per-board cached-image-path buffer for `board`
+ * (sized CONFIG_PATH_MAX), or NULL if board isn't a known name. */
+char *config_board_image(Config *cfg, const char *board);
+
+/* Normalise + validate a comma-separated board list (e.g. user input
+ * from the overlay `Ins` editor). Drops unknown tokens with a stderr
+ * warning, trims whitespace, lowercases, deduplicates. Writes the
+ * canonical form into `out` (size `out_sz`). */
+void config_normalize_boards(const char *in, char *out, size_t out_sz);
+
+/* True if `board` appears in the comma-separated list `csv`. */
+bool config_boards_contains(const char *csv, const char *board);
+
+/* Reapply board membership to rom_ext[]: for every slot that names a
+ * board whose hardware bool is on, copy the board's template path into
+ * rom_ext[]; for every slot whose only board(s) are now disabled,
+ * clear rom_ext[]. Returns the number of slots whose path changed. */
+int config_apply_boards(Config *cfg);
 
 /* Restore individual ROM paths to the compiled-in defaults for the model. */
 void config_default_os(CpcModel model, char *out, size_t sz);

--- a/src/main.c
+++ b/src/main.c
@@ -321,6 +321,12 @@ int main(int argc, char *argv[]) {
      * hooks. Production env vars (CC_TABLES, FAKE_RTC, AUTOSTART_FRAMES,
      * PASTE_GAP) use plain getenv() and are unaffected. */
     g_debug_enabled = cfg.debug ? 1 : 0;
+
+    /* Apply per-board ROM templates to rom_ext[]: every slot tagged
+     * with an active board (m4/albireo/symbiface_ide-for-cyboard) gets
+     * the board's template path loaded; slots whose only board is now
+     * inactive get cleared. See config_apply_boards() and #103. */
+    config_apply_boards(&cfg);
     SD_LOG("  rom_os=%s", cfg.rom_os);
     SD_LOG("  rom_basic=%s", cfg.rom_basic);
     SD_LOG("  rom_amsdos=%s [next: SDL_Init]", cfg.rom_amsdos);

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -513,18 +513,33 @@ static void activate_item(Overlay *ov) {
                                           sizeof(ov->cfg->rom_amsdos));
                 if (ov->cpc)
                     mem_load_amsdos(&ov->cpc->mem, ov->cfg->rom_amsdos);
-                /* Enable: open file picker to select SD card image (raw FAT) */
-                ov->dialog_kind  = DIALOG_M4_IMAGE;
-                ov->dialog_ready = false;
-                static const SDL_DialogFileFilter m4_filters[] = {
-                    { "SD card images", "img;IMG;bin;BIN;raw;RAW" },
-                    { "All files",      "*"                        },
-                };
-                SDL_ShowOpenFileDialog(overlay_file_callback, ov,
-                    ov->cpc ? ov->cpc->display.window : NULL,
-                    m4_filters, 2, NULL, false);
+                /* Reuse cached image if present (see cyboard/albireo). */
+                if (ov->cfg->board_m4_image[0]) {
+                    snprintf(ov->cfg->m4_image, sizeof(ov->cfg->m4_image),
+                             "%s", ov->cfg->board_m4_image);
+                    ov->cfg->m4 = true;
+                    if (ov->cpc) {
+                        ov->cpc->m4 = true;
+                        m4_set_image(&ov->cpc->m4_card, ov->cfg->m4_image);
+                    }
+                    ov->needs_cold_boot = true;
+                    ov->dirty = true;
+                } else {
+                    /* Enable: open file picker to select SD card image (raw FAT) */
+                    ov->dialog_kind  = DIALOG_M4_IMAGE;
+                    ov->dialog_ready = false;
+                    static const SDL_DialogFileFilter m4_filters[] = {
+                        { "SD card images", "img;IMG;bin;BIN;raw;RAW" },
+                        { "All files",      "*"                        },
+                    };
+                    SDL_ShowOpenFileDialog(overlay_file_callback, ov,
+                        ov->cpc ? ov->cpc->display.window : NULL,
+                        m4_filters, 2, NULL, false);
+                }
             } else {
-                /* Disable: clear flag and unload M4ROM from its slot */
+                /* Disable: clear flag and unload M4ROM from its slot.
+                 * Keep board_m4_image so the next enable doesn't
+                 * re-prompt; clear it via Del on this row. */
                 ov->cfg->m4 = false;
                 ov->cfg->m4_image[0] = '\0';
                 if (ov->cpc) {
@@ -593,18 +608,29 @@ static void activate_item(Overlay *ov) {
         }
         case 7:
             if (!ov->cfg->symbiface_ide) {
-                /* Enabling: open file dialog to select a disk image */
-                ov->dialog_kind  = DIALOG_IDE;
-                ov->dialog_ready = false;
-                static const SDL_DialogFileFilter ide_filters[] = {
-                    { "Disk images", "img;IMG;hdf;HDF;raw;RAW" },
-                    { "All files",   "*"                       },
-                };
-                SDL_ShowOpenFileDialog(overlay_file_callback, ov,
-                    ov->cpc ? ov->cpc->display.window : NULL,
-                    ide_filters, 2, NULL, false);
+                /* Enabling: if the cyboard board template has a cached
+                 * IDE image, reuse it (no dialog) — config_apply_boards
+                 * runs after this case and copies the cached image
+                 * into cfg.ide_image. Otherwise open the file picker. */
+                if (ov->cfg->board_cyboard_image[0]) {
+                    ov->cfg->symbiface_ide = true;
+                    ov->dirty = true;
+                } else {
+                    ov->dialog_kind  = DIALOG_IDE;
+                    ov->dialog_ready = false;
+                    static const SDL_DialogFileFilter ide_filters[] = {
+                        { "Disk images", "img;IMG;hdf;HDF;raw;RAW" },
+                        { "All files",   "*"                       },
+                    };
+                    SDL_ShowOpenFileDialog(overlay_file_callback, ov,
+                        ov->cpc ? ov->cpc->display.window : NULL,
+                        ide_filters, 2, NULL, false);
+                }
             } else {
-                /* Disabling: clear image path and disable */
+                /* Disabling: clear the LIVE image but keep the cached
+                 * board_cyboard_image so the next enable doesn't
+                 * re-prompt. The user clears the cache via Del on
+                 * this row (see key handler for OV_ADVANCED). */
                 ov->cfg->symbiface_ide = false;
                 ov->cfg->ide_image[0]  = '\0';
                 ov->dirty = true;
@@ -628,16 +654,23 @@ static void activate_item(Overlay *ov) {
                     }
                     ov->needs_cold_boot = true;
                 }
-                ov->dialog_kind  = DIALOG_ALBIREO;
-                ov->dialog_ready = false;
-                static const SDL_DialogFileFilter alb_filters[] = {
-                    { "USB drive images", "img;IMG;bin;BIN;raw;RAW;iso;ISO" },
-                    { "All files",        "*"                                },
-                };
-                SDL_ShowOpenFileDialog(overlay_file_callback, ov,
-                    ov->cpc ? ov->cpc->display.window : NULL,
-                    alb_filters, 2, NULL, false);
+                /* Reuse cached image if present (see case 7). */
+                if (ov->cfg->board_albireo_image[0]) {
+                    ov->cfg->albireo = true;
+                    ov->dirty = true;
+                } else {
+                    ov->dialog_kind  = DIALOG_ALBIREO;
+                    ov->dialog_ready = false;
+                    static const SDL_DialogFileFilter alb_filters[] = {
+                        { "USB drive images", "img;IMG;bin;BIN;raw;RAW;iso;ISO" },
+                        { "All files",        "*"                                },
+                    };
+                    SDL_ShowOpenFileDialog(overlay_file_callback, ov,
+                        ov->cpc ? ov->cpc->display.window : NULL,
+                        alb_filters, 2, NULL, false);
+                }
             } else {
+                /* Keep board_albireo_image for the next enable cycle. */
                 ov->cfg->albireo = false;
                 ov->cfg->albireo_image[0] = '\0';
                 if (ov->cpc) {
@@ -673,17 +706,27 @@ static void activate_item(Overlay *ov) {
                 ov->cfg->ide_image[0] = '\0';
                 ov->dirty = true;
             } else if (!ov->cfg->ide_image[0]) {
-                /* Enabling with no image selected — open file picker */
-                ov->dialog_kind  = DIALOG_IDE;
-                ov->dialog_ready = false;
-                static const SDL_DialogFileFilter ide_filters[] = {
-                    { "Disk images", "img;IMG;hdf;HDF;raw;RAW" },
-                    { "All files",   "*"                       },
-                };
-                SDL_ShowOpenFileDialog(overlay_file_callback, ov,
-                    ov->cpc ? ov->cpc->display.window : NULL,
-                    ide_filters, 2, NULL, false);
-                /* dirty set by file callback once image is chosen */
+                /* Enabling with no image selected — use the cached
+                 * board_cyboard_image if set; else open a file picker
+                 * (config_apply_boards runs in handle_event after this
+                 * and will sync the cache → live too, but doing it
+                 * here keeps the case self-contained). */
+                if (ov->cfg->board_cyboard_image[0]) {
+                    snprintf(ov->cfg->ide_image, sizeof(ov->cfg->ide_image),
+                             "%s", ov->cfg->board_cyboard_image);
+                    ov->dirty = true;
+                } else {
+                    ov->dialog_kind  = DIALOG_IDE;
+                    ov->dialog_ready = false;
+                    static const SDL_DialogFileFilter ide_filters[] = {
+                        { "Disk images", "img;IMG;hdf;HDF;raw;RAW" },
+                        { "All files",   "*"                       },
+                    };
+                    SDL_ShowOpenFileDialog(overlay_file_callback, ov,
+                        ov->cpc ? ov->cpc->display.window : NULL,
+                        ide_filters, 2, NULL, false);
+                    /* dirty set by file callback once image is chosen */
+                }
             } else {
                 ov->dirty = true;
             }
@@ -778,6 +821,29 @@ void overlay_init(Overlay *ov, Config *cfg, CPC *cpc) {
     ov->dialog_kind  = DIALOG_NONE;
     ov->dialog_drive = -1;
     ov->dialog_slot  = -1;
+    ov->last_m4            = cfg->m4;
+    ov->last_albireo       = cfg->albireo;
+    ov->last_symbiface_ide = cfg->symbiface_ide;
+}
+
+/* Check whether any of the ROM-owning hardware toggles flipped since
+ * we last looked; if so, re-apply per-board ROM templates and request
+ * a cold boot so the new board's grouping loads from scratch. Called
+ * from both overlay_handle_event (after activate_item) and
+ * overlay_tick (after dialog-callback completion), so changes via
+ * either path are caught. */
+static void overlay_check_board_changes(Overlay *ov) {
+    bool changed =
+        (ov->cfg->m4            != ov->last_m4) ||
+        (ov->cfg->albireo       != ov->last_albireo) ||
+        (ov->cfg->symbiface_ide != ov->last_symbiface_ide);
+    if (!changed) return;
+    config_apply_boards(ov->cfg);
+    ov->dirty = true;
+    ov->needs_cold_boot = true;
+    ov->last_m4            = ov->cfg->m4;
+    ov->last_albireo       = ov->cfg->albireo;
+    ov->last_symbiface_ide = ov->cfg->symbiface_ide;
 }
 
 void overlay_tick(Overlay *ov) {
@@ -816,10 +882,18 @@ void overlay_tick(Overlay *ov) {
         ov->dirty = true;
     } else if (ov->dialog_kind == DIALOG_IDE) {
         snprintf(ov->cfg->ide_image, CONFIG_PATH_MAX, "%s", ov->dialog_path);
+        /* Also stash in the cyboard board template so the next enable
+         * cycle reuses this path without re-prompting. */
+        snprintf(ov->cfg->board_cyboard_image,
+                 sizeof(ov->cfg->board_cyboard_image),
+                 "%s", ov->dialog_path);
         ov->cfg->symbiface_ide = true;
         ov->dirty = true;
     } else if (ov->dialog_kind == DIALOG_ALBIREO) {
         snprintf(ov->cfg->albireo_image, CONFIG_PATH_MAX, "%s", ov->dialog_path);
+        snprintf(ov->cfg->board_albireo_image,
+                 sizeof(ov->cfg->board_albireo_image),
+                 "%s", ov->dialog_path);
         ov->cfg->albireo = true;
         if (ov->cpc) {
             ov->cpc->albireo = true;
@@ -848,6 +922,8 @@ void overlay_tick(Overlay *ov) {
          * SDCARD.img and SDCARD/ sits next to it), wire it up as the file-API
          * backing so BASIC's cat/load/save keep working. */
         snprintf(ov->cfg->m4_image, CONFIG_PATH_MAX, "%s", ov->dialog_path);
+        snprintf(ov->cfg->board_m4_image, sizeof(ov->cfg->board_m4_image),
+                 "%s", ov->dialog_path);
         ov->cfg->m4 = true;
 
         char sibling[CONFIG_PATH_MAX];
@@ -884,6 +960,11 @@ void overlay_tick(Overlay *ov) {
         ov->dirty = true;
     }
     ov->dialog_kind = DIALOG_NONE;
+    /* Catch board toggles that flipped via a file-dialog callback
+     * (DIALOG_IDE → cfg.symbiface_ide, DIALOG_ALBIREO → cfg.albireo,
+     * DIALOG_M4_IMAGE → cfg.m4). Same effect as the call in
+     * overlay_handle_event after activate_item. */
+    overlay_check_board_changes(ov);
 }
 
 bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
@@ -963,10 +1044,87 @@ bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
     /* ---- ROM slots sub-panel ---- */
     /* idx 0 = Lower ROM; idx 1-32 = upper slots 0-31 */
     if (ov->state == OV_STATE_ROMSLOTS) {
+        /* Inline board-tag editor: when active, every key flows into
+         * the edit buffer. Enter commits, Esc cancels. */
+        if (ov->romslot_editing) {
+            if (sc == SDL_SCANCODE_ESCAPE) {
+                ov->romslot_editing = false;
+            } else if (sc == SDL_SCANCODE_RETURN
+                    || sc == SDL_SCANCODE_KP_ENTER) {
+                int slot = ov->romslot_row - 1;
+                if (slot >= 0 && slot < ROM_EXT_COUNT) {
+                    char prev_csv[64];
+                    snprintf(prev_csv, sizeof(prev_csv), "%s",
+                             ov->cfg->rom_ext_boards[slot]);
+                    config_normalize_boards(ov->romslot_edit_buf,
+                        ov->cfg->rom_ext_boards[slot],
+                        sizeof(ov->cfg->rom_ext_boards[slot]));
+                    /* Sync the per-board template tables: for each board
+                     * now tagged, store this slot's current path; for
+                     * each board removed, clear the template entry. */
+                    for (int b = 0; b < CONFIG_BOARDS_COUNT; b++) {
+                        const char *board = CONFIG_BOARDS[b];
+                        char (*tbl)[CONFIG_PATH_MAX] =
+                            config_board_slots(ov->cfg, board);
+                        if (!tbl) continue;
+                        bool was = config_boards_contains(prev_csv, board);
+                        bool now = config_boards_contains(
+                            ov->cfg->rom_ext_boards[slot], board);
+                        if (now && ov->cfg->rom_ext[slot][0]) {
+                            snprintf(tbl[slot], sizeof(tbl[slot]),
+                                     "%s", ov->cfg->rom_ext[slot]);
+                        } else if (was && !now) {
+                            tbl[slot][0] = '\0';
+                        }
+                    }
+                    ov->dirty = true;
+                    /* If the tag change touches an already-enabled
+                     * board, the slot may need reload/clear — let
+                     * apply_boards run and flag cold-boot if so. */
+                    if (config_apply_boards(ov->cfg) > 0)
+                        ov->needs_cold_boot = true;
+                }
+                ov->romslot_editing = false;
+            } else if (sc == SDL_SCANCODE_BACKSPACE) {
+                if (ov->romslot_edit_len > 0)
+                    ov->romslot_edit_buf[--ov->romslot_edit_len] = '\0';
+            } else {
+                /* Accept letters a–z, digits 0–9, comma, space.
+                 * Only `m4` needs digits from the whitelist but we
+                 * accept all for future-proofing. */
+                char ch = 0;
+                if (sc >= SDL_SCANCODE_A && sc <= SDL_SCANCODE_Z)
+                    ch = (char)('a' + (sc - SDL_SCANCODE_A));
+                else if (sc >= SDL_SCANCODE_1 && sc <= SDL_SCANCODE_9)
+                    ch = (char)('1' + (sc - SDL_SCANCODE_1));
+                else if (sc == SDL_SCANCODE_0)
+                    ch = '0';
+                else if (sc == SDL_SCANCODE_COMMA)
+                    ch = ',';
+                else if (sc == SDL_SCANCODE_SPACE)
+                    ch = ' ';
+                if (ch && ov->romslot_edit_len + 1 <
+                          (int)sizeof(ov->romslot_edit_buf)) {
+                    ov->romslot_edit_buf[ov->romslot_edit_len++] = ch;
+                    ov->romslot_edit_buf[ov->romslot_edit_len] = '\0';
+                }
+            }
+            return true;
+        }
         switch (sc) {
         case SDL_SCANCODE_ESCAPE:
             ov->state = OV_STATE_MENU;
             break;
+        case SDL_SCANCODE_INSERT: {
+            if (ov->romslot_row == 0) break;  /* lower ROM not taggable */
+            int slot = ov->romslot_row - 1;
+            if (!ov->cfg->rom_ext[slot][0]) break;  /* empty slot — no-op */
+            ov->romslot_editing = true;
+            snprintf(ov->romslot_edit_buf, sizeof(ov->romslot_edit_buf),
+                     "%s", ov->cfg->rom_ext_boards[slot]);
+            ov->romslot_edit_len = (int)strlen(ov->romslot_edit_buf);
+            break;
+        }
         case SDL_SCANCODE_UP:
             if (ov->romslot_row > 0) {
                 ov->romslot_row--;
@@ -1062,6 +1220,48 @@ bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
     case SDL_SCANCODE_RETURN:
     case SDL_SCANCODE_KP_ENTER:
         activate_item(ov);
+        overlay_check_board_changes(ov);
+        break;
+    case SDL_SCANCODE_DELETE:
+    case SDL_SCANCODE_BACKSPACE:
+        /* Del on the Extensions tab row for M4 / Symbiface IDE /
+         * Albireo also clears the cached board image — so the next
+         * enable re-prompts for a fresh path. Toggles the extension
+         * off as a side effect (the live cfg field is cleared too). */
+        if (ov->section == OV_ADVANCED) {
+            char *cached = NULL;
+            switch (ov->row) {
+            case 0:                                /* M4 */
+                cached = ov->cfg->board_m4_image;
+                ov->cfg->m4 = false;
+                ov->cfg->m4_image[0] = '\0';
+                if (ov->cpc) {
+                    ov->cpc->m4 = false;
+                    m4_set_image(&ov->cpc->m4_card, "");
+                }
+                break;
+            case 7:                                /* Symbiface IDE (cyboard) */
+                cached = ov->cfg->board_cyboard_image;
+                ov->cfg->symbiface_ide = false;
+                ov->cfg->ide_image[0] = '\0';
+                break;
+            case 9:                                /* Albireo */
+                cached = ov->cfg->board_albireo_image;
+                ov->cfg->albireo = false;
+                ov->cfg->albireo_image[0] = '\0';
+                if (ov->cpc) {
+                    ov->cpc->albireo = false;
+                    ch376_close(&ov->cpc->ch376);
+                }
+                break;
+            }
+            if (cached) {
+                cached[0] = '\0';
+                ov->dirty = true;
+                ov->needs_cold_boot = true;
+                overlay_check_board_changes(ov);
+            }
+        }
         break;
     default:
         break;
@@ -1082,7 +1282,7 @@ void overlay_render(const Overlay *ov, SDL_Renderer *r) {
     /* ---- ROM slots sub-panel ---- */
     if (ov->state == OV_STATE_ROMSLOTS) {
         fill_rect(r, 0, 0, lw, lh, 10, 10, 30, 245);
-        draw_text(r, DROP_PAD, 4, "ROMs  Esc=back  Enter=load  Del=clear (upper slots)",
+        draw_text(r, DROP_PAD, 4, "ROMs  Esc=back  Enter=load  Del=clear  Ins=tag (m4/albireo/cyboard)",
                   180, 180, 220);
         SDL_SetRenderDrawColor(r, 70, 90, 200, 255);
         SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_NONE);
@@ -1144,6 +1344,25 @@ void overlay_render(const Overlay *ov, SDL_Renderer *r) {
                     /* Empty slot — grey */
                     draw_text(r, VAL_X, ty, "[empty]", 70, 70, 90);
                 }
+
+                /* Boards column — show the comma-separated board CSV
+                 * (m4/albireo/cyboard) the slot is tagged with, or
+                 * (when the user is editing this slot) the live edit
+                 * buffer with a cursor. */
+                #define BOARDS_X 360
+                bool editing_here = (ov->state == OV_STATE_ROMSLOTS
+                                     && ov->romslot_editing
+                                     && idx == ov->romslot_row);
+                if (editing_here) {
+                    char buf[80];
+                    snprintf(buf, sizeof(buf), "%s_", ov->romslot_edit_buf);
+                    draw_text(r, BOARDS_X, ty, buf, 255, 220, 80);
+                } else if (ov->cfg->rom_ext_boards[slot][0] && has_ext) {
+                    draw_text(r, BOARDS_X, ty,
+                              ov->cfg->rom_ext_boards[slot],
+                              150, 200, 255);
+                }
+                #undef BOARDS_X
             }
         }
         SDL_SetRenderScale(r, 1.0f, 1.0f);

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -49,8 +49,22 @@ typedef struct {
     /* ROM slots sub-panel state */
     int          romslot_row;    /* selected slot 0-31 */
     int          romslot_scroll; /* index of first visible slot */
+    /* Inline editor for the boards CSV (Ins key on a populated slot). */
+    bool         romslot_editing;
+    char         romslot_edit_buf[64];
+    int          romslot_edit_len;
     /* set by overlay after a save that requires a cold boot */
     bool         needs_cold_boot;
+    /* Last-seen state of the three ROM-owning hardware toggles.
+     * Initialised in overlay_init from the loaded config. After every
+     * event AND every dialog-callback tick, the overlay diffs the
+     * current config against this snapshot; if any of the three flipped
+     * (Enter-on-toggle, file-dialog completion, anywhere) we re-apply
+     * board ROM templates and flag a cold boot. This catches the
+     * async dialog path that direct hooks in handle_event miss. */
+    bool         last_m4;
+    bool         last_albireo;
+    bool         last_symbiface_ide;
 } Overlay;
 
 void overlay_init(Overlay *ov, Config *cfg, CPC *cpc);


### PR DESCRIPTION
## Summary

- New '[board:NAME]' sections in '1984.conf' bundle a board's ROM slots and cached disk-image path. Whitelisted boards: 'm4', 'albireo', 'cyboard'. Toggling the matching hardware (m4 / albireo / symbiface_ide) auto-loads the slots and image; toggling off clears them but keeps the template for next time.
- 'Ins' in the ROM Slots overlay opens an inline editor to tag the focused slot with a comma-separated board list. Whitelist-validated; unknowns drop with stderr warning.
- File-dialog images (M4 SD, Albireo USB, Cyboard IDE) are cached into the board section automatically the first time you pick one. Subsequent enables skip the dialog. 'Del' on the extension row clears the cache and forces a fresh prompt next time.
- Any flip of m4 / albireo / symbiface_ide (Enter or async dialog completion) routes through 'overlay_check_board_changes' which re-applies templates and always requests a cold boot — so the new board's grouping loads from scratch.

## Closes

#103

## Changes

- 'src/config.{h,c}' — 'rom_ext_boards[]' (per-slot board CSV), 'board_*_slot[][]' template tables, 'board_*_image' cache fields; parser and writer for '[board:NAME]'; 'config_apply_boards()' applies templates to live cfg.
- 'src/overlay.{h,c}' — boards column in ROM Slots menu, 'Ins' inline editor, 'Del'-on-extension-row clears cache, state-tracker for board toggles via both direct-Enter and async file-dialog paths.
- 'src/main.c' — 'config_apply_boards()' on startup so a saved config restores the right ROM map at boot.
- Docs — 'README.md' (one-line feature mention), 'USAGE.md' (full syntax), 'ALBIREO.md' / 'CYBOARD.md' / 'M4.md' (per-extension tip boxes).

## Backward compatibility

Additive. Existing '1984.conf' files load and behave byte-identically:
- No '[board:*]' sections in conf → board tables stay zero → 'config_apply_boards' is a no-op.
- File-dialog behaviour unchanged when no cached image exists.
- Save without any tags writes no new '[board:*]' sections.

One intentional behaviour delta even without tags: toggling m4 / albireo / symbiface_ide ALWAYS sets needs_cold_boot now. Previously some disable paths skipped the cold boot. (Requested in the issue thread.)

## Test plan

- [x] Fresh '1984.conf' boots and behaves identically to the previous build (regression test: navigate to Extensions → Albireo → Enter still opens the file dialog, no '[board:*]' lines written on save).
- [x] Tag a slot via 'Ins' → save → reopen → tag persists in conf.
- [x] Tag 'm4,foo,albireo' → 'foo' is dropped with stderr warning, slot ends up tagged 'm4,albireo'.
- [x] Enable Cyboard → file dialog → pick image → save → disable → re-enable → no re-prompt, cached path is used.
- [x] Del on Albireo extension row → cached image cleared, extension disabled, next enable re-prompts.
- [x] Switch Cyboard off → Albireo on → cold boot fires (this was the original issue thread bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)