### PR TITLE
Net4CPC TAP backend: FreeBSD / NetBSD / OpenBSD support (closes #114)

### DIFF
--- a/NET4CPC.md
+++ b/NET4CPC.md
@@ -26,8 +26,21 @@ behaves as a real L2 endpoint on whatever the TAP is bridged to.
 - SymbOS networking
 - DHCP if the TAP is bridged to a network that has a DHCP server
 
-Linux only for now. macOS/Windows fall back to the legacy host-socket
-behaviour (the `--tap=` flag is silently ignored on those platforms).
+Linux, FreeBSD, NetBSD, OpenBSD. macOS and Windows fall back to the
+legacy host-socket behaviour (the `--tap=` flag is silently ignored
+on those platforms, the overlay shows the TAP row as
+`[unsupported on this OS]`).
+
+The auto-setup path differs by OS:
+
+- **Linux** — `pkexec ip tuntap …` with built-in NAT via iptables; one
+  password prompt, full LAN integration out of the box.
+- **BSDs** — `doas` (preferred) or `sudo` (fallback) wraps `ifconfig`
+  to create the tap interface and assign the host IP. NAT to the
+  wider host network is **not** auto-configured on BSD — you get
+  host-↔-CPC connectivity for free; outbound LAN/internet needs a
+  manual packet-filter rule (see [BSD NAT setup](#bsd-nat-setup)
+  below).
 
 ## ⚠️ Heads up — pick a subnet that doesn't collide with your LAN
 
@@ -153,6 +166,46 @@ The first TAP launch needs `CAP_NET_ADMIN` to call
    refuse to honour `LD_PRELOAD`, `LD_LIBRARY_PATH`, etc. on
    `setcap`'d binaries, which may break some development workflows.
 3. Run `1984` as root — discouraged.
+
+<a id="bsd-nat-setup"></a>
+## BSD NAT setup (manual)
+
+The Linux auto-setup wires up iptables MASQUERADE so the CPC reaches
+the wider host network and the internet. The BSD auto-setup stops
+after `ifconfig … inet … up` — host-↔-CPC works immediately, but
+outbound LAN/internet needs you to add a NAT rule in the host's
+packet filter. Pick the one for your OS:
+
+### FreeBSD / OpenBSD (pf)
+
+Add to `/etc/pf.conf`:
+
+```
+ext_if="em0"          # your real outbound interface
+nat on $ext_if from 10.0.0.0/24 to any -> ($ext_if)
+pass quick on tap0
+```
+
+Then `doas pfctl -f /etc/pf.conf && doas pfctl -e`.
+
+### FreeBSD (ipfw alternative)
+
+```
+doas sysctl net.inet.ip.forwarding=1
+doas ipfw add 1000 nat 1 ip from 10.0.0.0/24 to any out via em0
+doas ipfw nat 1 config if em0
+```
+
+### NetBSD (npf)
+
+```
+# /etc/npf.conf
+$ext_if = "wm0"
+map $ext_if dynamic 10.0.0.0/24 -> $ext_if
+group default { pass final on $ext_if all }
+```
+
+Then `doas npfctl reload && doas npfctl start`.
 
 ## Troubleshooting
 

--- a/src/main.c
+++ b/src/main.c
@@ -27,12 +27,13 @@
  * is the --tap=NAME the user passed on the command line (NULL/empty if
  * none); it suppresses auto-setup so power users keep full control.
  *
- * Persistence model: the auto-tap device 'cpc-tap0' lives for the host
- * uptime — created once on first enable (one pkexec prompt), reused
- * across subsequent 1984 launches in the same session (zero prompts),
- * cleared by the kernel on reboot. On overlay-toggle-off we just
- * detach our fd from it; the device itself stays, so flipping the
- * toggle back on also doesn't prompt. */
+ * Persistence model: the auto-tap device ('cpc-tap0' on Linux, 'tap0'
+ * on BSDs — the BSD tap driver only accepts 'tap<N>' names) lives for
+ * the host uptime — created once on first enable (one elevation
+ * prompt), reused across subsequent 1984 launches in the same session
+ * (zero prompts), cleared by the kernel on reboot. On overlay-toggle-off
+ * we just detach our fd from it; the device itself stays, so flipping
+ * the toggle back on also doesn't prompt. */
 static void net4cpc_tap_sync(Config *cfg, const char *cli_tap_dev) {
 #if !TAP_SUPPORTED
     /* No L2 TAP on this OS — the overlay hides the toggle, the config
@@ -85,7 +86,16 @@ static void net4cpc_tap_sync(Config *cfg, const char *cli_tap_dev) {
 
     if (!want_auto) return;
 
+    /* Linux's ip(8) accepts any device name; we use 'cpc-tap0' so the
+     * device is visibly attributable. BSD if_tap drivers (FreeBSD,
+     * NetBSD, OpenBSD) only accept names of the form 'tap<digits>'
+     * because the name is used to select the clone driver; pick a
+     * portable 'tap0' there. */
+#if defined(__linux__)
     static const char auto_name[] = "cpc-tap0";
+#else
+    static const char auto_name[] = "tap0";
+#endif
     /* Build "host_ip/cidr" from host_ip and netmask dotted-quads.
      * Count contiguous set bits to get the prefix length. */
     unsigned a, b, c, d;

--- a/src/tap.c
+++ b/src/tap.c
@@ -393,13 +393,15 @@ int tap_auto_create(const char *name, const char *ip_cidr) {
     snprintf(cmd, sizeof(cmd),
         "%s sh -c '"
         "set -e; "
+#if defined(__NetBSD__)
+        /* On NetBSD the tap pseudo-device is a loadable kernel module
+         * (if_tap) that isn't loaded by default on stock installs.
+         * modload returns 0 if already loaded so this is idempotent. */
+        "modload if_tap 2>/dev/null || true; "
+#endif
         "ifconfig %s create 2>/dev/null || true; "
         "ifconfig %s inet %s up; "
-#if defined(__OpenBSD__) || defined(__FreeBSD__)
         "sysctl -w net.inet.ip.forwarding=1 >/dev/null"
-#elif defined(__NetBSD__)
-        "sysctl -w net.inet.ip.forwarding=1 >/dev/null"
-#endif
         "' 2>&1",
         elev, name, name, ip_cidr);
 
@@ -410,12 +412,20 @@ int tap_auto_create(const char *name, const char *ip_cidr) {
     if (rc != 0) {
         fprintf(stderr, "tap: auto-create failed (system() returned %d). "
                         "Manual setup:\n"
+#if defined(__NetBSD__)
+                        "  %s modload if_tap            "
+                        "  # NetBSD: load the pseudo-device first\n"
+#endif
                         "  %s ifconfig %s create\n"
                         "  %s ifconfig %s inet %s up\n"
                         "  %s sysctl -w net.inet.ip.forwarding=1\n"
                         "(NAT to host network requires pf/ipfw/npf rules — "
                         "see NET4CPC.md)\n",
-                rc, elev, name, elev, name, ip_cidr, elev);
+                rc,
+#if defined(__NetBSD__)
+                elev,
+#endif
+                elev, name, elev, name, ip_cidr, elev);
         return -1;
     }
     fprintf(stderr, "tap: '%s' ready — %s\n"

--- a/src/tap.c
+++ b/src/tap.c
@@ -422,9 +422,9 @@ int tap_auto_create(const char *name, const char *ip_cidr) {
         "' 2>&1",
         elev, name, name, ip_cidr, owner, name);
 
-    fprintf(stderr, "tap: auto-creating '%s' (%s) via %s — "
-                    "you may be prompted for your password\n",
-                    name, ip_cidr, elev);
+    fprintf(stderr, "tap: auto-creating '%s' (%s) via %s, "
+                    "chown to '%s' — you may be prompted for your password\n",
+                    name, ip_cidr, elev, owner);
     int rc = system(cmd);
     if (rc != 0) {
         fprintf(stderr, "tap: auto-create failed (system() returned %d). "

--- a/src/tap.c
+++ b/src/tap.c
@@ -203,7 +203,240 @@ void tap_auto_destroy(const char *name) {
     (void)system(cmd);
 }
 
-#else  /* non-Linux: stub everything so the rest of net4cpc.c compiles */
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+
+/* -------------------------------------------------------------------
+ * BSD if_tap backend. FreeBSD / NetBSD have a cloning '/dev/tap'
+ * device — opening it spawns a tapN and the name is recovered via
+ * TAPGIFNAME. OpenBSD doesn't clone; it has fixed '/dev/tap0' …
+ * '/dev/tapN' nodes that need to exist (often via 'ifconfig tapN
+ * create' beforehand). All three speak raw Ethernet frames (no
+ * Linux 4-byte protocol prefix), so tap_read/tap_write are the same.
+ *
+ * Auto-setup uses a runtime probe for doas → sudo → fail. doas is
+ * the default on OpenBSD; FreeBSD/NetBSD users typically have sudo.
+ * If neither is present we print the manual command list and let
+ * the host-socket fallback take over.
+ *
+ * NAT/forwarding is intentionally minimal in v1: we bring up the
+ * interface and assign an address. Routing outward (pf/ipfw/npf
+ * NAT) is documented in NET4CPC.md as a manual follow-up — the
+ * three BSDs each have their own packet filter and a "one-click
+ * NAT" abstraction across them is more code than this branch should
+ * land at once. The CPC is reachable from the host either way.
+ * ----------------------------------------------------------------- */
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <pwd.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <net/if.h>
+#if defined(__FreeBSD__) || defined(__NetBSD__)
+#  include <net/if_tap.h>            /* TAPGIFNAME */
+#endif
+#include <ifaddrs.h>
+
+static const char *bsd_elevator(void) {
+    /* Runtime probe: prefer doas (lighter, default on OpenBSD),
+     * fall back to sudo, give up otherwise. system("command -v X")
+     * spawns a shell but only on the first call per process. */
+    static const char *picked = NULL;
+    static int probed = 0;
+    if (!probed) {
+        probed = 1;
+        if (system("command -v doas >/dev/null 2>&1") == 0) picked = "doas";
+        else if (system("command -v sudo >/dev/null 2>&1") == 0) picked = "sudo";
+    }
+    return picked;
+}
+
+int tap_open(const char *devname, char *out_name, size_t out_name_sz) {
+    char path[64];
+    int fd = -1;
+
+#if defined(__OpenBSD__)
+    /* OpenBSD: explicit /dev/tapN node. If devname is "tap5" we open
+     * /dev/tap5; if NULL/empty we walk tap0..tap63 until one opens. */
+    if (devname && devname[0]) {
+        const char *n = devname;
+        if (strncmp(n, "tap", 3) == 0) n += 3;
+        snprintf(path, sizeof(path), "/dev/tap%s", n);
+        fd = open(path, O_RDWR);
+        if (fd < 0) {
+            fprintf(stderr, "tap: open %s: %s\n", path, strerror(errno));
+            return -1;
+        }
+        if (out_name && out_name_sz)
+            snprintf(out_name, out_name_sz, "tap%s", n);
+    } else {
+        for (int i = 0; i < 64; i++) {
+            snprintf(path, sizeof(path), "/dev/tap%d", i);
+            fd = open(path, O_RDWR);
+            if (fd >= 0) {
+                if (out_name && out_name_sz)
+                    snprintf(out_name, out_name_sz, "tap%d", i);
+                break;
+            }
+        }
+        if (fd < 0) {
+            fprintf(stderr,
+                "tap: no openable /dev/tapN node found. Create one first:\n"
+                "tap:   doas ifconfig tap0 create\n");
+            return -1;
+        }
+    }
+#else
+    /* FreeBSD / NetBSD: cloning /dev/tap (also accept /dev/tapN for
+     * explicit selection). After open() the kernel has bound this fd
+     * to a fresh interface; TAPGIFNAME recovers its name. */
+    if (devname && devname[0]) {
+        const char *n = devname;
+        if (strncmp(n, "tap", 3) == 0) n += 3;
+        snprintf(path, sizeof(path), "/dev/tap%s", n);
+    } else {
+        snprintf(path, sizeof(path), "/dev/tap");
+    }
+    fd = open(path, O_RDWR);
+    if (fd < 0) {
+        fprintf(stderr, "tap: open %s: %s\n", path, strerror(errno));
+        return -1;
+    }
+    struct ifreq ifr;
+    memset(&ifr, 0, sizeof(ifr));
+#  if defined(TAPGIFNAME)
+    if (ioctl(fd, TAPGIFNAME, &ifr) == 0) {
+        if (out_name && out_name_sz)
+            snprintf(out_name, out_name_sz, "%s", ifr.ifr_name);
+    } else
+#  endif
+    {
+        /* Fallback: derive name from devnode minor via fstat. */
+        struct stat st;
+        if (fstat(fd, &st) == 0) {
+            int minor_num = (int)(st.st_rdev & 0xFF);
+            if (out_name && out_name_sz)
+                snprintf(out_name, out_name_sz, "tap%d", minor_num);
+        }
+    }
+#endif
+
+    int fl = fcntl(fd, F_GETFL, 0);
+    if (fl >= 0) fcntl(fd, F_SETFL, fl | O_NONBLOCK);
+    return fd;
+}
+
+void tap_close(int fd) { if (fd >= 0) close(fd); }
+
+int tap_read(int fd, u8 *buf, size_t maxlen) {
+    ssize_t n = read(fd, buf, maxlen);
+    if (n > 0) return (int)n;
+    if (n == 0) return 0;
+    if (errno == EAGAIN || errno == EWOULDBLOCK) return 0;
+    return -1;
+}
+
+int tap_write(int fd, const u8 *buf, size_t len) {
+    ssize_t n = write(fd, buf, len);
+    return (n < 0) ? -1 : (int)n;
+}
+
+static bool tap_str_is_safe(const char *s) {
+    if (!s || !*s) return false;
+    for (const char *p = s; *p; ++p) {
+        unsigned char c = (unsigned char)*p;
+        if (!(isalnum(c) || c == '-' || c == '.' || c == '/' || c == '_'))
+            return false;
+    }
+    return true;
+}
+
+static bool tap_dev_exists(const char *name) {
+    struct ifaddrs *ifa = NULL, *p;
+    if (getifaddrs(&ifa) != 0) return false;
+    bool found = false;
+    for (p = ifa; p; p = p->ifa_next) {
+        if (p->ifa_name && strcmp(p->ifa_name, name) == 0) { found = true; break; }
+    }
+    freeifaddrs(ifa);
+    return found;
+}
+
+int tap_auto_create(const char *name, const char *ip_cidr) {
+    if (!tap_str_is_safe(name) || !tap_str_is_safe(ip_cidr)) {
+        fprintf(stderr, "tap: refusing unsafe device/cidr string\n");
+        return -1;
+    }
+    const char *elev = bsd_elevator();
+    if (!elev) {
+        fprintf(stderr,
+            "tap: neither doas nor sudo is installed. Auto-setup needs one\n"
+            "tap: of them to run privileged commands. Either install one\n"
+            "tap: (`pkg install sudo` on FreeBSD, etc.) or run the manual\n"
+            "tap: commands shown after the next failure.\n");
+        return -1;
+    }
+    if (tap_dev_exists(name)) {
+        fprintf(stderr, "tap: '%s' already present, reusing (host IP not re-checked on BSD)\n", name);
+        return 0;
+    }
+
+    /* CIDR like "10.0.0.1/24" → ifconfig wants "10.0.0.1/24" inet on
+     * all three BSDs; the form is portable. The 'create' subcommand
+     * is also common across them when applied to a tap interface
+     * name; if the kernel already auto-created the interface from
+     * the device node, 'create' is a no-op (FreeBSD/NetBSD warn but
+     * succeed; OpenBSD treats it as creating the if). */
+    char cmd[1024];
+    snprintf(cmd, sizeof(cmd),
+        "%s sh -c '"
+        "set -e; "
+        "ifconfig %s create 2>/dev/null || true; "
+        "ifconfig %s inet %s up; "
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
+        "sysctl -w net.inet.ip.forwarding=1 >/dev/null"
+#elif defined(__NetBSD__)
+        "sysctl -w net.inet.ip.forwarding=1 >/dev/null"
+#endif
+        "' 2>&1",
+        elev, name, name, ip_cidr);
+
+    fprintf(stderr, "tap: auto-creating '%s' (%s) via %s — "
+                    "you may be prompted for your password\n",
+                    name, ip_cidr, elev);
+    int rc = system(cmd);
+    if (rc != 0) {
+        fprintf(stderr, "tap: auto-create failed (system() returned %d). "
+                        "Manual setup:\n"
+                        "  %s ifconfig %s create\n"
+                        "  %s ifconfig %s inet %s up\n"
+                        "  %s sysctl -w net.inet.ip.forwarding=1\n"
+                        "(NAT to host network requires pf/ipfw/npf rules — "
+                        "see NET4CPC.md)\n",
+                rc, elev, name, elev, name, ip_cidr, elev);
+        return -1;
+    }
+    fprintf(stderr, "tap: '%s' ready — %s\n"
+                    "tap: NAT to wider network not auto-configured on BSD; "
+                    "host ↔ CPC works.\n",
+                    name, ip_cidr);
+    return 0;
+}
+
+void tap_auto_destroy(const char *name) {
+    if (!tap_str_is_safe(name)) return;
+    if (!tap_dev_exists(name)) return;
+    const char *elev = bsd_elevator();
+    if (!elev) return;
+    char cmd[256];
+    snprintf(cmd, sizeof(cmd),
+        "%s ifconfig %s destroy >/dev/null 2>&1", elev, name);
+    (void)system(cmd);
+}
+
+#else  /* non-Linux, non-BSD: stub everything so net4cpc.c compiles */
 
 int  tap_open(const char *devname, char *out_name, size_t out_name_sz) {
     (void)devname; (void)out_name; (void)out_name_sz;

--- a/src/tap.c
+++ b/src/tap.c
@@ -389,9 +389,21 @@ int tap_auto_create(const char *name, const char *ip_cidr) {
             "tap: commands shown after the next failure.\n");
         return -1;
     }
+    /* If both the interface and the /dev/tapN node owned-by-us already
+     * exist, we can skip the elevation prompt entirely. Otherwise fall
+     * through to the script: it'll create if missing AND chown the
+     * device node so tap_open() can read/write without EACCES. */
     if (tap_dev_exists(name)) {
-        fprintf(stderr, "tap: '%s' already present, reusing (host IP not re-checked on BSD)\n", name);
-        return 0;
+        char devpath[64];
+        snprintf(devpath, sizeof(devpath), "/dev/%s", name);
+        struct stat st;
+        if (stat(devpath, &st) == 0 && st.st_uid == getuid()) {
+            fprintf(stderr, "tap: '%s' already present and owned by us, reusing\n", name);
+            return 0;
+        }
+        fprintf(stderr, "tap: '%s' exists but %s isn't owned by us (uid=%u); "
+                        "re-running setup to chown it\n",
+                name, devpath, (unsigned)getuid());
     }
 
     /* CIDR like "10.0.0.1/24" → ifconfig wants "10.0.0.1/24" inet on

--- a/src/tap.c
+++ b/src/tap.c
@@ -364,6 +364,17 @@ static bool tap_dev_exists(const char *name) {
     return found;
 }
 
+static const char *bsd_owner_name(void) {
+    const char *u = getenv("SUDO_USER");
+    if (u && *u) return u;
+    u = getenv("DOAS_USER");
+    if (u && *u) return u;
+    u = getenv("USER");
+    if (u && *u) return u;
+    struct passwd *pw = getpwuid(getuid());
+    return (pw && pw->pw_name) ? pw->pw_name : "nobody";
+}
+
 int tap_auto_create(const char *name, const char *ip_cidr) {
     if (!tap_str_is_safe(name) || !tap_str_is_safe(ip_cidr)) {
         fprintf(stderr, "tap: refusing unsafe device/cidr string\n");
@@ -389,6 +400,8 @@ int tap_auto_create(const char *name, const char *ip_cidr) {
      * name; if the kernel already auto-created the interface from
      * the device node, 'create' is a no-op (FreeBSD/NetBSD warn but
      * succeed; OpenBSD treats it as creating the if). */
+    const char *owner = bsd_owner_name();
+    if (!tap_str_is_safe(owner)) owner = "root";
     char cmd[1024];
     snprintf(cmd, sizeof(cmd),
         "%s sh -c '"
@@ -401,9 +414,13 @@ int tap_auto_create(const char *name, const char *ip_cidr) {
 #endif
         "ifconfig %s create 2>/dev/null || true; "
         "ifconfig %s inet %s up; "
+        /* /dev/tapN is root:wheel mode 0600 by default. Chown to the
+         * invoking user so the unprivileged 1984 process can open it
+         * via tap_open without EACCES. */
+        "chown %s /dev/%s; "
         "sysctl -w net.inet.ip.forwarding=1 >/dev/null"
         "' 2>&1",
-        elev, name, name, ip_cidr);
+        elev, name, name, ip_cidr, owner, name);
 
     fprintf(stderr, "tap: auto-creating '%s' (%s) via %s — "
                     "you may be prompted for your password\n",
@@ -418,6 +435,8 @@ int tap_auto_create(const char *name, const char *ip_cidr) {
 #endif
                         "  %s ifconfig %s create\n"
                         "  %s ifconfig %s inet %s up\n"
+                        "  %s chown %s /dev/%s          "
+                        "# so 1984 can open the device node\n"
                         "  %s sysctl -w net.inet.ip.forwarding=1\n"
                         "(NAT to host network requires pf/ipfw/npf rules — "
                         "see NET4CPC.md)\n",
@@ -425,7 +444,9 @@ int tap_auto_create(const char *name, const char *ip_cidr) {
 #if defined(__NetBSD__)
                 elev,
 #endif
-                elev, name, elev, name, ip_cidr, elev);
+                elev, name, elev, name, ip_cidr,
+                elev, owner, name,
+                elev);
         return -1;
     }
     fprintf(stderr, "tap: '%s' ready — %s\n"

--- a/src/tap.h
+++ b/src/tap.h
@@ -19,17 +19,24 @@
 #include <stddef.h>
 
 /* Compile-time gate for the L2 TAP backend + one-click auto-setup.
- *   Linux:    full support (existing).
- *   BSDs:     planned (#114); the per-OS device + ioctls land there.
+ *   Linux:    /dev/net/tun via TUNSETIFF; pkexec for elevation.
+ *   FreeBSD:  /dev/tap cloning device; ifconfig for setup;
+ *             doas → sudo probe for elevation.
+ *   NetBSD:   /dev/tap cloning device; same setup shape as FreeBSD.
+ *   OpenBSD:  /dev/tapN direct (no cloning); ifconfig + pfctl;
+ *             doas → sudo probe.
  *   macOS:    no native L2 TAP and no built-in privilege elevation;
- *             the host-socket fallback is the only realistic path.
+ *             host-socket fallback is the only realistic path.
  *   Windows:  requires the third-party OpenVPN TAP-Windows6 driver
  *             which is a separate install with no scriptable setup.
  *
  * When TAP_SUPPORTED is 0 the overlay hides the Net4CPC TAP row and
  * net4cpc_tap_sync() short-circuits, so unsupported builds never try
  * to call tap_open / tap_auto_create. */
-#if defined(__linux__)
+#if defined(__linux__) \
+ || defined(__FreeBSD__) \
+ || defined(__NetBSD__) \
+ || defined(__OpenBSD__)
 #  define TAP_SUPPORTED 1
 #else
 #  define TAP_SUPPORTED 0


### PR DESCRIPTION
## Summary

Adds native `if_tap` support for FreeBSD, NetBSD, and OpenBSD so the Net4CPC TAP backend works on all three with the same UX as Linux: enable in the overlay, one password prompt, CPC reachable on a host-local subnet.

Closes #114.

## What works (user-confirmed on NetBSD + OpenBSD)

- `make clean && make` builds without warnings on both BSDs.
- F9 → Extensions → Net4CPC + Net4CPC TAP triggers `doas`/`sudo` auto-setup; one password prompt creates `tap0`, assigns the host IP, enables forwarding, and chowns the device node.
- Subsequent launches reuse the existing `tap0` silently (no prompt).
- CPC's W5100S talks Ethernet to the host through `/dev/tap0` exactly as on Linux; DHCP lease + ping host ↔ CPC work.

## Implementation

- **`src/tap.h`** — extends `TAP_SUPPORTED` to cover `__FreeBSD__ || __NetBSD__ || __OpenBSD__`.
- **`src/tap.c`** — new `#elif` block for the BSDs:
  - **`tap_open`**: cloning `/dev/tap` on FreeBSD/NetBSD with `TAPGIFNAME` to recover the dynamically-assigned name (plus `fstat` minor-number fallback); explicit `/dev/tapN` walk on OpenBSD.
  - **`tap_read`/`tap_write`**: raw Ethernet, no Linux `IFF_NO_PI` quirk.
  - **`bsd_elevator()`**: runtime probe `doas → sudo → fail`.
  - **`tap_auto_create`**:
    - NetBSD: `modload if_tap` first (idempotent — module is loadable, not built-in by default).
    - `ifconfig <iface> create / inet <cidr> up`.
    - `chown <user> /dev/<iface>` so the unprivileged 1984 process can `open()` the device after the script returns.
    - `sysctl -w net.inet.ip.forwarding=1`.
  - Smart short-circuit: if interface exists *and* `st.st_uid == getuid()`, skip the elevation prompt entirely. Otherwise re-run setup (fixes the case where a previous launch left a root-owned device node).
  - `tap_dev_exists`: `getifaddrs()` walk.
- **`src/main.c`** — auto-name is `cpc-tap0` on Linux, `tap0` on BSDs (BSD `if_tap` only accepts `tap<digits>` for cloning).

## What's intentionally deferred

- **NAT auto-setup**. Each BSD ships a different packet filter (pf, ipfw, npf). One-click NAT across all three was too much surface for a single PR. Host-↔-CPC connectivity works without it. The new "BSD NAT setup (manual)" section in `NET4CPC.md` documents copy-pasteable pf, ipfw, and npf snippets.

## Iteration log (rough sequence we hit testing)

1. `modload: Device not configured tap` → NetBSD needs `modload if_tap` first.
2. `clone_command: Invalid argument` → BSD tap driver only accepts `tap<N>` names, not `cpc-tap0`.
3. `Permission denied` on `/dev/tap0` → need `chown` after create.
4. chown didn't run on already-existing tap → re-run setup when device exists but isn't owned by us.

## Test plan

- [x] Compile-clean on NetBSD + OpenBSD (user-tested).
- [x] First-launch flow on a fresh boot: one password prompt, tap created, owned by user.
- [x] Second-launch flow: silent, no prompt, reuses existing tap.
- [ ] FreeBSD compile (untested but should be a no-op given the shared `#elif` branch).
- [x] Linux build still warning-free, no behavioural change on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
