### PR TITLE
Video capture: GIF (F6) + WebM/VP9 (overlay, via ffmpeg)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ bin_PROGRAMS = 1984
 	src/ide.c \
 	src/fat.c \
 	src/ch376.c \
+	src/gifcap.c \
 	src/leds.c \
 	src/m4.c \
 	src/symbnet.c \
@@ -43,6 +44,7 @@ noinst_HEADERS = \
 	src/fat.h \
 	src/fdc.h \
 	src/gate_array.h \
+	src/gifcap.h \
 	src/ide.h \
 	src/joy.h \
 	src/kbd.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,6 +24,7 @@ bin_PROGRAMS = 1984
 	src/fat.c \
 	src/ch376.c \
 	src/gifcap.c \
+	src/webmcap.c \
 	src/leds.c \
 	src/m4.c \
 	src/symbnet.c \
@@ -45,6 +46,7 @@ noinst_HEADERS = \
 	src/fdc.h \
 	src/gate_array.h \
 	src/gifcap.h \
+	src/webmcap.h \
 	src/ide.h \
 	src/joy.h \
 	src/kbd.h \

--- a/configure.ac
+++ b/configure.ac
@@ -54,5 +54,17 @@ esac
 AC_SUBST([WIN_LIBS])
 AC_SUBST([WIN_SUBSYSTEM])
 
+# ffmpeg — optional. Enables WebM/VP9 video capture from the overlay's
+# "Capture video" menu. The F6-triggered .gif capture works without it.
+# Detected at configure time so the overlay can gate the menu row; the
+# path is hardcoded into the binary as FFMPEG_PATH for popen().
+AC_PATH_PROG([FFMPEG], [ffmpeg], [])
+AS_IF([test -n "$FFMPEG"],
+      [AC_DEFINE_UNQUOTED([FFMPEG_PATH], ["$FFMPEG"],
+           [Path to ffmpeg binary for WebM video capture])
+       AC_DEFINE([HAVE_FFMPEG], [1], [ffmpeg available for WebM capture])
+       AC_MSG_NOTICE([video capture: WebM enabled via $FFMPEG])],
+      [AC_MSG_NOTICE([video capture: WebM disabled (no ffmpeg found)])])
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/src/cpc.h
+++ b/src/cpc.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <stdbool.h>
 #include <stdlib.h>     /* dbg_getenv() wraps getenv() */
 #include "types.h"
 #include "z80.h"
@@ -92,6 +93,13 @@ extern int g_debug_enabled;
 static inline const char *dbg_getenv(const char *name) {
     return g_debug_enabled ? getenv(name) : NULL;
 }
+
+/* Video capture (GIF89a) — owned by main.c. Returns true if recording
+ * is active, regardless of how the call resolved. */
+bool videocap_start(const char *path);   /* false on open failure */
+void videocap_stop(void);
+bool videocap_active(void);
+int  videocap_frame_count(void);
 
 int  cpc_init(CPC *cpc, CpcModel model, const char *rom_os, const char *rom_basic);
 void cpc_reset(CPC *cpc);

--- a/src/gifcap.c
+++ b/src/gifcap.c
@@ -9,11 +9,14 @@
 
 struct GifCap {
     FILE   *fp;
-    int     w, h;
+    int     in_w, in_h;      /* input framebuffer size */
+    int     w, h;            /* output (GIF) size, nearest-neighbour scaled */
     int     delay_cs;
     int     frames;
-    /* Per-frame scratch — sized for the framebuffer. */
-    uint8_t *indices;       /* w*h palette indices */
+    /* Per-frame scratch — sized for the OUTPUT frame. */
+    uint8_t *indices;        /* w*h palette indices */
+    int     *row_src;        /* h entries: source row index for each out row */
+    int     *col_src;        /* w entries: source col index for each out col */
     uint32_t palette[256];
     int      palette_size;
 };
@@ -41,18 +44,22 @@ static int pal_find_or_insert(uint32_t *pal, int *pal_size,
     }
 }
 
-/* Build per-frame palette + index buffer. Returns true if losslessly
- * mappable in ≤256 colours; false → caller must fall back. */
+/* Build per-frame palette + index buffer (with nearest-neighbour
+ * scaling baked in). Returns true if losslessly mappable in ≤256
+ * colours; false → caller must fall back. */
 static bool build_palette(GifCap *g, const uint32_t *pixels) {
     int16_t htab[PAL_HASH_N];
     for (int i = 0; i < PAL_HASH_N; i++) htab[i] = -1;
     g->palette_size = 0;
-    int n = g->w * g->h;
-    for (int i = 0; i < n; i++) {
-        uint32_t rgb = pixels[i] & 0x00FFFFFFu;
-        int idx = pal_find_or_insert(g->palette, &g->palette_size, htab, rgb);
-        if (idx < 0) return false;
-        g->indices[i] = (uint8_t)idx;
+    for (int y = 0; y < g->h; y++) {
+        const uint32_t *src_row = pixels + g->row_src[y] * g->in_w;
+        uint8_t *dst_row = g->indices + y * g->w;
+        for (int x = 0; x < g->w; x++) {
+            uint32_t rgb = src_row[g->col_src[x]] & 0x00FFFFFFu;
+            int idx = pal_find_or_insert(g->palette, &g->palette_size, htab, rgb);
+            if (idx < 0) return false;
+            dst_row[x] = (uint8_t)idx;
+        }
     }
     return true;
 }
@@ -69,14 +76,16 @@ static void build_palette_rgb332(GifCap *g, const uint32_t *pixels) {
         int b = (b2 * 255) / 3;
         g->palette[i] = ((uint32_t)r << 16) | ((uint32_t)gg << 8) | (uint32_t)b;
     }
-    int n = g->w * g->h;
-    for (int i = 0; i < n; i++) {
-        uint32_t rgb = pixels[i];
-        int r = (rgb >> 16) & 0xFF;
-        int gg = (rgb >> 8) & 0xFF;
-        int b = (rgb     ) & 0xFF;
-        int idx = ((r >> 5) << 5) | ((gg >> 5) << 2) | (b >> 6);
-        g->indices[i] = (uint8_t)idx;
+    for (int y = 0; y < g->h; y++) {
+        const uint32_t *src_row = pixels + g->row_src[y] * g->in_w;
+        uint8_t *dst_row = g->indices + y * g->w;
+        for (int x = 0; x < g->w; x++) {
+            uint32_t rgb = src_row[g->col_src[x]];
+            int r = (rgb >> 16) & 0xFF;
+            int gg = (rgb >> 8) & 0xFF;
+            int b = (rgb     ) & 0xFF;
+            dst_row[x] = (uint8_t)(((r >> 5) << 5) | ((gg >> 5) << 2) | (b >> 6));
+        }
     }
 }
 
@@ -239,19 +248,39 @@ static void write_frame(GifCap *g) {
 
 /* ---------- public ---------- */
 
-GifCap *gifcap_open(const char *path, int width, int height, int frame_delay_cs) {
-    if (!path || width <= 0 || height <= 0 ||
-        width > GIFCAP_MAX_W || height > GIFCAP_MAX_H) return NULL;
+GifCap *gifcap_open(const char *path,
+                    int in_w, int in_h, int out_w, int out_h,
+                    int frame_delay_cs) {
+    if (!path || in_w <= 0 || in_h <= 0 || out_w <= 0 || out_h <= 0 ||
+        out_w > GIFCAP_MAX_W || out_h > GIFCAP_MAX_H) return NULL;
     if (frame_delay_cs < 1) frame_delay_cs = 1;
     GifCap *g = calloc(1, sizeof(*g));
     if (!g) return NULL;
     g->fp = fopen(path, "wb");
     if (!g->fp) { free(g); return NULL; }
-    g->w = width;
-    g->h = height;
+    g->in_w = in_w;
+    g->in_h = in_h;
+    g->w = out_w;
+    g->h = out_h;
     g->delay_cs = frame_delay_cs;
-    g->indices = malloc((size_t)width * (size_t)height);
-    if (!g->indices) { fclose(g->fp); free(g); return NULL; }
+    g->indices = malloc((size_t)out_w * (size_t)out_h);
+    g->row_src = malloc(sizeof(int) * out_h);
+    g->col_src = malloc(sizeof(int) * out_w);
+    if (!g->indices || !g->row_src || !g->col_src) {
+        free(g->indices); free(g->row_src); free(g->col_src);
+        fclose(g->fp); free(g); return NULL;
+    }
+    /* Precompute nearest-neighbour source coordinates. */
+    for (int y = 0; y < out_h; y++) {
+        int s = (y * in_h) / out_h;
+        if (s >= in_h) s = in_h - 1;
+        g->row_src[y] = s;
+    }
+    for (int x = 0; x < out_w; x++) {
+        int s = (x * in_w) / out_w;
+        if (s >= in_w) s = in_w - 1;
+        g->col_src[x] = s;
+    }
     write_header(g);
     return g;
 }
@@ -272,6 +301,8 @@ void gifcap_close(GifCap *g) {
         fclose(g->fp);
     }
     free(g->indices);
+    free(g->row_src);
+    free(g->col_src);
     free(g);
 }
 

--- a/src/gifcap.c
+++ b/src/gifcap.c
@@ -1,0 +1,278 @@
+/* gifcap.c — minimal GIF89a writer with in-tree LZW. See gifcap.h. */
+#include "gifcap.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define GIFCAP_MAX_W   2048
+#define GIFCAP_MAX_H   2048
+
+struct GifCap {
+    FILE   *fp;
+    int     w, h;
+    int     delay_cs;
+    int     frames;
+    /* Per-frame scratch — sized for the framebuffer. */
+    uint8_t *indices;       /* w*h palette indices */
+    uint32_t palette[256];
+    int      palette_size;
+};
+
+/* ---------- palette ---------- */
+
+/* Hashtable mapping 0x00RRGGBB → palette index. Open addressing, ~1024
+ * slots is plenty for ≤256 unique colours. */
+#define PAL_HASH_N  1024
+static int pal_find_or_insert(uint32_t *pal, int *pal_size,
+                              int16_t *htab, uint32_t rgb) {
+    uint32_t key = rgb | 0x01000000u;   /* never 0 — use 0 as empty */
+    uint32_t h = (rgb * 0x9E3779B1u) >> 22;   /* fold to 10 bits */
+    for (;;) {
+        int16_t slot = htab[h];
+        if (slot == -1) {
+            if (*pal_size >= 256) return -1;
+            int idx = (*pal_size)++;
+            pal[idx] = rgb & 0x00FFFFFFu;
+            htab[h] = (int16_t)idx;
+            return idx;
+        }
+        if ((pal[slot] | 0x01000000u) == key) return slot;
+        h = (h + 1) & (PAL_HASH_N - 1);
+    }
+}
+
+/* Build per-frame palette + index buffer. Returns true if losslessly
+ * mappable in ≤256 colours; false → caller must fall back. */
+static bool build_palette(GifCap *g, const uint32_t *pixels) {
+    int16_t htab[PAL_HASH_N];
+    for (int i = 0; i < PAL_HASH_N; i++) htab[i] = -1;
+    g->palette_size = 0;
+    int n = g->w * g->h;
+    for (int i = 0; i < n; i++) {
+        uint32_t rgb = pixels[i] & 0x00FFFFFFu;
+        int idx = pal_find_or_insert(g->palette, &g->palette_size, htab, rgb);
+        if (idx < 0) return false;
+        g->indices[i] = (uint8_t)idx;
+    }
+    return true;
+}
+
+/* Fallback: RGB332 uniform quantisation. Always fits in 256 entries. */
+static void build_palette_rgb332(GifCap *g, const uint32_t *pixels) {
+    g->palette_size = 256;
+    for (int i = 0; i < 256; i++) {
+        int r3 = (i >> 5) & 0x7;
+        int g3 = (i >> 2) & 0x7;
+        int b2 = (i     ) & 0x3;
+        int r = (r3 * 255) / 7;
+        int gg = (g3 * 255) / 7;
+        int b = (b2 * 255) / 3;
+        g->palette[i] = ((uint32_t)r << 16) | ((uint32_t)gg << 8) | (uint32_t)b;
+    }
+    int n = g->w * g->h;
+    for (int i = 0; i < n; i++) {
+        uint32_t rgb = pixels[i];
+        int r = (rgb >> 16) & 0xFF;
+        int gg = (rgb >> 8) & 0xFF;
+        int b = (rgb     ) & 0xFF;
+        int idx = ((r >> 5) << 5) | ((gg >> 5) << 2) | (b >> 6);
+        g->indices[i] = (uint8_t)idx;
+    }
+}
+
+/* ---------- LZW encoder + sub-block packer ---------- */
+
+typedef struct {
+    FILE   *fp;
+    uint8_t buf[255];
+    int     buf_len;
+    uint32_t bit_buf;
+    int     bit_cnt;
+} LzwOut;
+
+static void lzw_flush_block(LzwOut *o) {
+    if (o->buf_len == 0) return;
+    uint8_t sz = (uint8_t)o->buf_len;
+    fwrite(&sz, 1, 1, o->fp);
+    fwrite(o->buf, 1, o->buf_len, o->fp);
+    o->buf_len = 0;
+}
+
+static void lzw_emit_code(LzwOut *o, uint32_t code, int code_size) {
+    o->bit_buf |= (code << o->bit_cnt);
+    o->bit_cnt += code_size;
+    while (o->bit_cnt >= 8) {
+        o->buf[o->buf_len++] = (uint8_t)(o->bit_buf & 0xFF);
+        o->bit_buf >>= 8;
+        o->bit_cnt -= 8;
+        if (o->buf_len == 255) lzw_flush_block(o);
+    }
+}
+
+static void lzw_finish(LzwOut *o) {
+    if (o->bit_cnt > 0) {
+        o->buf[o->buf_len++] = (uint8_t)(o->bit_buf & 0xFF);
+        o->bit_buf = 0;
+        o->bit_cnt = 0;
+        if (o->buf_len == 255) lzw_flush_block(o);
+    }
+    lzw_flush_block(o);
+    uint8_t zero = 0;
+    fwrite(&zero, 1, 1, o->fp);   /* end-of-sub-block-stream */
+}
+
+/* Dictionary: chained hash keyed on (prefix << 8) | byte → code.
+ * 5021 is a small prime > 4096 (max LZW table size). */
+#define LZW_HASH_N 5021
+static void lzw_encode(FILE *fp, const uint8_t *data, int n, int min_code_size) {
+    LzwOut o = { .fp = fp };
+    fputc(min_code_size, fp);
+
+    uint32_t hash_key[LZW_HASH_N];
+    int16_t  hash_val[LZW_HASH_N];
+    for (int i = 0; i < LZW_HASH_N; i++) { hash_key[i] = 0xFFFFFFFFu; hash_val[i] = 0; }
+
+    int clear_code = 1 << min_code_size;
+    int end_code   = clear_code + 1;
+    int next_code  = clear_code + 2;
+    int code_size  = min_code_size + 1;
+    int max_code   = (1 << code_size);
+
+    lzw_emit_code(&o, (uint32_t)clear_code, code_size);
+    if (n == 0) { lzw_emit_code(&o, (uint32_t)end_code, code_size); lzw_finish(&o); return; }
+
+    int prefix = data[0];
+    for (int i = 1; i < n; i++) {
+        int k = data[i];
+        uint32_t key = ((uint32_t)prefix << 8) | (uint32_t)k;
+        uint32_t h = (key * 0x9E3779B1u) % LZW_HASH_N;
+        while (hash_key[h] != 0xFFFFFFFFu && hash_key[h] != key) {
+            h++;
+            if (h >= LZW_HASH_N) h = 0;
+        }
+        if (hash_key[h] == key) {
+            prefix = hash_val[h];
+            continue;
+        }
+        lzw_emit_code(&o, (uint32_t)prefix, code_size);
+        if (next_code < 4096) {
+            hash_key[h] = key;
+            hash_val[h] = (int16_t)next_code;
+            next_code++;
+            if (next_code > max_code && code_size < 12) {
+                code_size++;
+                max_code = 1 << code_size;
+            }
+        } else {
+            lzw_emit_code(&o, (uint32_t)clear_code, code_size);
+            for (int j = 0; j < LZW_HASH_N; j++) hash_key[j] = 0xFFFFFFFFu;
+            next_code = clear_code + 2;
+            code_size = min_code_size + 1;
+            max_code  = 1 << code_size;
+        }
+        prefix = k;
+    }
+    lzw_emit_code(&o, (uint32_t)prefix, code_size);
+    lzw_emit_code(&o, (uint32_t)end_code, code_size);
+    lzw_finish(&o);
+}
+
+/* ---------- GIF header / per-frame block ---------- */
+
+static void write_u16(FILE *fp, uint16_t v) { fputc(v & 0xFF, fp); fputc((v >> 8) & 0xFF, fp); }
+
+static void write_header(GifCap *g) {
+    fwrite("GIF89a", 1, 6, g->fp);
+    /* Logical Screen Descriptor */
+    write_u16(g->fp, (uint16_t)g->w);
+    write_u16(g->fp, (uint16_t)g->h);
+    fputc(0x00, g->fp);    /* packed: no global colour table */
+    fputc(0x00, g->fp);    /* background index */
+    fputc(0x00, g->fp);    /* pixel aspect ratio */
+    /* NETSCAPE2.0 application extension — loop forever. */
+    fputc(0x21, g->fp); fputc(0xFF, g->fp); fputc(0x0B, g->fp);
+    fwrite("NETSCAPE2.0", 1, 11, g->fp);
+    fputc(0x03, g->fp); fputc(0x01, g->fp);
+    write_u16(g->fp, 0);   /* 0 = loop forever */
+    fputc(0x00, g->fp);
+}
+
+static int log2_ceil(int n) {
+    int v = 1, k = 0;
+    while (v < n) { v <<= 1; k++; }
+    if (k < 1) k = 1;
+    return k;
+}
+
+static void write_frame(GifCap *g) {
+    int lct_bits = log2_ceil(g->palette_size);
+    if (lct_bits < 2) lct_bits = 2;            /* GIF requires at least 4 entries */
+    int lct_count = 1 << lct_bits;
+
+    /* Graphic Control Extension */
+    fputc(0x21, g->fp); fputc(0xF9, g->fp); fputc(0x04, g->fp);
+    fputc(0x00, g->fp);                         /* no transparency, no disposal */
+    write_u16(g->fp, (uint16_t)g->delay_cs);
+    fputc(0x00, g->fp); fputc(0x00, g->fp);
+
+    /* Image Descriptor */
+    fputc(0x2C, g->fp);
+    write_u16(g->fp, 0); write_u16(g->fp, 0);
+    write_u16(g->fp, (uint16_t)g->w);
+    write_u16(g->fp, (uint16_t)g->h);
+    /* packed: LCT=1, interlace=0, sort=0, reserved=0, size = lct_bits-1 */
+    fputc((uint8_t)(0x80 | (lct_bits - 1)), g->fp);
+
+    /* Local colour table — pad to power-of-two size. */
+    for (int i = 0; i < lct_count; i++) {
+        uint32_t c = (i < g->palette_size) ? g->palette[i] : 0;
+        fputc((c >> 16) & 0xFF, g->fp);
+        fputc((c >> 8)  & 0xFF, g->fp);
+        fputc((c)       & 0xFF, g->fp);
+    }
+
+    /* LZW image data. Min code size must be at least 2. */
+    int min_code_size = lct_bits;
+    if (min_code_size < 2) min_code_size = 2;
+    lzw_encode(g->fp, g->indices, g->w * g->h, min_code_size);
+}
+
+/* ---------- public ---------- */
+
+GifCap *gifcap_open(const char *path, int width, int height, int frame_delay_cs) {
+    if (!path || width <= 0 || height <= 0 ||
+        width > GIFCAP_MAX_W || height > GIFCAP_MAX_H) return NULL;
+    if (frame_delay_cs < 1) frame_delay_cs = 1;
+    GifCap *g = calloc(1, sizeof(*g));
+    if (!g) return NULL;
+    g->fp = fopen(path, "wb");
+    if (!g->fp) { free(g); return NULL; }
+    g->w = width;
+    g->h = height;
+    g->delay_cs = frame_delay_cs;
+    g->indices = malloc((size_t)width * (size_t)height);
+    if (!g->indices) { fclose(g->fp); free(g); return NULL; }
+    write_header(g);
+    return g;
+}
+
+bool gifcap_frame(GifCap *g, const uint32_t *pixels) {
+    if (!g || !pixels) return false;
+    if (!build_palette(g, pixels))
+        build_palette_rgb332(g, pixels);
+    write_frame(g);
+    g->frames++;
+    return true;
+}
+
+void gifcap_close(GifCap *g) {
+    if (!g) return;
+    if (g->fp) {
+        fputc(0x3B, g->fp);    /* trailer */
+        fclose(g->fp);
+    }
+    free(g->indices);
+    free(g);
+}
+
+int gifcap_frame_count(const GifCap *g) { return g ? g->frames : 0; }

--- a/src/gifcap.h
+++ b/src/gifcap.h
@@ -1,0 +1,33 @@
+/* gifcap.h — in-tree GIF89a screen-capture encoder.
+ *
+ * Self-contained: no libgif, no ffmpeg, no codec dependencies. Writes a
+ * GIF89a stream with one local colour table per frame, LZW-compressed,
+ * looping forever (NETSCAPE2.0 extension).
+ *
+ * Designed for the CPC framebuffer: ≤27 simultaneous colours fits
+ * trivially under GIF's 256-colour ceiling, so the per-frame palette is
+ * built losslessly from the unique RGB values in each frame. If the
+ * frame (overlay open, palette-cycling effect, …) ever exceeds 256
+ * unique colours we fall back to RGB332 uniform quantisation.
+ */
+#pragma once
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct GifCap GifCap;
+
+/* Open path for writing. width/height are the framebuffer dimensions.
+ * frame_delay_cs is the inter-frame delay in centiseconds (1/100 s);
+ * use 4 for 25 fps, 2 for 50 fps. Returns NULL on failure. */
+GifCap *gifcap_open(const char *path, int width, int height, int frame_delay_cs);
+
+/* Append one frame. pixels is width*height u32 values in 0x00RRGGBB
+ * (or 0xAARRGGBB — alpha is ignored). Returns true on success. */
+bool gifcap_frame(GifCap *g, const uint32_t *pixels);
+
+/* Finalise the file (writes trailer) and free the encoder. Safe with NULL. */
+void gifcap_close(GifCap *g);
+
+/* Number of frames written so far (for status display). */
+int gifcap_frame_count(const GifCap *g);

--- a/src/gifcap.h
+++ b/src/gifcap.h
@@ -17,12 +17,17 @@
 
 typedef struct GifCap GifCap;
 
-/* Open path for writing. width/height are the framebuffer dimensions.
- * frame_delay_cs is the inter-frame delay in centiseconds (1/100 s);
- * use 4 for 25 fps, 2 for 50 fps. Returns NULL on failure. */
-GifCap *gifcap_open(const char *path, int width, int height, int frame_delay_cs);
+/* Open path for writing. in_w/in_h are the framebuffer dimensions
+ * passed to gifcap_frame(); out_w/out_h are the dimensions written into
+ * the GIF (nearest-neighbour scaled). Pass out_w==in_w and out_h==in_h
+ * for no scaling. frame_delay_cs is the inter-frame delay in
+ * centiseconds (1/100 s); use 4 for 25 fps, 2 for 50 fps. Returns NULL
+ * on failure. */
+GifCap *gifcap_open(const char *path,
+                    int in_w, int in_h, int out_w, int out_h,
+                    int frame_delay_cs);
 
-/* Append one frame. pixels is width*height u32 values in 0x00RRGGBB
+/* Append one frame. pixels is in_w*in_h u32 values in 0x00RRGGBB
  * (or 0xAARRGGBB — alpha is ignored). Returns true on success. */
 bool gifcap_frame(GifCap *g, const uint32_t *pixels);
 

--- a/src/main.c
+++ b/src/main.c
@@ -30,8 +30,15 @@ bool videocap_active(void)        { return g_videocap != NULL; }
 int  videocap_frame_count(void)   { return gifcap_frame_count(g_videocap); }
 bool videocap_start(const char *path) {
     if (g_videocap) return true;
-    /* 4 cs = 25 fps; we decimate input from 50 Hz by writing every other frame */
-    g_videocap = gifcap_open(path, CPC_SCREEN_W, CPC_SCREEN_H, 4);
+    /* 4 cs = 25 fps; decimate input from 50 Hz by writing every other frame.
+     * Output at WINDOW_H to get the correct 4:3 aspect — the CPC's
+     * framebuffer is 768x272 (non-square pixels), but the display
+     * stretches that to 768x576. Nearest-neighbour scaling inside the
+     * encoder keeps pixel art crisp. */
+    g_videocap = gifcap_open(path,
+                             CPC_SCREEN_W, CPC_SCREEN_H,
+                             CPC_SCREEN_W, WINDOW_H,
+                             4);
     if (!g_videocap) {
         fprintf(stderr, "[videocap] failed to open '%s' for writing\n", path);
         return false;

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <libgen.h>
+#include <strings.h>     /* strcasecmp */
 #include "config.h"
 #include "overlay.h"
 #include "cpc.h"
@@ -22,37 +23,69 @@
 #include "compat_win.h"   /* net_compat_init() — WSAStartup on Windows */
 #include "startup_debug.h"   /* SD_INIT()/SD_LOG() — no-ops unless -DSTARTUP_DEBUG */
 #include "gifcap.h"
+#include "webmcap.h"
 
-/* --- Video capture (GIF89a) state. See videocap_* in cpc.h. ---------- */
-static GifCap *g_videocap = NULL;
-static int     g_videocap_skip = 0;   /* toggles 0/1 to halve framerate */
-bool videocap_active(void)        { return g_videocap != NULL; }
-int  videocap_frame_count(void)   { return gifcap_frame_count(g_videocap); }
+/* --- Video capture state. F6 → GIF (lean, no deps); overlay file
+ * picker → WebM via ffmpeg when configure detected it. Dispatch is by
+ * file extension. Output is scaled to 768x576 (4:3) in both paths. */
+static GifCap  *g_videocap_gif  = NULL;
+static WebmCap *g_videocap_webm = NULL;
+static int      g_videocap_skip = 0;   /* GIF-only: halve to 25 fps */
+
+bool videocap_active(void) {
+    return g_videocap_gif != NULL || g_videocap_webm != NULL;
+}
+int videocap_frame_count(void) {
+    if (g_videocap_gif)  return gifcap_frame_count(g_videocap_gif);
+    if (g_videocap_webm) return webmcap_frame_count(g_videocap_webm);
+    return 0;
+}
+
+static bool path_ends_with(const char *p, const char *suffix) {
+    size_t lp = strlen(p), ls = strlen(suffix);
+    if (lp < ls) return false;
+    return strcasecmp(p + lp - ls, suffix) == 0;
+}
+
 bool videocap_start(const char *path) {
-    if (g_videocap) return true;
-    /* 4 cs = 25 fps; decimate input from 50 Hz by writing every other frame.
-     * Output at WINDOW_H to get the correct 4:3 aspect — the CPC's
-     * framebuffer is 768x272 (non-square pixels), but the display
-     * stretches that to 768x576. Nearest-neighbour scaling inside the
-     * encoder keeps pixel art crisp. */
-    g_videocap = gifcap_open(path,
-                             CPC_SCREEN_W, CPC_SCREEN_H,
-                             CPC_SCREEN_W, WINDOW_H,
-                             4);
-    if (!g_videocap) {
-        fprintf(stderr, "[videocap] failed to open '%s' for writing\n", path);
-        return false;
+    if (videocap_active()) return true;
+    if (path_ends_with(path, ".webm")) {
+        g_videocap_webm = webmcap_open(path,
+                                       CPC_SCREEN_W, CPC_SCREEN_H,
+                                       CPC_SCREEN_W, WINDOW_H);
+        if (!g_videocap_webm) {
+            fprintf(stderr, "[videocap] WebM start failed for '%s'\n", path);
+            return false;
+        }
+    } else {
+        /* 4 cs = 25 fps; decimate 50 Hz input by writing every other frame.
+         * Output at WINDOW_H for the correct 4:3 aspect — the CPC
+         * framebuffer is 768x272 non-square pixels, displayed at
+         * 768x576. */
+        g_videocap_gif = gifcap_open(path,
+                                     CPC_SCREEN_W, CPC_SCREEN_H,
+                                     CPC_SCREEN_W, WINDOW_H,
+                                     4);
+        if (!g_videocap_gif) {
+            fprintf(stderr, "[videocap] GIF open failed for '%s'\n", path);
+            return false;
+        }
+        g_videocap_skip = 0;
     }
-    g_videocap_skip = 0;
     fprintf(stderr, "[videocap] recording to %s\n", path);
     return true;
 }
 void videocap_stop(void) {
-    if (!g_videocap) return;
-    int n = gifcap_frame_count(g_videocap);
-    gifcap_close(g_videocap);
-    g_videocap = NULL;
-    fprintf(stderr, "[videocap] stopped (%d frames)\n", n);
+    if (g_videocap_gif) {
+        int n = gifcap_frame_count(g_videocap_gif);
+        gifcap_close(g_videocap_gif);
+        g_videocap_gif = NULL;
+        fprintf(stderr, "[videocap] GIF stopped (%d frames)\n", n);
+    }
+    if (g_videocap_webm) {
+        webmcap_close(g_videocap_webm);
+        g_videocap_webm = NULL;
+    }
 }
 
 /* Synchronise the Net4CPC TAP backend with the current config. Used at
@@ -846,10 +879,15 @@ int main(int argc, char *argv[]) {
             monitor_notify_step(monitor);
         }
         /* Video capture: grab the CPC framebuffer before the overlay
-         * draws on top. Decimate 50 Hz → 25 fps. */
-        if (g_videocap) {
+         * draws on top. GIF decimates to 25 fps; WebM takes every
+         * frame at 50 fps (VP9 compresses interframe deltas well). */
+        if (g_videocap_gif) {
             if ((g_videocap_skip ^= 1) == 0)
-                gifcap_frame(g_videocap, cpc.display.pixels);
+                gifcap_frame(g_videocap_gif, cpc.display.pixels);
+        }
+        if (g_videocap_webm) {
+            if (!webmcap_frame(g_videocap_webm, cpc.display.pixels))
+                videocap_stop();
         }
         overlay_render(&overlay, cpc.display.renderer);
         /* Debug-mode FPS overlay (bottom-left, just above the LED bar).

--- a/src/main.c
+++ b/src/main.c
@@ -21,6 +21,32 @@
 #include "shutter_wav.h"
 #include "compat_win.h"   /* net_compat_init() — WSAStartup on Windows */
 #include "startup_debug.h"   /* SD_INIT()/SD_LOG() — no-ops unless -DSTARTUP_DEBUG */
+#include "gifcap.h"
+
+/* --- Video capture (GIF89a) state. See videocap_* in cpc.h. ---------- */
+static GifCap *g_videocap = NULL;
+static int     g_videocap_skip = 0;   /* toggles 0/1 to halve framerate */
+bool videocap_active(void)        { return g_videocap != NULL; }
+int  videocap_frame_count(void)   { return gifcap_frame_count(g_videocap); }
+bool videocap_start(const char *path) {
+    if (g_videocap) return true;
+    /* 4 cs = 25 fps; we decimate input from 50 Hz by writing every other frame */
+    g_videocap = gifcap_open(path, CPC_SCREEN_W, CPC_SCREEN_H, 4);
+    if (!g_videocap) {
+        fprintf(stderr, "[videocap] failed to open '%s' for writing\n", path);
+        return false;
+    }
+    g_videocap_skip = 0;
+    fprintf(stderr, "[videocap] recording to %s\n", path);
+    return true;
+}
+void videocap_stop(void) {
+    if (!g_videocap) return;
+    int n = gifcap_frame_count(g_videocap);
+    gifcap_close(g_videocap);
+    g_videocap = NULL;
+    fprintf(stderr, "[videocap] stopped (%d frames)\n", n);
+}
 
 /* Synchronise the Net4CPC TAP backend with the current config. Used at
  * boot and after the overlay flips net4cpc / net4cpc_tap. cli_tap_dev
@@ -139,8 +165,8 @@ static void apply_led_enables(const Config *cfg) {
     leds_set_enabled(LED_NET, mx4 && cfg->net4cpc);
 }
 
-#define TITLE_NORMAL_464  "CPC 464  |  F4=screenshot  F5=reset  F8=monitor  F9=options  F11=fullscreen"
-#define TITLE_NORMAL_6128 "CPC 6128  |  F4=screenshot  F5=reset  F8=monitor  F9=options  F11=fullscreen"
+#define TITLE_NORMAL_464  "CPC 464  |  F4=screenshot  F5=reset  F6=record  F8=monitor  F9=options  F11=fullscreen"
+#define TITLE_NORMAL_6128 "CPC 6128  |  F4=screenshot  F5=reset  F6=record  F8=monitor  F9=options  F11=fullscreen"
 #define TITLE_CAPTURED    "Mouse captured  |  Ctrl+Enter to release"
 
 static void set_mouse_capture(SDL_Window *win, bool capture, bool *flag, CpcModel model) {
@@ -188,6 +214,7 @@ static void usage(const char *prog, int code) {
         "Keyboard shortcuts:\n"
         "  F4     Save screenshot (.ppm)\n"
         "  F5     Warm reset\n"
+        "  F6     Toggle video capture (.gif in CWD)\n"
         "  F8     Open/close memory monitor / disassembler\n"
         "  F9     Options overlay\n"
         "  F11    Toggle fullscreen\n"
@@ -653,6 +680,22 @@ int main(int argc, char *argv[]) {
                     }
                 } else if (ev.key.scancode == SDL_SCANCODE_F5) {
                     cpc_reset(&cpc);
+                } else if (ev.key.scancode == SDL_SCANCODE_F6) {
+                    /* Toggle video capture. Auto-name in CWD when starting
+                     * outside the overlay file picker. */
+                    if (videocap_active()) {
+                        videocap_stop();
+                    } else {
+                        char path[256];
+                        time_t t = time(NULL);
+                        struct tm *lt = localtime(&t);
+                        if (lt)
+                            strftime(path, sizeof(path),
+                                     "1984-%Y%m%d-%H%M%S.gif", lt);
+                        else
+                            snprintf(path, sizeof(path), "1984-capture.gif");
+                        videocap_start(path);
+                    }
                 } else if (ev.key.scancode == SDL_SCANCODE_V &&
                            (SDL_GetModState() & SDL_KMOD_CTRL)) {
                     /* Release Ctrl from the CPC matrix before injecting text;
@@ -795,6 +838,12 @@ int main(int argc, char *argv[]) {
         } else if (was_stepping && cpc.paused) {
             monitor_notify_step(monitor);
         }
+        /* Video capture: grab the CPC framebuffer before the overlay
+         * draws on top. Decimate 50 Hz → 25 fps. */
+        if (g_videocap) {
+            if ((g_videocap_skip ^= 1) == 0)
+                gifcap_frame(g_videocap, cpc.display.pixels);
+        }
         overlay_render(&overlay, cpc.display.renderer);
         /* Debug-mode FPS overlay (bottom-left, just above the LED bar).
          * Doubles as a visual marker that debug machinery is live. */
@@ -916,6 +965,7 @@ int main(int argc, char *argv[]) {
     monitor_destroy(monitor);
     if (sfx_stream) SDL_DestroyAudioStream(sfx_stream);
     if (sfx_buf)    SDL_free(sfx_buf);
+    videocap_stop();   /* finalise GIF if recording */
     cpc_destroy(&cpc);
     SDL_Quit();
     return 0;

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -5,6 +5,7 @@
 #include "disk.h"
 #include "mem.h"
 #include "snapshot.h"
+#include "webmcap.h"   /* WEBMCAP_SUPPORTED */
 #include <string.h>
 #include <stdio.h>
 #include <libgen.h>
@@ -354,11 +355,14 @@ static void item_text(const Overlay *ov, int row,
             break;
         case 7:
             snprintf(lbl, lsz, "Capture video");
-            if (videocap_active())
+            if (!WEBMCAP_SUPPORTED) {
+                snprintf(val, vsz, "[needs ffmpeg — F6 still records .gif]");
+            } else if (videocap_active()) {
                 snprintf(val, vsz, "recording (%d frames) — Enter to stop",
                          videocap_frame_count());
-            else
-                snprintf(val, vsz, "[Enter to pick .gif]");
+            } else {
+                snprintf(val, vsz, "[Enter to pick .webm]");
+            }
             *readonly = true;
             break;
         }
@@ -800,18 +804,19 @@ static void activate_item(Overlay *ov) {
              * site, so the change takes effect on the next instruction. */
             break;
         case 7:
+            if (!WEBMCAP_SUPPORTED) break;
             if (videocap_active()) {
                 videocap_stop();
             } else {
                 ov->dialog_kind  = DIALOG_VIDEO_CAPTURE;
                 ov->dialog_ready = false;
-                static const SDL_DialogFileFilter gif_filters[] = {
-                    { "GIF animation", "gif;GIF" },
-                    { "All files",     "*"       },
+                static const SDL_DialogFileFilter webm_filters[] = {
+                    { "WebM (VP9)", "webm;WEBM" },
+                    { "All files",  "*"         },
                 };
                 SDL_ShowSaveFileDialog(overlay_file_callback, ov,
                     ov->cpc ? ov->cpc->display.window : NULL,
-                    gif_filters, 2, NULL);
+                    webm_filters, 2, NULL);
             }
             break;
         }
@@ -952,7 +957,7 @@ void overlay_tick(Overlay *ov) {
             char *dot = strrchr(path, '.');
             char *slash = strrchr(path, '/');
             if (!dot || (slash && dot < slash))
-                strncat(path, ".gif", sizeof(path) - strlen(path) - 1);
+                strncat(path, ".webm", sizeof(path) - strlen(path) - 1);
             videocap_start(path);
         }
     } else if (ov->dialog_kind == DIALOG_M4_IMAGE) {

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -33,7 +33,7 @@ static const int sec_x[OV_SEC_COUNT] = { 8, 80, 160, 248 };
  * "External Tape" toggle, only meaningful on the 6128 since the 464 has
  * the cassette deck built in). Other sections are fixed.
  * The Advanced tab (OV_TINKER) is hidden unless cfg->tinker is enabled. */
-static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 11, 7 };
+static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 11, 8 };
 
 static int ov_section_rows(const Overlay *ov, OvSection s) {
     if (s == OV_GENERAL && ov->cfg->model == MODEL_6128) return 8;
@@ -351,6 +351,15 @@ static void item_text(const Overlay *ov, int row,
             snprintf(lbl, lsz, "Debugging");
             snprintf(val, vsz, "%s",
                      ov->cfg->debug ? "enabled" : "disabled");
+            break;
+        case 7:
+            snprintf(lbl, lsz, "Capture video");
+            if (videocap_active())
+                snprintf(val, vsz, "recording (%d frames) — Enter to stop",
+                         videocap_frame_count());
+            else
+                snprintf(val, vsz, "[Enter to pick .gif]");
+            *readonly = true;
             break;
         }
         break;
@@ -790,6 +799,21 @@ static void activate_item(Overlay *ov) {
             /* No cold boot needed — debug machinery is checked at every
              * site, so the change takes effect on the next instruction. */
             break;
+        case 7:
+            if (videocap_active()) {
+                videocap_stop();
+            } else {
+                ov->dialog_kind  = DIALOG_VIDEO_CAPTURE;
+                ov->dialog_ready = false;
+                static const SDL_DialogFileFilter gif_filters[] = {
+                    { "GIF animation", "gif;GIF" },
+                    { "All files",     "*"       },
+                };
+                SDL_ShowSaveFileDialog(overlay_file_callback, ov,
+                    ov->cpc ? ov->cpc->display.window : NULL,
+                    gif_filters, 2, NULL);
+            }
+            break;
         }
         break;
 
@@ -920,6 +944,16 @@ void overlay_tick(Overlay *ov) {
             if (!dot || (slash && dot < slash))
                 strncat(path, ".sna", sizeof(path) - strlen(path) - 1);
             snapshot_save(ov->cpc, path);
+        }
+    } else if (ov->dialog_kind == DIALOG_VIDEO_CAPTURE) {
+        if (ov->dialog_path[0]) {
+            char path[512];
+            snprintf(path, sizeof(path), "%s", ov->dialog_path);
+            char *dot = strrchr(path, '.');
+            char *slash = strrchr(path, '/');
+            if (!dot || (slash && dot < slash))
+                strncat(path, ".gif", sizeof(path) - strlen(path) - 1);
+            videocap_start(path);
         }
     } else if (ov->dialog_kind == DIALOG_M4_IMAGE) {
         /* User picked an SD card image — enable M4, load its ROM, and seed

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -28,7 +28,8 @@ typedef enum {
     DIALOG_BASIC_ROM = 7,
     DIALOG_TAPE      = 8,
     DIALOG_SNAPSHOT_LOAD = 9,
-    DIALOG_SNAPSHOT_SAVE = 10
+    DIALOG_SNAPSHOT_SAVE = 10,
+    DIALOG_VIDEO_CAPTURE = 11
 } DialogKind;
 
 typedef struct {

--- a/src/webmcap.c
+++ b/src/webmcap.c
@@ -1,0 +1,108 @@
+/* webmcap.c — WebM/VP9 capture via ffmpeg subprocess.
+ *
+ * popen() is POSIX-only; on Windows _popen exists with the same shape.
+ * SDL3 supports Windows but the emulator's primary platforms are
+ * Linux/BSD/macOS where popen works as expected. We do not handle
+ * SIGPIPE specially: ffmpeg only closes its stdin when we ask it to
+ * (via pclose), so a broken pipe here means ffmpeg itself crashed —
+ * we treat that as end-of-recording.
+ */
+#define _POSIX_C_SOURCE 200809L
+#include "webmcap.h"
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#  include <io.h>
+#  define popen  _popen
+#  define pclose _pclose
+#endif
+
+struct WebmCap {
+    FILE *fp;
+    int   in_w, in_h;
+    int   frames;
+    bool  broken;
+};
+
+WebmCap *webmcap_open(const char *path,
+                      int in_w, int in_h,
+                      int out_w, int out_h) {
+#ifndef HAVE_FFMPEG
+    (void)path; (void)in_w; (void)in_h; (void)out_w; (void)out_h;
+    fprintf(stderr, "[webmcap] not compiled with ffmpeg support\n");
+    return NULL;
+#else
+    if (!path || in_w <= 0 || in_h <= 0 || out_w <= 0 || out_h <= 0)
+        return NULL;
+
+    /* Ensure SIGPIPE doesn't kill us if ffmpeg dies mid-recording. */
+    signal(SIGPIPE, SIG_IGN);
+
+    /* ffmpeg invocation:
+     *  -y                  overwrite output
+     *  -f rawvideo         input is raw pixels (no container)
+     *  -pixel_format bgra  SDL ARGB8888 == BGRA in little-endian byte order
+     *  -video_size WxH     input dimensions
+     *  -framerate 50       CPC native vsync
+     *  -i -                stdin
+     *  -vf scale=W:H:flags=neighbor   nearest-neighbour upscale (keep pixel art)
+     *  -c:v libvpx-vp9     open, royalty-free, YouTube-native
+     *  -b:v 2M             ~2 Mbit/s is plenty for 768x576 cartoon-flat content
+     *  -row-mt 1           multithread the row encoder
+     *  -loglevel error     keep our stderr clean
+     */
+    char cmd[1024];
+    snprintf(cmd, sizeof(cmd),
+        "%s -y -loglevel error "
+        "-f rawvideo -pixel_format bgra -video_size %dx%d -framerate 50 -i - "
+        "-vf scale=%d:%d:flags=neighbor,format=yuv420p "
+        "-c:v libvpx-vp9 -b:v 2M -row-mt 1 -deadline good -cpu-used 4 "
+        "\"%s\"",
+        FFMPEG_PATH, in_w, in_h, out_w, out_h, path);
+
+    FILE *fp = popen(cmd, "w");
+    if (!fp) {
+        fprintf(stderr, "[webmcap] popen('%s'): failed\n", FFMPEG_PATH);
+        return NULL;
+    }
+    WebmCap *w = calloc(1, sizeof(*w));
+    if (!w) { pclose(fp); return NULL; }
+    w->fp   = fp;
+    w->in_w = in_w;
+    w->in_h = in_h;
+    fprintf(stderr, "[webmcap] recording %dx%d -> %dx%d VP9 -> %s\n",
+            in_w, in_h, out_w, out_h, path);
+    return w;
+#endif
+}
+
+bool webmcap_frame(WebmCap *w, const uint32_t *pixels) {
+    if (!w || !w->fp || !pixels || w->broken) return false;
+    size_t n = (size_t)w->in_w * (size_t)w->in_h;
+    size_t wr = fwrite(pixels, 4, n, w->fp);
+    if (wr != n) {
+        fprintf(stderr, "[webmcap] short write (%zu/%zu) — ffmpeg gone?\n",
+                wr, n);
+        w->broken = true;
+        return false;
+    }
+    w->frames++;
+    return true;
+}
+
+void webmcap_close(WebmCap *w) {
+    if (!w) return;
+    int n = w->frames;
+    if (w->fp) {
+        fflush(w->fp);
+        int rc = pclose(w->fp);
+        fprintf(stderr, "[webmcap] finished — %d frames, ffmpeg exit=%d\n",
+                n, rc);
+    }
+    free(w);
+}
+
+int webmcap_frame_count(const WebmCap *w) { return w ? w->frames : 0; }

--- a/src/webmcap.h
+++ b/src/webmcap.h
@@ -1,0 +1,42 @@
+/* webmcap.h — WebM (VP9) screen capture via ffmpeg subprocess pipe.
+ *
+ * We do not link any codec library. Raw BGRA frames are written to
+ * ffmpeg's stdin; ffmpeg scales (768x272 → 768x576), encodes VP9 at a
+ * modest bitrate, and muxes into Matroska/WebM. The user only needs
+ * the ffmpeg binary at runtime — detected by ./configure and baked in
+ * as FFMPEG_PATH.
+ *
+ * On builds where ffmpeg was not present at configure time, HAVE_FFMPEG
+ * is undefined and the overlay hides this option. The compiled code in
+ * webmcap.c still builds (it just refuses to start the process so users
+ * who install ffmpeg later can rebuild without source changes).
+ */
+#pragma once
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct WebmCap WebmCap;
+
+/* Spawn ffmpeg piping VP9-encoded WebM to `path`. Frames passed to
+ * webmcap_frame() are assumed to be in_w*in_h BGRA32, encoded at 50 fps
+ * and scaled to out_w*out_h before encoding. Returns NULL on failure
+ * (no ffmpeg at runtime, popen failure, …). */
+WebmCap *webmcap_open(const char *path,
+                      int in_w, int in_h,
+                      int out_w, int out_h);
+
+/* Submit one BGRA frame. Returns true on success; false ends the
+ * recording (caller should stop). */
+bool webmcap_frame(WebmCap *w, const uint32_t *pixels);
+
+/* Close the pipe and wait for ffmpeg to finish writing the file. */
+void webmcap_close(WebmCap *w);
+
+int  webmcap_frame_count(const WebmCap *w);
+
+/* Compile-time gate matching the AC_PATH_PROG result. */
+#ifdef HAVE_FFMPEG
+#  define WEBMCAP_SUPPORTED 1
+#else
+#  define WEBMCAP_SUPPORTED 0
+#endif


### PR DESCRIPTION
## Summary

- Adds **F6 hotkey** for quick GIF screen capture — in-tree GIF89a + LZW encoder, zero codec dependencies, output 768x576 (4:3, nearest-neighbour scaled from the 768x272 framebuffer).
- Adds **Overlay → Advanced → Capture video** for WebM/VP9 recordings via an `ffmpeg` subprocess pipe — royalty-free, YouTube-native, 50 fps at 2 Mbit/s.
- `./configure` detects ffmpeg (`AC_PATH_PROG`); when absent the overlay row reads `[needs ffmpeg — F6 still records .gif]`. F6 keeps working either way.

Closes #118.

## Test plan
- [x] In-tree GIF encoder: standalone unit test produces a valid GIF89a (ImageMagick parses every frame; distinct frame content verified).
- [x] WebM pipe: 100-frame smoke test → valid Matroska/WebM, VP9 stream, 50 fps, ffmpeg exit 0.
- [x] Interactive: user confirmed both paths work (.gif via F6 and .webm via overlay).
- [ ] CI: Linux + Windows builds pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)