### PR TITLE
overlay: ROM-slot Del clears board tags (follow-up to #103)

### DIFF
--- a/src/overlay.c
+++ b/src/overlay.c
@@ -1187,6 +1187,20 @@ bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
                     config_default_amsdos(
                         ov->cfg->rom_amsdos, sizeof(ov->cfg->rom_amsdos));
                 }
+                /* Removing the ROM also removes its board membership and
+                 * the per-board template entries that pointed at it —
+                 * otherwise the next enable of any tagged board would
+                 * silently restore the now-deleted path on cold boot,
+                 * and the [board:NAME] sections would still reference
+                 * the dropped slot in the saved conf. */
+                if (ov->cfg->rom_ext_boards[slot][0]) {
+                    for (int b = 0; b < CONFIG_BOARDS_COUNT; b++) {
+                        char (*tbl)[CONFIG_PATH_MAX] =
+                            config_board_slots(ov->cfg, CONFIG_BOARDS[b]);
+                        if (tbl) tbl[slot][0] = '\0';
+                    }
+                    ov->cfg->rom_ext_boards[slot][0] = '\0';
+                }
                 ov->needs_cold_boot = true;
                 ov->dirty = true;
             }


### PR DESCRIPTION
## Summary

Fixes a follow-up bug to #103: pressing `Del` on a tagged ROM slot left the board membership (`cfg.rom_ext_boards[slot]`) and the per-board template entries (`board_m4_slot[slot]` / `board_albireo_slot[slot]` / `board_cyboard_slot[slot]`) intact. Two visible consequences:

1. The next launch's `config_apply_boards()` happily restored the deleted ROM path from the still-populated `[board:NAME]` template — the ROM came back from the dead on cold boot.
2. The boards column in the ROM Slots overlay kept showing the stale CSV tag against an empty slot.

## Fix

The `Del` handler now wipes both `rom_ext_boards[slot]` and every `board_*_slot[slot]` entry that referenced the slot, mirroring what `Ins` does for the opposite direction.

## Test plan

- [x] Tag a slot (e.g. HDCPM at slot 1 → `cyboard`), save, restart → ROM is restored as expected (#103 baseline still works).
- [x] Del a tagged slot → ROM and tag both clear in the UI.
- [x] Esc → Save → quit → relaunch → slot stays empty; `[board:cyboard]` in `1984.conf` no longer lists the slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
