### PR TITLE
overlay: show version + git commit in Advanced tab (#136)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -74,7 +74,8 @@ noinst_HEADERS = \
 	src/z80dis.h
 
 1984_CFLAGS  = $(AM_CFLAGS) $(SDL3_CFLAGS) -Wall -Wextra \
-               -DROM_INSTALL_DIR=\"$(pkgdatadir)/roms\"
+               -DROM_INSTALL_DIR=\"$(pkgdatadir)/roms\" \
+               -DPROG_GIT_COMMIT=\"$(PROG_GIT_COMMIT)\"
 # $(WIN_SUBSYSTEM) (-mconsole) must come LAST so it wins over the -mwindows
 # that $(SDL3_LIBS) drags in.
 1984_LDADD   = $(SDL3_LIBS) -lm $(WIN_LIBS) $(WIN_SUBSYSTEM)

--- a/configure.ac
+++ b/configure.ac
@@ -66,5 +66,12 @@ AS_IF([test -n "$FFMPEG"],
        AC_MSG_NOTICE([video capture: WebM enabled via $FFMPEG])],
       [AC_MSG_NOTICE([video capture: WebM disabled (no ffmpeg found)])])
 
+# Short git commit shown in the Advanced overlay alongside PACKAGE_VERSION.
+# Resolved at configure time so non-git source trees (dist tarballs, flatpak
+# tarball builds) still get a sensible "unknown" fallback.
+PROG_GIT_COMMIT=`git -C "$srcdir" rev-parse --short HEAD 2>/dev/null || echo unknown`
+AC_MSG_NOTICE([git commit: $PROG_GIT_COMMIT])
+AC_SUBST([PROG_GIT_COMMIT])
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -34,7 +34,7 @@ static const int sec_x[OV_SEC_COUNT] = { 8, 80, 160, 248 };
  * "External Tape" toggle, only meaningful on the 6128 since the 464 has
  * the cassette deck built in). Other sections are fixed.
  * The Advanced tab (OV_TINKER) is hidden unless cfg->tinker is enabled. */
-static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 11, 8 };
+static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 11, 9 };
 
 static int ov_section_rows(const Overlay *ov, OvSection s) {
     if (s == OV_GENERAL && ov->cfg->model == MODEL_6128) return 8;
@@ -363,6 +363,11 @@ static void item_text(const Overlay *ov, int row,
             } else {
                 snprintf(val, vsz, "[Enter to pick .webm]");
             }
+            *readonly = true;
+            break;
+        case 8:
+            snprintf(lbl, lsz, "Version");
+            snprintf(val, vsz, "%s (commit %s)", PACKAGE_VERSION, PROG_GIT_COMMIT);
             *readonly = true;
             break;
         }


### PR DESCRIPTION
Closes #136.

Adds a read-only **Version** row at the bottom of the Advanced overlay tab showing the running release and the short git commit it was built from, e.g. `0.4.6 (commit f2f4bd2)`.

## Changes
- `configure.ac` — resolves `PROG_GIT_COMMIT` via `git rev-parse --short HEAD` at configure time; falls back to `unknown` for dist tarballs / non-git source trees (e.g. flatpak builds).
- `Makefile.am` — adds `-DPROG_GIT_COMMIT="$(PROG_GIT_COMMIT)"` to `1984_CFLAGS`. `PACKAGE_VERSION` is already provided via automake's `DEFS`.
- `src/overlay.c` — bumps `OV_TINKER` row count 8 → 9 and adds a `*readonly = true` row that prints `PACKAGE_VERSION (commit PROG_GIT_COMMIT)`. The row has no `activate_item` handler so Enter is a no-op, and it renders in the standard greyed-out style used for other read-only rows.

## Test plan
- [x] `autoreconf -fi && ./configure && make` — clean build
- [x] `strings ./1984 | grep -E "0\.4\.6|f2f4bd2"` confirms both strings are embedded
- [ ] Open overlay → Advanced and verify the Version row appears at the bottom and is non-interactive