### PR TITLE
net4cpc: implement IPRAW socket mode for ICMP / PING.COM (#125)

### DIFF
--- a/src/n4c_stack.c
+++ b/src/n4c_stack.c
@@ -27,12 +27,14 @@ static u8   s_sipr[4];
 static u8   s_gar [4];
 static u8   s_subr[4];
 
-static N4CUdpDeliver s_udp_deliver = NULL;
-static N4CTcpEvent   s_tcp_state   = NULL;
-static N4CTcpDeliver s_tcp_data    = NULL;
-static N4CTcpAck     s_tcp_ack     = NULL;
+static N4CUdpDeliver   s_udp_deliver    = NULL;
+static N4CRawIpDeliver s_raw_ip_deliver = NULL;
+static N4CTcpEvent     s_tcp_state      = NULL;
+static N4CTcpDeliver   s_tcp_data       = NULL;
+static N4CTcpAck       s_tcp_ack        = NULL;
 
-void n4c_stack_set_udp_deliver(N4CUdpDeliver fn) { s_udp_deliver = fn; }
+void n4c_stack_set_udp_deliver(N4CUdpDeliver fn)   { s_udp_deliver    = fn; }
+void n4c_stack_set_ip_deliver (N4CRawIpDeliver fn) { s_raw_ip_deliver = fn; }
 
 void n4c_stack_set_tcp_callbacks(N4CTcpEvent on_state,
                                  N4CTcpDeliver on_data,
@@ -399,6 +401,14 @@ static void handle_ipv4(const u8 *eth, int len) {
 
     const u8 *payload = ip + ihl;
     int payload_len   = total - ihl;
+
+    /* Raw-IP deliver hook (W5100S IPRAW sockets). Suppresses the
+     * default per-protocol handling for this frame when claimed —
+     * e.g. PING.COM consumes ICMP echo replies through here. */
+    if (s_raw_ip_deliver &&
+        s_raw_ip_deliver(proto, src_ip,
+                         payload, (u16)payload_len))
+        return;
 
     switch (proto) {
     case IP_PROTO_ICMP: handle_icmp(src_ip, payload, payload_len, eth + 6); break;
@@ -1233,5 +1243,42 @@ int n4c_stack_send_udp(u16 src_port,
     TLOG("UDP -> %u.%u.%u.%u:%u from :%u  %u bytes\n",
          dst_ip[0], dst_ip[1], dst_ip[2], dst_ip[3], dst_port,
          src_port, payload_len);
+    return payload_len;
+}
+
+int n4c_stack_send_ip(u8 proto, const u8 dst_ip[4],
+                      const u8 *payload, u16 payload_len) {
+    if (!n4c_stack_active()) return -1;
+
+    u8 dst_mac[6];
+    if (!n4c_stack_arp_resolve(dst_ip, dst_mac))
+        return -1;
+
+    if (payload_len > TAP_FRAME_MAX - 14 - 20) return -1;
+
+    u8 frame[TAP_FRAME_MAX];
+    int ip_total = 20 + payload_len;
+    int eth_len  = 14 + ip_total;
+
+    build_eth(frame, dst_mac, s_mac, ETH_TYPE_IPV4);
+
+    u8 *ip = frame + 14;
+    ip[0] = 0x45;
+    ip[1] = 0;
+    put_u16_be(ip + 2, (u16)ip_total);
+    put_u16_be(ip + 4, 0);
+    put_u16_be(ip + 6, 0x4000);
+    ip[8]  = 64;
+    ip[9]  = proto;
+    put_u16_be(ip + 10, 0);
+    memcpy(ip + 12, s_sipr, 4);
+    memcpy(ip + 16, dst_ip, 4);
+    put_u16_be(ip + 10, ip_checksum(ip, 20));
+
+    memcpy(ip + 20, payload, payload_len);
+
+    if (tap_tx(frame, eth_len) < 0) return -1;
+    TLOG("IP  -> %u.%u.%u.%u proto=%u  %u bytes\n",
+         dst_ip[0], dst_ip[1], dst_ip[2], dst_ip[3], proto, payload_len);
     return payload_len;
 }

--- a/src/n4c_stack.h
+++ b/src/n4c_stack.h
@@ -74,6 +74,23 @@ typedef int (*N4CUdpDeliver)(const u8 src_ip[4], u16 src_port,
                              const u8 *payload, u16 payload_len);
 void n4c_stack_set_udp_deliver(N4CUdpDeliver fn);
 
+/* Send a raw IP datagram (the caller supplies just the L4 payload —
+ * the stack adds the IPv4 header). Used by the W5100S IPRAW socket
+ * mode, which KCNet's PING.COM uses for ICMP echo. Returns payload_len
+ * on success, -1 if ARP is pending. */
+int  n4c_stack_send_ip(u8 proto, const u8 dst_ip[4],
+                       const u8 *payload, u16 payload_len);
+
+/* Hook installed by net4cpc.c: called by the stack for every inbound
+ * IPv4 datagram BEFORE the protocol-specific (ICMP/UDP/TCP) handler
+ * runs. Lets an IPRAW socket claim it. Returning non-zero suppresses
+ * the default per-protocol handling for this frame; 0 means "not for
+ * me, run the default" (echo-request auto-reply, UDP/TCP socket
+ * delivery, etc.). */
+typedef int (*N4CRawIpDeliver)(u8 proto, const u8 src_ip[4],
+                               const u8 *payload, u16 payload_len);
+void n4c_stack_set_ip_deliver(N4CRawIpDeliver fn);
+
 /* Toggle the built-in DHCPv4 server. When off, DHCP traffic flows
  * through to the deliver callback unchanged. main.c flips this on
  * when cfg->net4cpc_tap is set. */

--- a/src/net4cpc.c
+++ b/src/net4cpc.c
@@ -40,6 +40,8 @@ static char tap_dev_name[32] = { 0 };
 static int  stack_deliver_udp(const u8 src_ip[4], u16 src_port,
                               u16 dst_port,
                               const u8 *payload, u16 payload_len);
+static int  stack_deliver_ip (u8 proto, const u8 src_ip[4],
+                              const u8 *payload, u16 payload_len);
 static void stack_sync_config(void);
 static void stack_tcp_state (int s, u8 new_sr);
 static int  stack_tcp_data  (int s, const u8 *data, int len);
@@ -69,8 +71,14 @@ static const u16 BUF_SIZE     = 2048u;
 #define SR_RX_RD  0x28u /* 2 bytes */
 
 /* Socket modes */
-#define SMODE_TCP 0x01u
-#define SMODE_UDP 0x02u
+#define SMODE_TCP   0x01u
+#define SMODE_UDP   0x02u
+#define SMODE_IPRAW 0x03u   /* raw IP — used by KCNet PING.COM for ICMP */
+
+/* IPRAW-specific socket register: Sn_PROTO (the IP protocol number
+ * the chip puts in the IP header of outbound packets and matches on
+ * inbound). Per W5100S datasheet § 4.2.5. */
+#define SR_PROTO 0x14u
 
 /* Socket status */
 #define SSTAT_CLOSED      0x00u
@@ -84,6 +92,7 @@ static const u16 BUF_SIZE     = 2048u;
 #define SSTAT_CLOSE_WAIT  0x1Cu
 #define SSTAT_LAST_ACK    0x1Du
 #define SSTAT_UDP         0x22u
+#define SSTAT_IPRAW       0x32u
 
 /* Socket commands */
 #define SCMD_OPEN    0x01u
@@ -304,6 +313,16 @@ static void handle_command(int s, u8 cmd) {
             rx_wr[s] = 0;
             break;
         }
+        if (mode == SMODE_IPRAW && n4c_stack_active()) {
+            regs[SOCK_BASE[s] + SR_SR] = SSTAT_IPRAW;
+            set16(SOCK_BASE[s] + SR_TX_FSR, BUF_SIZE);
+            set16(SOCK_BASE[s] + SR_TX_WR,  0);
+            set16(SOCK_BASE[s] + SR_TX_RD,  0);
+            set16(SOCK_BASE[s] + SR_RX_RSR, 0);
+            set16(SOCK_BASE[s] + SR_RX_RD,  0);
+            rx_wr[s] = 0;
+            break;
+        }
         sock_fd[s] = socket(AF_INET,
                             mode == SMODE_UDP ? SOCK_DGRAM : SOCK_STREAM, 0);
         if (sock_fd[s] != -1) {
@@ -425,6 +444,15 @@ static void handle_command(int s, u8 cmd) {
                     sendto(sock_fd[s], (const char *)buf, len, 0,
                            (struct sockaddr *)&dst, sizeof(dst));
                 }
+            } else if (mode == SMODE_IPRAW && n4c_stack_active()) {
+                u8 dst_ip[4] = {
+                    regs[SOCK_BASE[s] + SR_DIPR],
+                    regs[SOCK_BASE[s] + SR_DIPR + 1],
+                    regs[SOCK_BASE[s] + SR_DIPR + 2],
+                    regs[SOCK_BASE[s] + SR_DIPR + 3],
+                };
+                u8 proto = regs[SOCK_BASE[s] + SR_PROTO];
+                udp_send_result = n4c_stack_send_ip(proto, dst_ip, buf, len);
             } else if (mode == SMODE_TCP && n4c_stack_active()) {
                 /* TAP-backed TCP. Don't advance TX_RD here — the stack
                  * does that via the ack callback when the peer ACKs. */
@@ -455,7 +483,7 @@ static void handle_command(int s, u8 cmd) {
          * DHCPDECLINE. (For broadcasts arp_resolve() returns the
          * broadcast MAC immediately so SEND_OK is always the right
          * answer there.) */
-        if (mode == SMODE_UDP) {
+        if (mode == SMODE_UDP || mode == SMODE_IPRAW) {
             if (udp_send_result > 0)
                 regs[SOCK_BASE[s] + SR_IR] |= 0x10;   /* SEND_OK */
             else
@@ -536,6 +564,7 @@ static const char *reg_name(u16 addr, int *sock_out) {
             case 0x0C: case 0x0D: case 0x0E: case 0x0F: return "Sn_DIPR";
             case 0x10: case 0x11: return "Sn_DPORT";
             case 0x12: case 0x13: return "Sn_MSSR";
+            case 0x14: return "Sn_PROTO";
             case 0x15: return "Sn_TOS";
             case 0x16: return "Sn_TTL";
             case 0x20: case 0x21: return "Sn_TX_FSR";
@@ -736,6 +765,7 @@ int net4cpc_attach_tap(const char *devname) {
     tap_fd = fd;
     n4c_stack_attach(tap_fd, regs + 0x09, regs + 0x0F, regs + 0x01, regs + 0x05);
     n4c_stack_set_udp_deliver(stack_deliver_udp);
+    n4c_stack_set_ip_deliver (stack_deliver_ip);
     n4c_stack_set_tcp_callbacks(stack_tcp_state,
                                 stack_tcp_data,
                                 stack_tcp_ack);
@@ -813,6 +843,36 @@ static int stack_deliver_udp(const u8 src_ip[4], u16 src_port,
         write_rx_byte(s, src_ip[3]);
         write_rx_byte(s, (u8)(src_port >> 8));
         write_rx_byte(s, (u8)(src_port));
+        write_rx_byte(s, (u8)(payload_len >> 8));
+        write_rx_byte(s, (u8)(payload_len));
+        for (u16 i = 0; i < payload_len; i++)
+            write_rx_byte(s, payload[i]);
+        update_rx_rsr(s);
+        regs[SOCK_BASE[s] + SR_IR] |= 0x04;   /* RECV */
+        return 1;
+    }
+    return 0;
+}
+
+/* IPRAW inbound: find a socket in IPRAW mode whose Sn_PROTO matches
+ * this frame's IP protocol, and push it the W5100S IPRAW frame format
+ * (4 bytes src IP, 2 bytes length, then the L3 payload). */
+static int stack_deliver_ip(u8 proto, const u8 src_ip[4],
+                            const u8 *payload, u16 payload_len) {
+    for (int s = 0; s < 4; s++) {
+        u8 mode = regs[SOCK_BASE[s] + SR_MR] & 0x0F;
+        u8 sr   = regs[SOCK_BASE[s] + SR_SR];
+        if (mode != SMODE_IPRAW || sr != SSTAT_IPRAW) continue;
+        if (regs[SOCK_BASE[s] + SR_PROTO] != proto) continue;
+
+        u16 used  = (u16)(rx_wr[s] - get16(SOCK_BASE[s] + SR_RX_RD));
+        u16 space = (u16)(BUF_SIZE - used);
+        if (space < 6u + payload_len) return 0;
+
+        write_rx_byte(s, src_ip[0]);
+        write_rx_byte(s, src_ip[1]);
+        write_rx_byte(s, src_ip[2]);
+        write_rx_byte(s, src_ip[3]);
         write_rx_byte(s, (u8)(payload_len >> 8));
         write_rx_byte(s, (u8)(payload_len));
         for (u16 i = 0; i < payload_len; i++)


### PR DESCRIPTION
## Summary

- Add the W5100S IPRAW socket mode (Sn_MR=0x03) on top of the existing TAP-backed n4c_stack, so KCNet's PING.COM can send ICMP echo.
- New \`n4c_stack_send_ip()\` builds the IPv4 header itself, ARP-resolves the next hop, and writes to the TAP; SCMD_SEND for IPRAW reads Sn_PROTO + Sn_DIPR and calls it.
- New raw-IP deliver callback gets first refusal on every inbound IPv4 frame; if an IPRAW socket is open with a matching Sn_PROTO, the L3 payload is pushed into the socket's RX buffer with the 6-byte W5100S IPRAW header (4 bytes src IP, 2 bytes length).
- The deliver callback short-circuits when no IPRAW socket is open, so the existing ICMP echo responder, UDP, and TCP paths are untouched.

Closes #125.

## Test plan

- [x] Build clean (Fedora, in distrobox).
- [x] PING.COM in HDCPM/CP/M+ resolves a hostname and prints echo replies via the TAP backend.
- [x] SymbOS networking re-tested: DHCP, DNS, telnet over TCP still work.
- [ ] CI build matrix (Fedora + MinGW) on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)