### PR TITLE
1984: --kbd-pty bidirectional keyboard PTY (#129 tooling)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,7 @@ bin_PROGRAMS = 1984
 	src/mem.c \
 	src/overlay.c \
 	src/paste.c \
+	src/kbd_pty.c \
 	src/ppi.c \
 	src/psg.c \
 	src/rtc.c \

--- a/debug/issue-129-ncfg-freeze/README.md
+++ b/debug/issue-129-ncfg-freeze/README.md
@@ -1,0 +1,49 @@
+# Issue #129 — NCFG-freeze investigation harness
+
+Autonomous probe for the residual race that occasionally crashes the CP/M+
+kernel during `ncfg -r` / `ncfg -a:cpc` / `ping`. Drives 1984 end-to-end:
+
+- Pastes `|hdcpm`, waits for CP/M+ to boot.
+- Pastes `ncfg -r`, `ncfg -a:cpc`, `ping -c5 slashdot.org` at fixed frame
+  intervals via the `--kbd-pty` keyboard PTY.
+- Takes a screenshot at frame 11000 (~220 s wall) via `--screenshot-at`.
+- OCRs the screenshot with `tesseract` (in the project's distrobox) to
+  classify each run: `PASS_PING`, `POST_NCFG_NO_PING`, `REBOOTED`, etc.
+- Captures `ONE_K_TRACE_LBA` + `ONE_K_TRACE_IM1` traces per run for
+  diff-based comparison.
+
+## Usage
+
+```bash
+debug/issue-129-ncfg-freeze/probe.py [N]
+```
+
+`N` defaults to 1. Artifacts land in `/tmp/ncfg-probe/`:
+
+- `run<i>.ppm` / `.png` — final-state screenshot (the actual evidence).
+- `run<i>.log` — emulator stderr (IDE LBA + IRQ-PC trace).
+- `run<i>-report.txt` — OCR of the screenshot plus classification.
+
+Typical observed distribution on the user's setup: ~60% `PASS_PING`,
+~30% `REBOOTED`, ~10% `POST_NCFG_NO_PING`.
+
+## How the failure looks
+
+All `REBOOTED` runs are bit-identical down to the IDE LBA sequence
+(1571 cmds, ending at a re-mount sweep `0x123-0x222`). The CPU enters
+a long block instruction at PC `0x0B2C` inside NCFG / kernel code; ~28
+consecutive IM1 IRQs fire at that exact PC during a single LDIR-style
+loop, and at some iteration state gets corrupted and HDCPM re-mounts.
+Same fingerprint as the original race partially closed in PR #128.
+
+## Why this needs `--kbd-pty`
+
+The CP/M+ kernel writes its console output directly to screen RAM
+without going through the firmware `&BB5A` vector, so a generic text
+hook only catches HDCPM-ROM banner output (everything up to "Hard
+disk N mounted") and goes blind once CP/M+ takes over. We use the PTY
+for typed input — which the kbd matrix sees identically regardless of
+what's reading it — and rely on the final screenshot+OCR for state
+verification. A proper screen-RAM scrape would let the probe react
+mid-flight to the freeze instead of inferring it from the final
+frame, but that's a separate task.

--- a/debug/issue-129-ncfg-freeze/probe.py
+++ b/debug/issue-129-ncfg-freeze/probe.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""NCFG-freeze probe — kbd-PTY input, final screenshot OCR.
+
+For each run: launch 1984 with --kbd-pty and --screenshot-at, send
+`|hdcpm` after the UniDOS probe, send `ncfg -r` once CP/M+ should be up,
+let the screenshot fire and 1984 exit, then OCR the final image to
+classify: PASS / FREEZE / REBOOTED. Per-run artifacts in /tmp/ncfg-probe/.
+
+Usage: debug/issue-129-ncfg-freeze/probe.py [N]
+"""
+import os, sys, re, time, subprocess, signal
+
+REPO = os.path.abspath(os.path.dirname(__file__) + "/../..")
+ART  = "/tmp/ncfg-probe"
+os.makedirs(ART, exist_ok=True)
+
+# Frame plan (50 Hz). Wall clock for each frame N: N/50 seconds.
+#  0–900       UniDOS probe (paste is gated by ONE_K_AUTOSTART_FRAMES=900).
+#  900         send "|hdcpm\r".
+#  900-2700    HDCPM ROM banner + CP/M+ kernel load → A0:CPM> by ~2700.
+#  3500        send "ncfg -r\r".
+#  3500-4500   NCFG reset (~5–10 s).
+#  4500        send "ncfg -a:cpc\r".
+#  4500-6000   DHCP cycle (~10–15 s).
+#  6000        send "ping -c5 slashdot.org\r".
+#  6000-10000  ping completes (5 ICMP, ~5–10 s).
+# 11000        --screenshot-at fires, 1984 exits.
+HDCPM_SEND_FRAME  = 900
+NCFG_R_FRAME      = 3500
+NCFG_A_FRAME      = 4500
+PING_FRAME        = 6000
+SHOT_FRAME        = 11000
+FRAME_S           = 1 / 50.0
+
+def ocr(png):
+    try:
+        out = subprocess.run(
+            ["distrobox", "enter", "my-distrobox", "--", "tesseract", png, "-"],
+            capture_output=True, text=True, timeout=20)
+        return out.stdout
+    except Exception as e:
+        return f"<<ocr error: {e}>>"
+
+def run_once(run_id):
+    rd = f"{ART}/run{run_id}"
+    ppm    = f"{rd}.ppm"
+    png    = f"{rd}.png"
+    log    = f"{rd}.log"
+    rep_p  = f"{rd}-report.txt"
+    for f in (ppm, png, log, rep_p):
+        try: os.unlink(f)
+        except: pass
+
+    rep = open(rep_p, "w")
+    proc = subprocess.Popen(
+        ["./1984", "--memory=576", "--kbd-pty",
+         f"--screenshot-at={SHOT_FRAME}:{ppm}"],
+        cwd=REPO,
+        stderr=open(log, "w"), stdout=subprocess.DEVNULL,
+        env={**os.environ,
+             "ONE_K_TRACE_LBA": "1",
+             "ONE_K_TRACE_IM1": "1"},
+        preexec_fn=os.setsid,
+    )
+    # Find the kbd PTY path from the stderr file.
+    kbd_pty = None
+    deadline = time.monotonic() + 5
+    while not kbd_pty:
+        try:
+            with open(log) as f:
+                for line in f:
+                    m = re.search(r"kbd PTY: (\S+)", line)
+                    if m: kbd_pty = m.group(1); break
+        except FileNotFoundError: pass
+        if time.monotonic() > deadline: break
+        time.sleep(0.1)
+    if not kbd_pty:
+        proc.kill(); rep.write("no kbd PTY\n"); return "ERROR"
+    rep.write(f"kbd PTY: {kbd_pty}\n")
+
+    kfd = os.open(kbd_pty, os.O_RDWR | os.O_NONBLOCK)
+    t0 = time.monotonic()
+
+    def send_at_frame(frame, payload):
+        target = t0 + frame * FRAME_S
+        delay = max(0, target - time.monotonic())
+        time.sleep(delay)
+        os.write(kfd, payload)
+
+    try:
+        send_at_frame(HDCPM_SEND_FRAME, b"|hdcpm\r")
+        send_at_frame(NCFG_R_FRAME,     b"ncfg -r\r")
+        send_at_frame(NCFG_A_FRAME,     b"ncfg -a:cpc\r")
+        send_at_frame(PING_FRAME,       b"ping -c5 slashdot.org\r")
+        # Wait for 1984 to take the screenshot and exit on its own.
+        proc.wait(timeout=180)
+    except subprocess.TimeoutExpired:
+        rep.write("emu timed out (did not exit at screenshot frame)\n")
+    finally:
+        os.close(kfd)
+        try: os.killpg(proc.pid, signal.SIGTERM)
+        except: pass
+
+    if not os.path.exists(ppm) or os.path.getsize(ppm) == 0:
+        rep.write("no screenshot produced\n")
+        return "ERROR"
+    subprocess.run(["convert", ppm, png], check=False)
+    text = ocr(png)
+    rep.write("--- OCR ---\n" + text + "---\n")
+
+    low = text.lower()
+    # PASS: see the ping result table (PING statistic / packets transmitted)
+    if "packets transmitted" in low or "ping statistic" in low:
+        return "PASS_PING"
+    # REBOOT: BASIC banner reappeared
+    if "amstrad 128k" in low or "locomotive" in low:
+        return "REBOOTED"
+    # NCFG completed config but ping didn't run / didn't return
+    if ("network" in low and "gateway" in low) and "slashdot" in low:
+        return "PING_HUNG"
+    if "network" in low and "gateway" in low:
+        return "POST_NCFG_NO_PING"
+    # ncfg -r typed but no NCFG output → freeze in ncfg -r
+    if "ncfg -r" in low and re.search(r"a.:.pm", low):
+        return "FREEZE_NCFG_R"
+    return "OTHER"
+
+def main():
+    N = int(sys.argv[1]) if len(sys.argv) > 1 else 1
+    tally = {}
+    for i in range(1, N+1):
+        out = run_once(i)
+        tally[out] = tally.get(out, 0) + 1
+        print(f"[{i:2d}/{N}] {out}")
+    print("---")
+    for k, v in sorted(tally.items()):
+        print(f"  {k}: {v}")
+
+if __name__ == "__main__":
+    main()

--- a/src/cpc.c
+++ b/src/cpc.c
@@ -1,6 +1,7 @@
 #include "cpc.h"
 #include "net4cpc.h"
 #include "snapshot.h"
+#include "kbd_pty.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -1029,6 +1030,15 @@ void cpc_frame(CPC *cpc) {
             ringp++;
         }
         int t = z80_step(&cpc->cpu, &cpc->bus);
+        /* Firmware text-out hook for --kbd-pty. The CPC ROM exposes
+         * "TXT WR CHAR" at &BB5A — A holds the byte to print. By
+         * sampling AFTER the step we catch the moment the CPU has
+         * just entered the vector (PC is at the second instruction
+         * already, but A is still the caller's). We rely on the next
+         * step to detect this; cheap, and only emits when a kbd PTY
+         * is actually open. */
+        if (cpc->cpu.pc == 0xBB5A && kbd_pty_is_open())
+            kbd_pty_emit_char(cpc->cpu.a);
         done += t;
         g_total_t += t;
         /* Advance the cassette by this instruction's T-states and push

--- a/src/kbd_pty.c
+++ b/src/kbd_pty.c
@@ -9,10 +9,15 @@
 #define _XOPEN_SOURCE 600
 #include "kbd_pty.h"
 
-#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* PTYs are POSIX-only — Windows stubs return failure so callers fail
+ * closed if --kbd-pty is passed. The harness is Linux-only anyway. */
+#ifndef _WIN32
+
+#include <fcntl.h>
 #include <unistd.h>
 #include <termios.h>
 
@@ -95,3 +100,12 @@ void kbd_pty_emit_char(unsigned char c) {
     /* Best-effort write; don't block if the reader isn't draining. */
     (void)!write(s_fd, &c, 1);
 }
+
+#else  /* _WIN32 */
+
+const char *kbd_pty_open(void) { return NULL; }
+bool        kbd_pty_is_open(void) { return false; }
+void        kbd_pty_tick(Paste *p) { (void)p; }
+void        kbd_pty_emit_char(unsigned char c) { (void)c; }
+
+#endif  /* _WIN32 */

--- a/src/kbd_pty.c
+++ b/src/kbd_pty.c
@@ -1,0 +1,97 @@
+/* kbd_pty — bidirectional terminal-like PTY for the CPC. Chars written
+ * to the PTY get injected into the keyboard matrix via the existing
+ * paste machinery; chars the CPC writes via the firmware text-out
+ * vector (&BB5A: TXT WR CHAR — covers BASIC, AMSDOS, and CP/M+
+ * command-line output) are streamed out the PTY. Used by the issue
+ * #129 investigation harness so external scripts can drive the
+ * machine end-to-end without xdotool/Xvfb. */
+
+#define _XOPEN_SOURCE 600
+#include "kbd_pty.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <termios.h>
+
+static int   s_fd = -1;
+static char  s_slave[256];
+
+const char *kbd_pty_open(void) {
+    if (s_fd >= 0) return s_slave;
+
+    int fd = posix_openpt(O_RDWR | O_NOCTTY);
+    if (fd < 0) return NULL;
+    if (grantpt(fd) < 0 || unlockpt(fd) < 0) { close(fd); return NULL; }
+
+    const char *name = ptsname(fd);
+    if (!name) { close(fd); return NULL; }
+    strncpy(s_slave, name, sizeof(s_slave) - 1);
+    s_slave[sizeof(s_slave) - 1] = '\0';
+
+    /* Raw, non-blocking — no echo, no canonical line buffering, no
+     * signal interpretation, no input translation. */
+    struct termios tio;
+    memset(&tio, 0, sizeof(tio));
+    tio.c_cflag = CS8 | CREAD | CLOCAL;
+    tio.c_iflag = 0;
+    tio.c_oflag = 0;
+    tio.c_lflag = 0;       /* clears ECHO, ICANON, ISIG */
+    tio.c_cc[VMIN]  = 0;
+    tio.c_cc[VTIME] = 0;
+    cfsetispeed(&tio, B9600);
+    cfsetospeed(&tio, B9600);
+    tcsetattr(fd, TCSANOW, &tio);
+    fcntl(fd, F_SETFL, O_NONBLOCK);
+
+    s_fd = fd;
+    return s_slave;
+}
+
+bool kbd_pty_is_open(void) { return s_fd >= 0; }
+
+/* In-memory line buffer of pending PTY input that paste hasn't picked up
+ * yet. Drained into the paste buf each tick. */
+static char s_in[512];
+static int  s_in_len;
+
+void kbd_pty_tick(Paste *p) {
+    if (s_fd < 0) return;
+
+    /* Drain anything new on the PTY into our local buffer. */
+    while (s_in_len < (int)sizeof(s_in) - 1) {
+        char c;
+        ssize_t n = read(s_fd, &c, 1);
+        if (n <= 0) break;
+        /* paste.c maps '\n' to Enter and silently skips '\r'. Translate
+         * CR-only or CRLF coming over the wire into LF so terminal-style
+         * line endings ("\r") fire Enter correctly. */
+        if (c == '\r') c = '\n';
+        s_in[s_in_len++] = c;
+    }
+    s_in[s_in_len] = '\0';
+
+    /* If the existing paste is still typing, leave its buffer alone —
+     * we'll catch up on the next tick. */
+    if (p->buf && p->pos < p->len) return;
+    if (s_in_len == 0) return;
+
+    /* Hand the buffered chars to paste. paste_text appends a newline at
+     * the end; to avoid that on partial input we strip a trailing
+     * delimiter if we already have one. The harness sends chars + \n
+     * explicitly anyway, so the auto-newline isn't a problem in
+     * practice — paste skips characters not in its keymap. */
+    paste_text_raw(p, s_in);
+    s_in_len = 0;
+}
+
+/* Called by cpc.c whenever the Z80 enters the firmware text-out vector
+ * &BB5A. The byte to print is in A. We pipe it straight through; the
+ * far side gets raw CPC bytes including the firmware's CR/LF. */
+void kbd_pty_emit_char(unsigned char c) {
+    if (s_fd < 0) return;
+    /* Best-effort write; don't block if the reader isn't draining. */
+    (void)!write(s_fd, &c, 1);
+}

--- a/src/kbd_pty.h
+++ b/src/kbd_pty.h
@@ -1,0 +1,27 @@
+/* kbd_pty — POSIX pseudo-terminal that injects characters into the CPC
+ * keyboard matrix. Lets external scripts drive BASIC / CP/M+ / SymbOS
+ * programmatically without going through xdotool + SDL. Pairs naturally
+ * with the existing --monitor-pty for debugger-side access. Used by the
+ * issue #129 investigation harness; off by default and gated on
+ * --kbd-pty so the host CPU isn't penalised when nobody connects. */
+#pragma once
+#include <stdbool.h>
+#include "paste.h"
+
+/* Open the PTY. Returns the slave device path (e.g. /dev/pts/12) on
+ * success, NULL on failure. Caller doesn't free the returned pointer
+ * — it's owned by an internal static buffer. */
+const char *kbd_pty_open(void);
+
+/* Drain available characters from the PTY and feed them to the existing
+ * paste machinery so they get typed into the keyboard matrix. Call once
+ * per frame, before cpc_frame(). No-op if not opened. */
+void kbd_pty_tick(Paste *p);
+
+/* True if a PTY was opened successfully. */
+bool kbd_pty_is_open(void);
+
+/* Stream a single character out the PTY. Called from cpc.c when the Z80
+ * enters the firmware TXT WR CHAR vector (&BB5A) so external readers
+ * see the CPC's text output in real time. */
+void kbd_pty_emit_char(unsigned char c);

--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,7 @@
 #include "cpc.h"
 #include "mem.h"
 #include "paste.h"
+#include "kbd_pty.h"
 #include "joy.h"
 #include "net4cpc.h"
 #include "n4c_stack.h"
@@ -250,6 +251,8 @@ static void usage(const char *prog, int code) {
         "  --save-sna-at-ide=N:PATH  Save a .sna snapshot when the Nth ATA command is issued (for cross-emulator bisection)\n"
         "  --screenshot-at=N:PATH  Save a screenshot at frame N to PATH, then exit\n"
         "  --monitor-pty       Open a PTY for the memory monitor (minicom -b 9600 -D <path>)\n"
+        "  --kbd-pty           Open a PTY that injects writes as keystrokes and streams\n"
+        "                      the firmware text-out (&BB5A) for external test harnesses\n"
         "  -h, --help          Show this help and exit\n"
         "\n"
         "Keyboard shortcuts:\n"
@@ -289,6 +292,7 @@ int main(int argc, char *argv[]) {
     const char *save_sna_ide_path = NULL;
     bool        trace_io         = false;
     bool        monitor_pty      = false;
+    bool        kbd_pty_enabled  = false;
     CpcModel    model_override   = (CpcModel)-1;  /* -1 = no override */
     bool        dd1_override     = false;
     int         memory_override  = 0;             /* 0 = no override */
@@ -347,6 +351,8 @@ int main(int argc, char *argv[]) {
             memory_override = kb;
         } else if (strcmp(argv[i], "--monitor-pty") == 0) {
             monitor_pty = true;
+        } else if (strcmp(argv[i], "--kbd-pty") == 0) {
+            kbd_pty_enabled = true;
         } else if (strcmp(argv[i], "--trace-io") == 0) {
             trace_io = true;
         } else if (strcmp(argv[i], "--trace-palette") == 0) {
@@ -573,6 +579,12 @@ int main(int argc, char *argv[]) {
 
     Paste paste;
     paste_init(&paste);
+
+    if (kbd_pty_enabled) {
+        const char *p = kbd_pty_open();
+        if (p) fprintf(stderr, "1984: kbd PTY: %s\n", p);
+        else   fprintf(stderr, "1984: failed to open kbd PTY\n");
+    }
 
     Joy joy;
     joy_init(&joy);
@@ -854,6 +866,7 @@ int main(int argc, char *argv[]) {
         }
 
         monitor_pty_tick(monitor);
+        kbd_pty_tick(&paste);
         paste_tick(&paste, &cpc.kbd);
         bool was_paused   = cpc.paused;
         bool was_stepping = cpc.step_once;

--- a/src/paste.c
+++ b/src/paste.c
@@ -1,4 +1,5 @@
 #include "paste.h"
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -140,6 +141,18 @@ void paste_text(Paste *p, const char *text) {
     p->buf[p->len]   = '\0';
     p->pos   = 0;
     p->timer = 3;   /* wait 3 frames for Ctrl to clear from the CPC matrix */
+    p->held  = false;
+}
+
+void paste_text_raw(Paste *p, const char *text) {
+    free(p->buf);
+    p->len = (int)strlen(text);
+    p->buf = malloc(p->len + 1);
+    if (!p->buf) { p->len = 0; return; }
+    memcpy(p->buf, text, p->len);
+    p->buf[p->len] = '\0';
+    p->pos   = 0;
+    p->timer = 3;
     p->held  = false;
 }
 

--- a/src/paste.h
+++ b/src/paste.h
@@ -13,8 +13,14 @@ typedef struct {
 void paste_init(Paste *p);
 void paste_free(Paste *p);
 
-/* Queue text for character-by-character injection into the CPC keyboard. */
+/* Queue text for character-by-character injection into the CPC keyboard.
+ * Auto-appends a newline so single-shot commands fire on their own. */
 void paste_text(Paste *p, const char *text);
+
+/* Like paste_text but does NOT append a newline. Used by the kbd PTY to
+ * stream incoming PTY bytes verbatim — the caller is responsible for
+ * sending \r itself when it wants Enter pressed. */
+void paste_text_raw(Paste *p, const char *text);
 
 /* Call once per frame before cpc_frame(); injects one key event at a time. */
 void paste_tick(Paste *p, Keyboard *k);


### PR DESCRIPTION
## Summary

Adds a POSIX pseudo-terminal that lets external scripts type into the CPC and read what the firmware prints, without going through xdotool / SDL focus. Pairs naturally with the existing \`--monitor-pty\`. Lays the foundation for autonomous investigation of the #129 NCFG residual race.

## What's in this PR

- **\`--kbd-pty\`** flag: opens a PTY. Writes get injected as keystrokes via the paste machinery; reads receive the CPC's firmware \`&BB5A\` text-out stream. Both directions are non-blocking and the PTY closes cleanly on emulator exit.
- **\`paste_text_raw()\`** in \`paste.c\`: existing \`paste_text\` auto-appends a newline, which would Enter after every chunk if used for streamed input. The raw variant doesn't, so the kbd-PTY can stream bytes verbatim.
- **\`debug/issue-129-ncfg-freeze/probe.py\`**: autonomous harness that types the full HDCPM → ncfg -r → ncfg -a:cpc → ping sequence and classifies each run via screenshot OCR. Reproduces ~30% reboot rate matching the user's manual observation and pins the failure to a long block instruction at PC=0x0B2C inside NCFG / kernel code.

No \"fix\" for #129 here — just the tooling that lets us investigate it autonomously.

## Why the firmware-only text capture

CP/M+ kernel writes go straight to screen RAM without ever calling \`&BB5A\`, so the PTY only captures BASIC and HDCPM ROM banner output. That's fine for input-driven test harnesses; a proper screen-RAM scrape that decodes the active font would let probes also react mid-flight, but that's a separate task documented in the README.

## Test plan

- [x] Smoke test: \`PRINT 99\` typed via the PTY runs in BASIC and the \"99\" output rendered to the screen, confirmed by OCR of \`--screenshot-at\`.
- [x] Full probe sequence reproduces the residual freeze (3/10 reboots) bit-identically across runs, matching #129's manual observation.
- [x] Build clean on Fedora (in distrobox).
- [ ] CI build matrix (Fedora + MinGW) on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)