### PR TITLE
tap: compile-time gate for unsupported platforms (refs #114)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -735,14 +735,12 @@ int config_apply_boards(Config *cfg) {
          * if more than one active claims this slot. */
         const char *winner = NULL;
         const char *winner_path = NULL;
-        int active_count = 0;
         for (int b = 0; b < CONFIG_BOARDS_COUNT; b++) {
             const char *board = CONFIG_BOARDS[b];
             if (!config_boards_contains(csv, board)) continue;
             if (!board_is_active(cfg, board)) continue;
             const char *p = board_template_path(cfg, board, slot);
             if (!p) continue;
-            active_count++;
             if (winner_path && strcmp(winner_path, p) != 0)
                 fprintf(stderr, "1984: slot %d conflict — board '%s' wants '%s', "
                                 "overrides earlier '%s' from '%s'\n",

--- a/src/main.c
+++ b/src/main.c
@@ -34,6 +34,13 @@
  * detach our fd from it; the device itself stays, so flipping the
  * toggle back on also doesn't prompt. */
 static void net4cpc_tap_sync(Config *cfg, const char *cli_tap_dev) {
+#if !TAP_SUPPORTED
+    /* No L2 TAP on this OS — the overlay hides the toggle, the config
+     * field stays a no-op, and Net4CPC stays on the host-socket
+     * fallback unconditionally. Silently return. */
+    (void)cfg; (void)cli_tap_dev;
+    return;
+#else
     const bool want_auto =
         cfg->net4cpc && cfg->net4cpc_tap &&
         (!cli_tap_dev || !cli_tap_dev[0]);
@@ -106,6 +113,7 @@ static void net4cpc_tap_sync(Config *cfg, const char *cli_tap_dev) {
     n4c_stack_set_dhcp_enabled(true);
     n4c_stack_set_dns_enabled(true);
     have_auto = true;
+#endif /* TAP_SUPPORTED */
 }
 
 static void apply_led_enables(const Config *cfg) {

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -1,5 +1,6 @@
 #include "overlay.h"
 #include "cpc.h"
+#include "tap.h"     /* TAP_SUPPORTED */
 #include "m4.h"
 #include "disk.h"
 #include "mem.h"
@@ -321,7 +322,10 @@ static void item_text(const Overlay *ov, int row,
             break;
         case 4:
             snprintf(lbl, lsz, "Net4CPC TAP");
-            if (!ov->cfg->net4cpc) {
+            if (!TAP_SUPPORTED) {
+                snprintf(val, vsz, "[unsupported on this OS]");
+                *readonly = true;
+            } else if (!ov->cfg->net4cpc) {
                 snprintf(val, vsz, "[needs Net4CPC]");
                 *readonly = true;
             } else {
@@ -331,7 +335,9 @@ static void item_text(const Overlay *ov, int row,
             break;
         case 5:
             snprintf(lbl, lsz, "DHCP server");
-            if (!ov->cfg->net4cpc || !ov->cfg->net4cpc_tap) {
+            if (!TAP_SUPPORTED) {
+                snprintf(val, vsz, "[Net4CPC TAP unsupported]");
+            } else if (!ov->cfg->net4cpc || !ov->cfg->net4cpc_tap) {
                 snprintf(val, vsz, "[Net4CPC TAP off]");
             } else {
                 snprintf(val, vsz, "%s, lease %s-%s",
@@ -771,7 +777,7 @@ static void activate_item(Overlay *ov) {
             break;
         }
         case 4:
-            if (ov->cfg->net4cpc) {
+            if (TAP_SUPPORTED && ov->cfg->net4cpc) {
                 ov->cfg->net4cpc_tap = !ov->cfg->net4cpc_tap;
                 ov->dirty = true;
                 ov->needs_cold_boot = true;

--- a/src/tap.h
+++ b/src/tap.h
@@ -18,6 +18,23 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+/* Compile-time gate for the L2 TAP backend + one-click auto-setup.
+ *   Linux:    full support (existing).
+ *   BSDs:     planned (#114); the per-OS device + ioctls land there.
+ *   macOS:    no native L2 TAP and no built-in privilege elevation;
+ *             the host-socket fallback is the only realistic path.
+ *   Windows:  requires the third-party OpenVPN TAP-Windows6 driver
+ *             which is a separate install with no scriptable setup.
+ *
+ * When TAP_SUPPORTED is 0 the overlay hides the Net4CPC TAP row and
+ * net4cpc_tap_sync() short-circuits, so unsupported builds never try
+ * to call tap_open / tap_auto_create. */
+#if defined(__linux__)
+#  define TAP_SUPPORTED 1
+#else
+#  define TAP_SUPPORTED 0
+#endif
+
 #define TAP_FRAME_MAX  2048
 
 /* Open the TAP device. Returns fd >= 0 on success, -1 on failure with errno


### PR DESCRIPTION
## Summary

Adds a `TAP_SUPPORTED` compile-time gate in `src/tap.h`. Linux: on (existing behaviour). Windows + macOS: off — the Net4CPC TAP overlay row is hidden (read-only `[unsupported on this OS]`) and the boot-time `net4cpc_tap_sync()` short-circuits so we never try to open `/dev/net/tun` or run `pkexec ip tuntap`.

This is the prep step for #114 (full BSD port). Once `if_tap` support for FreeBSD / NetBSD / OpenBSD lands, the gate becomes a one-line change:

```c
#if defined(__linux__) || defined(__FreeBSD__) || \
    defined(__NetBSD__) || defined(__OpenBSD__)
#  define TAP_SUPPORTED 1
#else
#  define TAP_SUPPORTED 0
#endif
```

Refs #114.

## Changes

- `src/tap.h` — `TAP_SUPPORTED` macro (1 on Linux, 0 elsewhere).
- `src/main.c` — `net4cpc_tap_sync()` early-returns when gate is off.
- `src/overlay.c` — TAP and DHCP rows show `[unsupported on this OS]`; toggle handler refuses to flip `cfg.net4cpc_tap`.
- `src/config.c` — drop an unused `active_count` counter in `config_apply_boards` that the compiler started flagging after #113 merged.

## Behaviour delta

- **Linux**: no change.
- **Windows / macOS**: Net4CPC stays on the existing host-socket fallback (the default before TAP shipped). The L2 TAP feature is hidden from the UI rather than failing at runtime with confusing errors.

## Test plan

- [x] Linux build clean, no warnings.
- [ ] Windows MinGW CI passes the `!TAP_SUPPORTED` compile path.
- [x] Linux runtime: overlay still shows the TAP row; toggle still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
