### PR TITLE
albireo: dual-CH376 emulation + opt-in USB HID mouse (#122)

### DIFF
--- a/debug/issue-122-albireo-mouse/NOTES.md
+++ b/debug/issue-122-albireo-mouse/NOTES.md
@@ -1,0 +1,100 @@
+# Issue #122 — Albireo USB HID mouse, picking up tomorrow
+
+## Current state of the code (June 2026)
+
+A previous pass landed an end-to-end USB-mouse implementation in commit
+**`8034dab`** (May 2026, *"feat: Albireo USB HID mouse + UNIDOS file-open
+polish"*). It is currently shipped on `main`. Nothing has reverted or
+disabled it. The commit claims *"verified end-to-end against UNIDOS and
+SymbOS"*, but user recollection (June 2026) is that the work was abandoned
+mid-flight — so we need a fresh test to see whether it actually works or
+quietly regressed.
+
+### What is wired up today
+
+| Layer                       | Where                                | Status |
+|-----------------------------|--------------------------------------|--------|
+| Struct fields `mouse_dx/dy/buttons` | `src/ch376.h:111-113`        | ✓      |
+| Reset clears mouse state    | `src/ch376.c:360-361`                | ✓      |
+| HID API `ch376_mouse_move/button`   | `src/ch376.c:887-898`        | ✓      |
+| SDL → CH376 event wiring    | `src/main.c:631` (motion), `:644` (button) | ✓ |
+| `SET_ADDRESS` (0x45) → SUCCESS | `src/ch376.c:664-667`             | ✓      |
+| `SET_CONFIG`  (0x49) → SUCCESS | `src/ch376.c:664-667`             | ✓      |
+| `ISSUE_TKN_X` (0x4E) on endpoint 1 → 3-byte HID report | `src/ch376.c:786-806` | ✓ |
+| `SET_USB_ADDR` (0x13)       | `src/ch376.c:458`                    | ✓      |
+| `SET_FREQ`    (0x0B)        | command table                        | ✓      |
+
+### What the code expects vs. what SymbOS might actually do
+
+The `ISSUE_TKN_X` handler matches **only** when the endpoint param byte is
+`0x19` — i.e. endpoint 1, IN direction (`(ep & 0x0F) == 0x09 && (ep & 0xF0)
+== 0x10`). Anything else returns `USB_INT_DISCONNECT` and SymbOS gives up.
+Most likely failure modes:
+
+1. **SymbOS polls a different endpoint.** Real Albireo USB mice may enumerate
+   to endpoint 2 or 3 depending on the device descriptor; SymbOS may
+   hard-code one address.
+2. **Missing GET_DESCRIPTOR phase.** We don't currently implement
+   `CTRL_TRANSFER`-style descriptor reads (device descriptor, config
+   descriptor, HID report descriptor). If SymbOS tries to enumerate the
+   device first, it gets `USB_INT_DISK_ERR` (default-case fall-through) and
+   bails before ever issuing `ISSUE_TKN_X`.
+3. **`SET_USB_MODE` flow mismatch.** UNIDOS picks `0x06`; SymbOS may pick
+   `0x07` (host with SOF). Both are accepted today but may need different
+   subsequent state.
+4. **Idle-poll convention.** When no mouse data is available, SymbOS may
+   expect `USB_INT_USB_NAK` (`0x2A`) or similar, not the SUCCESS-with-zero
+   report we may currently send (the code returns the 3-byte report
+   unconditionally even when `dx==dy==0`).
+
+## Plan for tomorrow
+
+1. **Capture a real trace.** Run `debug/issue-122-albireo-mouse/trace.sh
+   [path-to-albireo-image]` — boots a 6128 with Albireo enabled and
+   `--trace-albireo` logging every CH376 command + interrupt code into
+   `trace.log` alongside this NOTES.md.
+   - Click in the window to engage mouse capture.
+   - Boot SymbOS from the Albireo volume.
+   - Move the mouse a few times once on the desktop.
+   - Click left/right.
+   - Quit (F12 or close window).
+
+2. **Read the log.** Look for, in order:
+   - Did SymbOS get past `SET_USB_MODE`? (any disconnect after that point
+     means descriptor reads probably failed)
+   - Are there any `DISK_ERR` lines? Those are unhandled commands SymbOS
+     issued — those are our gaps.
+   - Do `ISSUE_TKN_X` lines show up at all? If yes, with what endpoint byte?
+   - If `ISSUE_TKN_X` polls come in but DISCONNECT goes back, the endpoint
+     mask is wrong — log the actual byte and widen the match.
+
+3. **Decide direction.**
+   - If SymbOS *never* reaches `ISSUE_TKN_X` → we need to implement minimal
+     USB descriptor responses (likely via a new `CTRL_TRANSFER`-style
+     command path).
+   - If it reaches `ISSUE_TKN_X` but with a different endpoint → small
+     constant fix.
+   - If it reaches and returns success but the mouse still doesn't move on
+     screen → likely a polarity/scaling issue in the HID report bytes (the
+     code already clamps to int8; check whether SymbOS expects unsigned bias
+     instead).
+
+## References
+
+- `--trace-albireo` flag — primary debug signal.
+- `src/ch376.c` — current emulation; command dispatcher around line 458 and 664.
+- UNIDOS source (Albireo node, for protocol reference):
+  `~/Downloads/UNI/SOURCE/ALBIREO/src/LowLevel.a`
+- Albireo hardware doc:
+  https://pulkomandy.github.io/shinra.github.io/albireo.html
+- ALBIREO.md — documents the *storage*-side SymbOS issue (text-vs-apps
+  tradeoff via `albireo_disable_disk_read`); orthogonal to mouse but useful
+  context.
+
+## Out of scope
+
+- SC16C650B UART (NVRAM). Separate concern.
+- The SymbOS-on-Albireo storage rendering tradeoff (already documented in
+  ALBIREO.md). Disabling Albireo storage via `albireo_disable_disk_read=true`
+  in `1984.conf` may help isolate the mouse path from the storage bug
+  during testing.

--- a/debug/issue-122-albireo-mouse/trace.sh
+++ b/debug/issue-122-albireo-mouse/trace.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# One-command Albireo USB HID mouse trace capture for issue #122.
+#
+# Usage:
+#   debug/issue-122-albireo-mouse/trace.sh [PATH_TO_ALBIREO_IMAGE]
+#
+# Boots 1984 with Albireo enabled (mouse capture engaged), streams every
+# CH376 command + interrupt code to debug/issue-122-albireo-mouse/trace.log.
+# Click in the window to capture the mouse, boot SymbOS, move the mouse,
+# then quit (F12 or close window). The log gets saved alongside this script.
+#
+# What to look for in the log (see NOTES.md for full guidance):
+#   - SET_USB_MODE → does SymbOS pick 0x06 (host, no SOF) or 0x07 (host, SOF)?
+#   - SET_ADDRESS / SET_USB_ADDR / SET_CONFIG sequence — do all return SUCCESS?
+#   - ISSUE_TKN_X polls — what endpoint byte is SymbOS sending?
+#   - Any descriptor reads (CTRL_TRANSFER, GET_DESCRIPTOR) we may be skipping?
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+ALBIREO_IMG="${1:-${HOME}/Dev/1984-images/albireo-symbos.img}"
+LOG="debug/issue-122-albireo-mouse/trace.log"
+
+if [[ ! -f "$ALBIREO_IMG" ]]; then
+  echo "error: Albireo image not found: $ALBIREO_IMG" >&2
+  echo "       Pass the path as the first argument, or place it at the default." >&2
+  exit 1
+fi
+
+if [[ ! -x ./1984 ]]; then
+  echo "note: ./1984 not built — building inside distrobox" >&2
+  distrobox enter my-distrobox -- make -j4
+fi
+
+echo "Tracing to $LOG"
+echo "Click the window to engage mouse capture, boot SymbOS, then F12 or close."
+
+./1984 \
+  --6128 \
+  --trace-albireo \
+  2> >(tee "$LOG" >&2)

--- a/debug/issue-122-albireo-mouse/trace.sh
+++ b/debug/issue-122-albireo-mouse/trace.sh
@@ -37,6 +37,5 @@ echo "Tracing to $LOG"
 echo "Click the window to engage mouse capture, boot SymbOS, then F12 or close."
 
 ./1984 \
-  --6128 \
   --trace-albireo \
   2> >(tee "$LOG" >&2)

--- a/src/ch376.c
+++ b/src/ch376.c
@@ -21,6 +21,7 @@ int ch376_disable_disk_read = 0;
 #define USB_INT_DISK_READ  0x1D
 #define USB_INT_DISK_WRITE 0x1E
 #define USB_INT_DISK_ERR   0x1F
+#define USB_INT_USB_NAK    0x2A   /* device has no data right now */
 #define ERR_OPEN_DIR       0x41
 #define ERR_MISS_FILE      0x42
 #define ERR_FOUND_NAME     0x43
@@ -51,7 +52,7 @@ static void raise_int(CH376 *ch, u8 code) {
     ch->int_status  = code;
     ch->int_pending = true;
     if (ch376_trace)
-        fprintf(stderr, "[albireo]   int=%02X\n", code);
+        fprintf(stderr, "[%s]   int=%02X\n", ch->tag ? ch->tag : "albireo", code);
 }
 
 static const char *cmd_name(u8 c) {
@@ -359,6 +360,7 @@ void ch376_reset(CH376 *ch) {
     ch->filename[0] = '\0';
     ch->mouse_dx = ch->mouse_dy = 0;
     ch->mouse_buttons = 0;
+    ch->mouse_last_buttons = 0;
     ch->sec_reading = ch->sec_writing = false;
     ch->sec_remaining = 0;
     ch->sec_pos = 0;
@@ -434,7 +436,8 @@ static void execute(CH376 *ch) {
     u8 *p  = ch->params;
 
     if (ch376_trace) {
-        fprintf(stderr, "[albireo] cmd %02X %-14s", cmd, cmd_name(cmd));
+        fprintf(stderr, "[%s] cmd %02X %-14s",
+                ch->tag ? ch->tag : "albireo", cmd, cmd_name(cmd));
         for (int i = 0; i < ch->param_count && i < 16; i++)
             fprintf(stderr, " %02X", p[i]);
         if (cmd == 0x2F && ch->param_count > 0)
@@ -783,24 +786,59 @@ static void execute(CH376 *ch) {
         raise_int(ch, USB_INT_DISK_WRITE);
         break;
 
-    case 0x4E: { /* ISSUE_TKN_X — params: (token, endpoint+pid).
-                  * SymbOS / Albireo HID mouse path uses endpoint 0x19
-                  * (read endpoint 1) with token DATA0/DATA1 alternating.
-                  * Stage a 3-byte boot-mouse report (buttons, dx, dy). */
+    case 0x4E: { /* ISSUE_TKN_X — params: (toggle-sync, endpoint+pid).
+                  * The endpoint+pid byte is (ep << 4) | pid where pid
+                  * is the CH376 PID code: 1=OUT, 9=IN, D=SETUP. */
         u8 endpoint = p[1];
-        if ((endpoint & 0x0F) == 0x09 && (endpoint & 0xF0) == 0x10) {
-            /* IN token on endpoint 1 — return mouse HID report. */
-            int dx = ch->mouse_dx;
-            int dy = ch->mouse_dy;
-            if (dx >  127) dx =  127; else if (dx < -128) dx = -128;
-            if (dy >  127) dy =  127; else if (dy < -128) dy = -128;
-            ch->mouse_dx -= dx;
-            ch->mouse_dy -= dy;
-            u8 v[4] = { 3, ch->mouse_buttons, (u8)(s8)dx, (u8)(s8)dy };
-            set_response(ch, v, 4);
+        u8 pid = endpoint & 0x0F;
+        u8 ep  = (endpoint >> 4) & 0x0F;
+        if (!ch->has_mouse) {
+            /* USB HID mouse path is opt-in (Albireo Mouse toggle).
+             * Refuse all USB tokens so SymbOS gives up on HID and
+             * keeps the chip available for storage. */
+            raise_int(ch, USB_INT_DISCONNECT);
+        }
+        else if (ep == 1 && pid == 0x09) {
+            /* HID IN on endpoint 1 — return 3-byte boot-mouse report when
+             * there's something to deliver, otherwise NAK so SymbOS yields
+             * back to its other tasks (disk I/O, UI redraw, ...). */
+            if (ch->mouse_dx == 0 && ch->mouse_dy == 0 &&
+                ch->mouse_buttons == ch->mouse_last_buttons) {
+                /* Zero out the full 4-byte report so the host's
+                 * RD_USB_DATA0 reads back length=0, buttons=0, dx=0, dy=0
+                 * regardless of how many bytes it consumes. Without this,
+                 * SymbOS reads the previous report (drift) or 0xFF padding
+                 * from past-end reads (drifts up-left at -1,-1 per poll). */
+                u8 zero[4] = { 0, 0, 0, 0 };
+                set_response(ch, zero, 4);
+                raise_int(ch, USB_INT_USB_NAK);
+            } else {
+                int dx = ch->mouse_dx;
+                int dy = ch->mouse_dy;
+                if (dx >  127) dx =  127; else if (dx < -128) dx = -128;
+                if (dy >  127) dy =  127; else if (dy < -128) dy = -128;
+                ch->mouse_dx -= dx;
+                ch->mouse_dy -= dy;
+                ch->mouse_last_buttons = ch->mouse_buttons;
+                u8 v[4] = { 3, ch->mouse_buttons, (u8)(s8)dx, (u8)(s8)dy };
+                set_response(ch, v, 4);
+                raise_int(ch, USB_INT_SUCCESS);
+            }
+        } else if (ep == 0) {
+            /* Control transfer on EP0. The CH376 high-level commands
+             * SET_ADDRESS (0x45) and SET_CONFIG (0x49) already handle
+             * standard device-level requests internally; SymbOS still
+             * probes EP0 with raw SETUP / IN / OUT tokens for HID
+             * class requests (SET_IDLE, SET_PROTOCOL, GET_REPORT).
+             * We don't model the device descriptors, so acknowledge
+             * every stage with a zero-length response — that keeps the
+             * enumeration alive so SymbOS moves on to polling EP1. */
+            if (pid == 0x09) {
+                u8 zero = 0;
+                set_response(ch, &zero, 1);   /* len=0, no data */
+            }
             raise_int(ch, USB_INT_SUCCESS);
         } else {
-            /* Anything else on the USB token path — nothing to emulate. */
             raise_int(ch, USB_INT_DISCONNECT);
         }
         break;

--- a/src/ch376.c
+++ b/src/ch376.c
@@ -21,7 +21,6 @@ int ch376_disable_disk_read = 0;
 #define USB_INT_DISK_READ  0x1D
 #define USB_INT_DISK_WRITE 0x1E
 #define USB_INT_DISK_ERR   0x1F
-#define USB_INT_USB_NAK    0x2A   /* device has no data right now */
 #define ERR_OPEN_DIR       0x41
 #define ERR_MISS_FILE      0x42
 #define ERR_FOUND_NAME     0x43
@@ -800,8 +799,9 @@ static void execute(CH376 *ch) {
         }
         else if (ep == 1 && pid == 0x09) {
             /* HID IN on endpoint 1 — return 3-byte boot-mouse report when
-             * there's something to deliver, otherwise NAK so SymbOS yields
-             * back to its other tasks (disk I/O, UI redraw, ...). */
+             * there's something to deliver. Complete idle polls with a
+             * zero-length SUCCESS: SymbOS retries NAK immediately, which
+             * starves storage work on the second CH376. */
             if (ch->mouse_dx == 0 && ch->mouse_dy == 0 &&
                 ch->mouse_buttons == ch->mouse_last_buttons) {
                 /* Zero out the full 4-byte report so the host's
@@ -811,7 +811,7 @@ static void execute(CH376 *ch) {
                  * from past-end reads (drifts up-left at -1,-1 per poll). */
                 u8 zero[4] = { 0, 0, 0, 0 };
                 set_response(ch, zero, 4);
-                raise_int(ch, USB_INT_USB_NAK);
+                raise_int(ch, USB_INT_SUCCESS);
             } else {
                 int dx = ch->mouse_dx;
                 int dy = ch->mouse_dy;

--- a/src/ch376.h
+++ b/src/ch376.h
@@ -31,6 +31,10 @@
 #define CH376_BUF_MAX  256
 
 typedef struct {
+    /* Trace prefix for log lines — set by the owner before reset (e.g.
+     * "albireo-a" / "albireo-b" on dual-CH376 cards). */
+    const char *tag;
+
     /* --- Command/response state --- */
     u8   pending_cmd;
     int  param_needed;     /* fixed param byte count; -1 = until NUL */
@@ -111,6 +115,12 @@ typedef struct {
     int   mouse_dx;
     int   mouse_dy;
     u8    mouse_buttons;        /* bit0=left, bit1=right, bit2=middle */
+    u8    mouse_last_buttons;   /* last value delivered via ISSUE_TKN_X */
+    /* When true, ISSUE_TKN_X accepts EP0 control transfers and EP1 IN
+     * mouse-report polls; when false the chip behaves like the original
+     * single-chip Albireo emulation (DISCONNECT on EP0/EP1) so SymbOS
+     * doesn't start its polling thread. */
+    bool  has_mouse;
 } CH376;
 
 extern int ch376_trace;

--- a/src/config.c
+++ b/src/config.c
@@ -191,6 +191,7 @@ static void config_create_default(const char *path, const char *home) {
         "symbnet=false\n"
         "albireo=false\n"
         "albireo_image=\n"
+        "albireo_mouse=false\n"
         "albireo_disable_disk_read=false\n"
         "\n"
         "[display]\n"
@@ -381,6 +382,9 @@ int config_load_from(Config *cfg, const char *path_override) {
                 else { fprintf(stderr, "1984.conf:%d: albireo must be true/false\n", lineno); rc = -1; }
             } else if (!strcmp(key, "albireo_image")) {
                 if (val[0]) expand_path(val, cfg->albireo_image, sizeof(cfg->albireo_image));
+            } else if (!strcmp(key, "albireo_mouse")) {
+                if (parse_bool(val, &b)) cfg->albireo_mouse = b;
+                else { fprintf(stderr, "1984.conf:%d: albireo_mouse must be true/false\n", lineno); rc = -1; }
             } else if (!strcmp(key, "albireo_disable_disk_read")) {
                 if (parse_bool(val, &b)) cfg->albireo_disable_disk_read = b;
                 else { fprintf(stderr, "1984.conf:%d: albireo_disable_disk_read must be true/false\n", lineno); rc = -1; }
@@ -529,6 +533,7 @@ int config_save(const Config *cfg) {
         "symbnet=%s\n"
         "albireo=%s\n"
         "albireo_image=%s\n"
+        "albireo_mouse=%s\n"
         "albireo_disable_disk_read=%s\n\n"
         "[display]\n"
         "scale=%d\n"
@@ -561,6 +566,7 @@ int config_save(const Config *cfg) {
         cfg->symbnet          ? "true" : "false",
         cfg->albireo          ? "true" : "false",
         cfg->albireo_image,
+        cfg->albireo_mouse    ? "true" : "false",
         cfg->albireo_disable_disk_read ? "true" : "false",
         cfg->scale,
         cfg->fullscreen ? "true" : "false",

--- a/src/config.h
+++ b/src/config.h
@@ -73,6 +73,12 @@ typedef struct {
     bool symbnet;     /* 1984 emulator synthetic SymbOS network port (0xFD30/31) */
     bool albireo;
     char albireo_image[CONFIG_PATH_MAX];
+    /* When the dual-CH376 card is enabled, populate the second chip at
+     * 0xFE40/41 so SymbOS can enumerate a USB HID mouse on chip A and
+     * still serve disk I/O from chip B. When false, only chip A is
+     * wired — matches a single-chip Albireo card and avoids the
+     * polling overhead SymbOS's HID driver adds. */
+    bool albireo_mouse;
     /* If true, the CH376 emulation refuses raw-sector DISK_READ commands so
      * SymbOS falls back to the chip's built-in FS via FILE_OPEN/BYTE_READ.
      * Works around a current rendering bug where SymbOS-FAT-driver-via-raw-

--- a/src/cpc.c
+++ b/src/cpc.c
@@ -261,8 +261,8 @@ static u8 bus_io_read(void *ctx, u16 port) {
     else if (hi == 0xFA) {
         result = 0xFF;
     }
-    /* Albireo CH376: hi=0xFE, lo=0x80/0x81 (left chip, storage) or
-     * 0x40/0x41 (right chip, USB host — present on dual-chip cards).
+    /* Albireo CH376: hi=0xFE, lo=0x80/0x81 (left chip, storage or USB
+     * mouse) or 0x40/0x41 (right chip, dual-mode storage).
      * Claim before M4 wide decode. */
     else if (cpc->mx4 && cpc->albireo && hi == 0xFE && (port & 0xFE) == 0x80) {
         result = ch376_read(&cpc->ch376, (u8)(port & 0x01));
@@ -412,8 +412,9 @@ static void bus_io_write(void *ctx, u16 port, u8 val) {
         }
         return;
     }
-    /* Albireo CH376: hi=0xFE, lo=0x80/0x81 (left chip, storage) or
-     * 0x40/0x41 (right chip, USB host). Claim before M4 wide decode. */
+    /* Albireo CH376: hi=0xFE, lo=0x80/0x81 (left chip, storage or USB
+     * mouse) or 0x40/0x41 (right chip, dual-mode storage).
+     * Claim before M4 wide decode. */
     if (cpc->mx4 && cpc->albireo && hi == 0xFE && (port & 0xFE) == 0x80) {
         ch376_write(&cpc->ch376, (u8)(port & 0x01), val);
         return;

--- a/src/cpc.c
+++ b/src/cpc.c
@@ -261,9 +261,15 @@ static u8 bus_io_read(void *ctx, u16 port) {
     else if (hi == 0xFA) {
         result = 0xFF;
     }
-    /* Albireo CH376: hi=0xFE, lo=0x80/0x81 (claim before M4 wide decode) */
+    /* Albireo CH376: hi=0xFE, lo=0x80/0x81 (left chip, storage) or
+     * 0x40/0x41 (right chip, USB host — present on dual-chip cards).
+     * Claim before M4 wide decode. */
     else if (cpc->mx4 && cpc->albireo && hi == 0xFE && (port & 0xFE) == 0x80) {
         result = ch376_read(&cpc->ch376, (u8)(port & 0x01));
+    }
+    else if (cpc->mx4 && cpc->albireo && cpc->albireo_mouse &&
+             hi == 0xFE && (port & 0xFE) == 0x40) {
+        result = ch376_read(&cpc->ch376_b, (u8)(port & 0x01));
     }
     /* M4 DATAPORT: hi=0xFE or 0xFF (read = ready/status) */
     else if (cpc->mx4 && cpc->m4 && (hi == 0xFE || hi == 0xFF)) {
@@ -406,9 +412,15 @@ static void bus_io_write(void *ctx, u16 port, u8 val) {
         }
         return;
     }
-    /* Albireo CH376: hi=0xFE, lo=0x80/0x81 (claim before M4 wide decode) */
+    /* Albireo CH376: hi=0xFE, lo=0x80/0x81 (left chip, storage) or
+     * 0x40/0x41 (right chip, USB host). Claim before M4 wide decode. */
     if (cpc->mx4 && cpc->albireo && hi == 0xFE && (port & 0xFE) == 0x80) {
         ch376_write(&cpc->ch376, (u8)(port & 0x01), val);
+        return;
+    }
+    if (cpc->mx4 && cpc->albireo && cpc->albireo_mouse &&
+            hi == 0xFE && (port & 0xFE) == 0x40) {
+        ch376_write(&cpc->ch376_b, (u8)(port & 0x01), val);
         return;
     }
     /* M4 DATAPORT: hi=0xFE or 0xFF — accumulate command byte */
@@ -539,6 +551,9 @@ int cpc_init(CPC *cpc, CpcModel model, const char *rom_os, const char *rom_basic
     m4_init(&cpc->m4_card, "");
     symbnet_init(&cpc->symbnet_card, &cpc->m4_card);
     ch376_init(&cpc->ch376);
+    cpc->ch376.tag = "albireo-a";
+    ch376_init(&cpc->ch376_b);
+    cpc->ch376_b.tag = "albireo-b";
     tape_init(&cpc->tape);
     net4cpc_reset();
 
@@ -578,6 +593,7 @@ void cpc_reset(CPC *cpc) {
     mouse_init(&cpc->mouse);    /* clear accumulated deltas; capture state managed by main */
     m4_reset(&cpc->m4_card);
     ch376_reset(&cpc->ch376);
+    ch376_reset(&cpc->ch376_b);
     cpc->mem.lower_rom_enabled = true;
     cpc->mem.upper_rom_enabled = true;
     cpc->mem.ram_bank = 0;
@@ -594,6 +610,7 @@ void cpc_destroy(CPC *cpc) {
     disk_eject(&cpc->drive[1]);
     ide_close(&cpc->ide_chip);
     ch376_close(&cpc->ch376);
+    ch376_close(&cpc->ch376_b);
     tape_eject(&cpc->tape);
     display_destroy(&cpc->display);
 }

--- a/src/cpc.h
+++ b/src/cpc.h
@@ -50,9 +50,10 @@ typedef struct {
     SymbNet    symbnet_card;
     bool       albireo;        /* Albireo / dual-CH376 card present       */
     bool       albireo_mouse;  /* Populate the second chip + accept HID   */
-    CH376      ch376;          /* Left chip  @ 0xFE80/81 — storage + mouse */
-    CH376      ch376_b;        /* Right chip @ 0xFE40/41 — storage (only
-                                  wired when albireo_mouse is true)        */
+    CH376      ch376;          /* Left chip  @ 0xFE80/81 — storage, or HID
+                                  mouse when albireo_mouse is true         */
+    CH376      ch376_b;        /* Right chip @ 0xFE40/41 — storage in
+                                  dual-chip mouse mode                     */
     Tape       tape;           /* cassette / .cdt image */
     /* Per-sample snapshot of the cassette data line, captured inside the
      * Z80 step loop at audio rate. Mixed into the PSG output frame so the

--- a/src/cpc.h
+++ b/src/cpc.h
@@ -48,8 +48,11 @@ typedef struct {
     M4         m4_card;
     bool       symbnet;        /* 1984 emulator synthetic SymbOS network port */
     SymbNet    symbnet_card;
-    bool       albireo;        /* Albireo USB host add-on (CH376) */
-    CH376      ch376;
+    bool       albireo;        /* Albireo / dual-CH376 card present       */
+    bool       albireo_mouse;  /* Populate the second chip + accept HID   */
+    CH376      ch376;          /* Left chip  @ 0xFE80/81 — storage + mouse */
+    CH376      ch376_b;        /* Right chip @ 0xFE40/41 — storage (only
+                                  wired when albireo_mouse is true)        */
     Tape       tape;           /* cassette / .cdt image */
     /* Per-sample snapshot of the cassette data line, captured inside the
      * Z80 step loop at audio rate. Mixed into the PSG output frame so the

--- a/src/main.c
+++ b/src/main.c
@@ -490,15 +490,11 @@ int main(int argc, char *argv[]) {
         ide_open(&cpc.ide_chip, cfg.ide_image);
     cpc.albireo       = cfg.albireo && cfg.rom_board;
     cpc.albireo_mouse = cpc.albireo && cfg.albireo_mouse;
-    cpc.ch376.has_mouse = cpc.albireo_mouse;
+    cpc.ch376.has_mouse   = cpc.albireo_mouse;
+    cpc.ch376_b.has_mouse = false;
     if (cpc.albireo && cfg.albireo_image[0]) {
-        ch376_open(&cpc.ch376, cfg.albireo_image);
-        if (cpc.albireo_mouse) {
-            /* Dual-chip mode: open the same image on chip B so SymbOS
-             * has a working storage path after chip A is pinned in
-             * USB-host mode for the mouse. */
-            ch376_open(&cpc.ch376_b, cfg.albireo_image);
-        }
+        CH376 *storage = cpc.albireo_mouse ? &cpc.ch376_b : &cpc.ch376;
+        ch376_open(storage, cfg.albireo_image);
     }
     ch376_disable_disk_read = cfg.albireo_disable_disk_read ? 1 : 0;
     /* M4 and Albireo share the 0xFExx port range — Albireo wins if both set. */
@@ -940,13 +936,13 @@ int main(int argc, char *argv[]) {
                 ide_open(&cpc.ide_chip, cfg.ide_image);
             cpc.albireo       = cfg.albireo && cfg.rom_board;
             cpc.albireo_mouse = cpc.albireo && cfg.albireo_mouse;
-            cpc.ch376.has_mouse = cpc.albireo_mouse;
+            cpc.ch376.has_mouse   = cpc.albireo_mouse;
+            cpc.ch376_b.has_mouse = false;
             ch376_close(&cpc.ch376);
             ch376_close(&cpc.ch376_b);
             if (cpc.albireo && cfg.albireo_image[0]) {
-                ch376_open(&cpc.ch376, cfg.albireo_image);
-                if (cpc.albireo_mouse)
-                    ch376_open(&cpc.ch376_b, cfg.albireo_image);
+                CH376 *storage = cpc.albireo_mouse ? &cpc.ch376_b : &cpc.ch376;
+                ch376_open(storage, cfg.albireo_image);
             }
             ch376_disable_disk_read = cfg.albireo_disable_disk_read ? 1 : 0;
             if (cpc.albireo && cpc.m4) {

--- a/src/main.c
+++ b/src/main.c
@@ -488,9 +488,18 @@ int main(int argc, char *argv[]) {
         m4_set_image(&cpc.m4_card, cfg.m4_image);
     if (cfg.symbiface_ide && cfg.ide_image[0])
         ide_open(&cpc.ide_chip, cfg.ide_image);
-    cpc.albireo = cfg.albireo && cfg.rom_board;
-    if (cpc.albireo && cfg.albireo_image[0])
+    cpc.albireo       = cfg.albireo && cfg.rom_board;
+    cpc.albireo_mouse = cpc.albireo && cfg.albireo_mouse;
+    cpc.ch376.has_mouse = cpc.albireo_mouse;
+    if (cpc.albireo && cfg.albireo_image[0]) {
         ch376_open(&cpc.ch376, cfg.albireo_image);
+        if (cpc.albireo_mouse) {
+            /* Dual-chip mode: open the same image on chip B so SymbOS
+             * has a working storage path after chip A is pinned in
+             * USB-host mode for the mouse. */
+            ch376_open(&cpc.ch376_b, cfg.albireo_image);
+        }
+    }
     ch376_disable_disk_read = cfg.albireo_disable_disk_read ? 1 : 0;
     /* M4 and Albireo share the 0xFExx port range — Albireo wins if both set. */
     if (cpc.albireo && cpc.m4) {
@@ -725,7 +734,7 @@ int main(int argc, char *argv[]) {
                 if (ev.type == SDL_EVENT_MOUSE_MOTION) {
                     if (cpc.symbiface_mouse)
                         mouse_move(&cpc.mouse, (int)ev.motion.xrel, (int)ev.motion.yrel);
-                    if (cpc.albireo)
+                    if (cpc.albireo_mouse)
                         ch376_mouse_move(&cpc.ch376, (int)ev.motion.xrel, (int)ev.motion.yrel);
                     continue;
                 }
@@ -738,7 +747,7 @@ int main(int argc, char *argv[]) {
                     if (btn >= 0) {
                         if (cpc.symbiface_mouse)
                             mouse_button(&cpc.mouse, btn, pressed);
-                        if (cpc.albireo)
+                        if (cpc.albireo_mouse)
                             ch376_mouse_button(&cpc.ch376, btn, pressed);
                     }
                     continue;
@@ -758,13 +767,10 @@ int main(int argc, char *argv[]) {
                 }
             }
 
-            /* Click in emulator window captures mouse only when the
-             * SYMBiFACE II PS/2 mouse is enabled. Albireo on its own
-             * doesn't drive a usable mouse path in the current build
-             * (SymbOS abandons USB HID after SETUP returns DISCONNECT),
-             * so capturing for it would just trap the host pointer for
-             * nothing. Ctrl+Enter releases capture. */
-            if (!mouse_captured && cpc.symbiface_mouse &&
+            /* Click in emulator window captures mouse when either the
+             * SYMBiFACE II PS/2 mouse or the Albireo USB HID mouse is
+             * enabled. Ctrl+Enter releases capture. */
+            if (!mouse_captured && (cpc.symbiface_mouse || cpc.albireo_mouse) &&
                 !overlay.visible &&
                 ev.type == SDL_EVENT_MOUSE_BUTTON_DOWN &&
                 ev.button.windowID == SDL_GetWindowID(cpc.display.window)) {
@@ -773,8 +779,12 @@ int main(int argc, char *argv[]) {
                 int btn = (ev.button.button == SDL_BUTTON_LEFT)   ? 0 :
                           (ev.button.button == SDL_BUTTON_RIGHT)  ? 1 :
                           (ev.button.button == SDL_BUTTON_MIDDLE) ? 2 : -1;
-                if (btn >= 0)
-                    mouse_button(&cpc.mouse, btn, true);
+                if (btn >= 0) {
+                    if (cpc.symbiface_mouse)
+                        mouse_button(&cpc.mouse, btn, true);
+                    if (cpc.albireo_mouse)
+                        ch376_mouse_button(&cpc.ch376, btn, true);
+                }
                 continue;
             }
 
@@ -928,10 +938,16 @@ int main(int argc, char *argv[]) {
             ide_close(&cpc.ide_chip);
             if (cpc.symbiface_ide && cfg.ide_image[0])
                 ide_open(&cpc.ide_chip, cfg.ide_image);
-            cpc.albireo = cfg.albireo && cfg.rom_board;
+            cpc.albireo       = cfg.albireo && cfg.rom_board;
+            cpc.albireo_mouse = cpc.albireo && cfg.albireo_mouse;
+            cpc.ch376.has_mouse = cpc.albireo_mouse;
             ch376_close(&cpc.ch376);
-            if (cpc.albireo && cfg.albireo_image[0])
+            ch376_close(&cpc.ch376_b);
+            if (cpc.albireo && cfg.albireo_image[0]) {
                 ch376_open(&cpc.ch376, cfg.albireo_image);
+                if (cpc.albireo_mouse)
+                    ch376_open(&cpc.ch376_b, cfg.albireo_image);
+            }
             ch376_disable_disk_read = cfg.albireo_disable_disk_read ? 1 : 0;
             if (cpc.albireo && cpc.m4) {
                 cpc.m4 = false;

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -270,20 +270,20 @@ static void item_text(const Overlay *ov, int row,
             }
             break;
         case 9:
-            snprintf(lbl, lsz, "Albireo Mouse");
+            snprintf(lbl, lsz, "CH376-A Mouse");
             if (!ov->cfg->rom_board) {
-                snprintf(val, vsz, "[needs Roms Board]");
+                snprintf(val, vsz, "(Albireo compatible) [needs Roms Board]");
                 *readonly = true;
             } else if (!ov->cfg->albireo) {
-                snprintf(val, vsz, "[needs dual-CH376 card]");
+                snprintf(val, vsz, "(Albireo compatible) [needs CH376-B Disk]");
                 *readonly = true;
             } else {
-                snprintf(val, vsz, "%s",
+                snprintf(val, vsz, "(Albireo compatible) %s",
                          ov->cfg->albireo_mouse ? "enabled" : "disabled");
             }
             break;
         case 10:
-            snprintf(lbl, lsz, "dual-CH376 card");
+            snprintf(lbl, lsz, "CH376-B Disk");
             if (!ov->cfg->rom_board) {
                 snprintf(val, vsz, "(Albireo compatible) [needs Roms Board]");
                 *readonly = true;

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -34,7 +34,7 @@ static const int sec_x[OV_SEC_COUNT] = { 8, 80, 160, 248 };
  * "External Tape" toggle, only meaningful on the 6128 since the 464 has
  * the cassette deck built in). Other sections are fixed.
  * The Advanced tab (OV_TINKER) is hidden unless cfg->tinker is enabled. */
-static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 11, 9 };
+static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 12, 9 };
 
 static int ov_section_rows(const Overlay *ov, OvSection s) {
     if (s == OV_GENERAL && ov->cfg->model == MODEL_6128) return 8;
@@ -270,19 +270,35 @@ static void item_text(const Overlay *ov, int row,
             }
             break;
         case 9:
-            snprintf(lbl, lsz, "Albireo");
+            snprintf(lbl, lsz, "Albireo Mouse");
             if (!ov->cfg->rom_board) {
                 snprintf(val, vsz, "[needs Roms Board]");
                 *readonly = true;
-            } else if (ov->cfg->albireo && ov->cfg->albireo_image[0]) {
-                char tmp[CONFIG_PATH_MAX];
-                snprintf(tmp, sizeof(tmp), "%s", ov->cfg->albireo_image);
-                trunc_path(basename(tmp), val, vsz);
+            } else if (!ov->cfg->albireo) {
+                snprintf(val, vsz, "[needs dual-CH376 card]");
+                *readonly = true;
             } else {
-                snprintf(val, vsz, "%s", ov->cfg->albireo ? "enabled" : "disabled");
+                snprintf(val, vsz, "%s",
+                         ov->cfg->albireo_mouse ? "enabled" : "disabled");
             }
             break;
-        case 10: {
+        case 10:
+            snprintf(lbl, lsz, "dual-CH376 card");
+            if (!ov->cfg->rom_board) {
+                snprintf(val, vsz, "(Albireo compatible) [needs Roms Board]");
+                *readonly = true;
+            } else if (ov->cfg->albireo && ov->cfg->albireo_image[0]) {
+                char tmp[CONFIG_PATH_MAX];
+                char base[24];
+                snprintf(tmp, sizeof(tmp), "%s", ov->cfg->albireo_image);
+                trunc_path(basename(tmp), base, sizeof(base));
+                snprintf(val, vsz, "(Albireo compatible) %s", base);
+            } else {
+                snprintf(val, vsz, "(Albireo compatible) %s",
+                         ov->cfg->albireo ? "enabled" : "disabled");
+            }
+            break;
+        case 11: {
             snprintf(lbl, lsz, "Cyboard");
             if (!ov->cfg->rom_board) {
                 snprintf(val, vsz, "[needs Roms Board]");
@@ -492,7 +508,7 @@ static void activate_item(Overlay *ov) {
          * down here. */
         if (!ov->cfg->rom_board &&
             (ov->row == 0 || ov->row == 7 || ov->row == 8 ||
-             ov->row == 9 || ov->row == 10))
+             ov->row == 9 || ov->row == 10 || ov->row == 11))
             break;
         switch (ov->row) {
         case 0:
@@ -662,9 +678,42 @@ static void activate_item(Overlay *ov) {
             break;
         case 8:
             ov->cfg->symbiface_mouse = !ov->cfg->symbiface_mouse;
+            /* SymbIface Mouse and Albireo Mouse both drive the host
+             * pointer — only one can own it at a time. */
+            if (ov->cfg->symbiface_mouse && ov->cfg->albireo_mouse) {
+                ov->cfg->albireo_mouse = false;
+                if (ov->cpc) {
+                    ov->cpc->albireo_mouse = false;
+                    ov->cpc->ch376.has_mouse = false;
+                    ch376_close(&ov->cpc->ch376_b);
+                }
+                ov->needs_cold_boot = true;
+            }
             ov->dirty = true;
             break;
         case 9:
+            /* Albireo Mouse toggle (opt-in HID polling on chip A +
+             * second storage chip at 0xFE40). Requires the dual-CH376
+             * card to be enabled; mutually exclusive with the SymbIface
+             * PS/2 mouse. */
+            if (!ov->cfg->rom_board || !ov->cfg->albireo) break;
+            ov->cfg->albireo_mouse = !ov->cfg->albireo_mouse;
+            if (ov->cfg->albireo_mouse && ov->cfg->symbiface_mouse) {
+                ov->cfg->symbiface_mouse = false;
+                if (ov->cpc) ov->cpc->symbiface_mouse = false;
+            }
+            if (ov->cpc) {
+                ov->cpc->albireo_mouse = ov->cfg->albireo_mouse;
+                ov->cpc->ch376.has_mouse = ov->cfg->albireo_mouse;
+                if (ov->cfg->albireo_mouse && ov->cfg->albireo_image[0])
+                    ch376_open(&ov->cpc->ch376_b, ov->cfg->albireo_image);
+                else
+                    ch376_close(&ov->cpc->ch376_b);
+            }
+            ov->needs_cold_boot = true;
+            ov->dirty = true;
+            break;
+        case 10:
             if (!ov->cfg->albireo) {
                 /* Mutually exclusive with M4 (both claim port 0xFExx). */
                 if (ov->cfg->m4) {
@@ -694,17 +743,23 @@ static void activate_item(Overlay *ov) {
                         alb_filters, 2, NULL, false);
                 }
             } else {
-                /* Keep board_albireo_image for the next enable cycle. */
+                /* Disabling the card also drops the Albireo Mouse — it
+                 * has no chip to talk to. Keep board_albireo_image for
+                 * the next enable cycle. */
                 ov->cfg->albireo = false;
                 ov->cfg->albireo_image[0] = '\0';
+                ov->cfg->albireo_mouse = false;
                 if (ov->cpc) {
                     ov->cpc->albireo = false;
+                    ov->cpc->albireo_mouse = false;
+                    ov->cpc->ch376.has_mouse = false;
                     ch376_close(&ov->cpc->ch376);
+                    ch376_close(&ov->cpc->ch376_b);
                 }
                 ov->dirty = true;
             }
             break;
-        case 10: {
+        case 11: {
             bool all = ov->cfg->net4cpc && ov->cfg->rtc &&
                        ov->cfg->symbiface_ide && ov->cfg->symbiface_mouse;
             bool enable = !all;
@@ -947,7 +1002,10 @@ void overlay_tick(Overlay *ov) {
         if (ov->cpc) {
             ov->cpc->albireo = true;
             ch376_close(&ov->cpc->ch376);
+            ch376_close(&ov->cpc->ch376_b);
             ch376_open(&ov->cpc->ch376, ov->cfg->albireo_image);
+            if (ov->cfg->albireo_mouse)
+                ch376_open(&ov->cpc->ch376_b, ov->cfg->albireo_image);
         }
         ov->dirty = true;
     } else if (ov->dialog_kind == DIALOG_SNAPSHOT_LOAD) {
@@ -1318,13 +1376,17 @@ bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
                 ov->cfg->symbiface_ide = false;
                 ov->cfg->ide_image[0] = '\0';
                 break;
-            case 9:                                /* Albireo */
+            case 10:                               /* Albireo / dual-CH376 */
                 cached = ov->cfg->board_albireo_image;
                 ov->cfg->albireo = false;
                 ov->cfg->albireo_image[0] = '\0';
+                ov->cfg->albireo_mouse = false;
                 if (ov->cpc) {
                     ov->cpc->albireo = false;
+                    ov->cpc->albireo_mouse = false;
+                    ov->cpc->ch376.has_mouse = false;
                     ch376_close(&ov->cpc->ch376);
+                    ch376_close(&ov->cpc->ch376_b);
                 }
                 break;
             }

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -685,15 +685,18 @@ static void activate_item(Overlay *ov) {
                 if (ov->cpc) {
                     ov->cpc->albireo_mouse = false;
                     ov->cpc->ch376.has_mouse = false;
+                    ch376_close(&ov->cpc->ch376);
                     ch376_close(&ov->cpc->ch376_b);
+                    if (ov->cfg->albireo_image[0])
+                        ch376_open(&ov->cpc->ch376, ov->cfg->albireo_image);
                 }
                 ov->needs_cold_boot = true;
             }
             ov->dirty = true;
             break;
         case 9:
-            /* Albireo Mouse toggle (opt-in HID polling on chip A +
-             * second storage chip at 0xFE40). Requires the dual-CH376
+            /* Albireo Mouse toggle (opt-in HID polling on chip A plus
+             * storage on chip B at 0xFE40). Requires the dual-CH376
              * card to be enabled; mutually exclusive with the SymbIface
              * PS/2 mouse. */
             if (!ov->cfg->rom_board || !ov->cfg->albireo) break;
@@ -705,10 +708,14 @@ static void activate_item(Overlay *ov) {
             if (ov->cpc) {
                 ov->cpc->albireo_mouse = ov->cfg->albireo_mouse;
                 ov->cpc->ch376.has_mouse = ov->cfg->albireo_mouse;
-                if (ov->cfg->albireo_mouse && ov->cfg->albireo_image[0])
-                    ch376_open(&ov->cpc->ch376_b, ov->cfg->albireo_image);
-                else
-                    ch376_close(&ov->cpc->ch376_b);
+                ov->cpc->ch376_b.has_mouse = false;
+                ch376_close(&ov->cpc->ch376);
+                ch376_close(&ov->cpc->ch376_b);
+                if (ov->cfg->albireo_image[0]) {
+                    CH376 *storage = ov->cfg->albireo_mouse
+                                   ? &ov->cpc->ch376_b : &ov->cpc->ch376;
+                    ch376_open(storage, ov->cfg->albireo_image);
+                }
             }
             ov->needs_cold_boot = true;
             ov->dirty = true;
@@ -1001,11 +1008,14 @@ void overlay_tick(Overlay *ov) {
         ov->cfg->albireo = true;
         if (ov->cpc) {
             ov->cpc->albireo = true;
+            ov->cpc->albireo_mouse = ov->cfg->albireo_mouse;
             ch376_close(&ov->cpc->ch376);
             ch376_close(&ov->cpc->ch376_b);
-            ch376_open(&ov->cpc->ch376, ov->cfg->albireo_image);
-            if (ov->cfg->albireo_mouse)
-                ch376_open(&ov->cpc->ch376_b, ov->cfg->albireo_image);
+            ov->cpc->ch376.has_mouse = ov->cfg->albireo_mouse;
+            ov->cpc->ch376_b.has_mouse = false;
+            CH376 *storage = ov->cfg->albireo_mouse
+                           ? &ov->cpc->ch376_b : &ov->cpc->ch376;
+            ch376_open(storage, ov->cfg->albireo_image);
         }
         ov->dirty = true;
     } else if (ov->dialog_kind == DIALOG_SNAPSHOT_LOAD) {


### PR DESCRIPTION
Closes #122.

Models the [etomuc dual-CH376 MX4 card](https://github.com/etomuc/CPC-USB-Ports-Albireo-compatible-): chip A at \`0xFE80/81\` (original Albireo address) and chip B at \`0xFE40/41\`. SymbOS enumerates the USB HID mouse on chip A and uses chip B for disk I/O, so both stay live in the same session.

## Summary
- Second \`CH376\` instance wired at \`0xFE40/41\` in \`cpc.c\`; only present when the new \`CH376-A Mouse\` toggle is on.
- \`ISSUE_TKN_X\` (0x4E) now accepts EP0 control transfers (SETUP / IN / OUT) for HID class requests after \`SET_CONFIG\`, and the EP1 IN handler returns \`USB_INT_SUCCESS\` with a zero-payload report on idle polls so SymbOS yields cycles to chip B's storage work instead of busy-looping on NAK retries.
- A 4-byte zero buffer is staged on idle so \`RD_USB_DATA0\` reads back zeros instead of stale/0xFF-padded values (kills the up-left cursor drift).
- New \`CH376.has_mouse\` per-chip flag gates EP0/EP1 acceptance — chip B (and chip A when the mouse is off) returns \`USB_INT_DISCONNECT\` on USB tokens, matching original single-chip Albireo behaviour.
- Storage moves between chips at the toggle: single-chip mode → chip A; dual-chip mouse mode → chip B only. Eliminates duplicated \`FILE*\` state.
- Window mouse capture engages on either \`symbiface_mouse\` or \`albireo_mouse\` (\`main.c\`).
- Trace prefix distinguishes \`[albireo-a]\` / \`[albireo-b]\` via a new \`CH376.tag\` field.
- Investigation harness landed alongside (\`debug/issue-122-albireo-mouse/\`).

## Overlay
Two new Extensions tab rows:

- **\`CH376-A Mouse\`** — opt-in HID polling. Mutex with \`SYMBiFACE Mouse\`. Requires \`CH376-B Disk\` to be enabled.
- **\`CH376-B Disk\`** — storage card itself. Coexists freely with either mouse path.

## Test plan
- [x] dual-CH376 on, mouse off → SD access only, original single-chip speed.
- [x] dual-CH376 on, mouse on → mouse + SD work together (user-confirmed; trace shows 817 mouse reports + 834 sector reads in one session).
- [x] dual-CH376 + SymbIface Mouse → no mutex, both available.
- [x] Mouse toggle on/off triggers cold boot and reopens storage on the correct chip.