### PR TITLE
add F10 host mount of card images (closes #142)

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -34,6 +34,7 @@ Each source file maps to one hardware component:
 | `src/z80dis.c` / `z80dis.h` | Z80 disassembler — standalone, no external dependencies |
 | `src/joy.c` / `joy.h` | Joystick/gamepad input — SDL gamepad + raw joystick fallback, hot-plug |
 | `src/main.c` | Entry point — SDL init, event loop, F5/F9/F12/Ctrl+V handling |
+| `src/host_mount.c` / `host_mount.h` | F10 toggle: pauses the guest, calls `guestmount` on every active FAT card image (M4 SD / IDE / Albireo) under `/run/user/$UID/1984/`, opens the host file manager via `xdg-open`. Second F10 unmounts and the main loop cold-boots so the guest's stale FAT cache is dropped. Linux-only; non-Linux stubs return false from `host_mount_open`. See issue #142. |
 
 ---
 

--- a/Development.md
+++ b/Development.md
@@ -33,8 +33,8 @@ Each source file maps to one hardware component:
 | `src/monitor.c` / `monitor.h` | Memory monitor / debugger — 80×25 terminal window, commands, PTY interface |
 | `src/z80dis.c` / `z80dis.h` | Z80 disassembler — standalone, no external dependencies |
 | `src/joy.c` / `joy.h` | Joystick/gamepad input — SDL gamepad + raw joystick fallback, hot-plug |
-| `src/main.c` | Entry point — SDL init, event loop, F5/F9/F12/Ctrl+V handling |
-| `src/host_mount.c` / `host_mount.h` | F10 toggle: pauses the guest, calls `guestmount` on every active FAT card image (M4 SD / IDE / Albireo) under `/run/user/$UID/1984/`, opens the host file manager via `xdg-open`. Second F10 unmounts and the main loop cold-boots so the guest's stale FAT cache is dropped. Linux-only; non-Linux stubs return false from `host_mount_open`. See issue #142. |
+| `src/main.c` | Entry point — SDL init, event loop, F5/F9/F10/F12/Ctrl+V handling |
+| `src/host_mount.c` / `host_mount.h` | F10 toggle: pauses the guest and mounts every active FAT card image (M4 SD / IDE / Albireo) on the host so the user can drag files in / out. Backend cascade per card: `gnome-disk-image-mounter` → bare `udisksctl loop-setup`+`mount` → libguestfs `guestmount`. udisks mounts land in `/run/media/$USER/<label>/` as first-class GNOME removable volumes; the guestmount fallback uses `~/.cache/1984/mounts/`. Press F10 again, or eject the card from the file manager (polled via `findmnt` once per frame), to unmount. The main loop then sets `overlay.needs_cold_boot` so the guest's stale FAT cache is dropped on resume. Linux-only; non-Linux stubs return false from `host_mount_open`. Issue #142. |
 
 ---
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,7 @@ bin_PROGRAMS = 1984
 	src/ch376.c \
 	src/gifcap.c \
 	src/webmcap.c \
+	src/host_mount.c \
 	src/leds.c \
 	src/m4.c \
 	src/symbnet.c \
@@ -50,6 +51,7 @@ noinst_HEADERS = \
 	src/gate_array.h \
 	src/gifcap.h \
 	src/webmcap.h \
+	src/host_mount.h \
 	src/ide.h \
 	src/joy.h \
 	src/kbd.h \

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Boots to Locomotive BASIC. Commercial games and standard software run well. Demo
 
 **Input** — keyboard, host-clipboard paste, USB/Bluetooth joystick and gamepad with hot-plug.
 
+**Host file exchange** — F10 pauses the guest and mounts every active card image (M4 SD / IDE / Albireo) on the host so files can be dragged in or out from the file manager. Uses `gnome-disk-image-mounter` / `udisksctl` for first-class Nautilus integration, with `guestmount` as a fallback. Press F10 again or eject the card from the file manager to unmount, sync, and cold-boot.
+
 **Capture** — F4 still-screenshot (`.ppm`), F6 GIF screen-recording (in-tree LZW encoder, no dependencies), and WebM/VP9 recording via `ffmpeg` (optional, detected by `./configure`) — YouTube-native.
 
 **Extensions** — DDI-1 floppy interface (464), DS12887 RTC (Cyboard / SYMBiFACE II), SYMBiFACE II / Cyboard IDE (FAT16/FAT32 disk images), SYMBiFACE II PS/2 mouse, Albireo USB mass-storage (CH376 host controller, driven by UNIDOS), **Net4CPC Ethernet (W5100S) with one-click TAP backend on Linux — auto-creates the tap device, runs a built-in DHCP server, DNS proxy, and NAT to the host network. The CPC is fully on the LAN: pingable from the host, accepts inbound connections, and DHCP works end-to-end (verified in HDCPM + SymbOS)**, Amstrad Diagnostics ROM as a one-click toggle. Per-board ROM groupings (`Ins` in the ROM Slots menu) tag each slot with the boards that need it — M4 / Albireo / Cyboard — so enabling a board auto-loads its ROMs and cached disk image; disabling clears them. No re-prompt for paths between sessions.
@@ -59,7 +61,7 @@ Pre-built Linux and Windows binaries are attached to each [GitHub Release](https
 ## Documentation
 
 - **[INSTALL.md](INSTALL.md)** — installing pre-built binaries, building from source on each supported platform, ROM file requirements
-- **[USAGE.md](USAGE.md)** — command-line options, keyboard shortcuts, joystick mapping, options overlay (F9), memory monitor (F8), config file format
+- **[USAGE.md](USAGE.md)** — command-line options, keyboard shortcuts, joystick mapping, options overlay (F9), memory monitor (F8), F10 host-side card browse, config file format
 - **[Development.md](Development.md)** — architecture, render pipeline, hardware emulation details, CI, port-specific notes (Haiku / NetBSD / Windows)
 
 Per-expansion guides:

--- a/USAGE.md
+++ b/USAGE.md
@@ -66,11 +66,23 @@ Passing an unrecognised option prints the usage summary to stderr and exits with
 
 ### F10 — browse card images on the host
 
-Pressing **F10** pauses the emulated CPC and FUSE-mounts every active card image under `/run/user/$UID/1984/{m4,ide,albireo}/`, then opens that root in the host file manager (via `xdg-open`). Drag files in or out as you would with any folder. Press **F10 again** to unmount, sync, and cold-boot the emulator so the guest re-reads the FAT cleanly. Cold-boot is mandatory because the guest's in-RAM FAT cache would otherwise overwrite your changes on the next sync.
+Pressing **F10** pauses the emulated CPC and mounts every active card image (M4 SD / IDE / Albireo) on the host, then opens the file manager at the mount root. Drag files in or out as you would with any folder.
 
-Floppies (`.DSK`) are not supported (AMSDOS, not FAT — `guestmount` can't read them). M4 in directory mode (`m4_path` set, no `m4_image`) is skipped since the host directory is already directly accessible.
+To finish browsing: either **press F10 again**, or **eject the card from the file manager** (the eject button next to the mounted volume in Nautilus' sidebar). Either way 1984 unmounts, syncs, and cold-boots so the guest re-reads the FAT cleanly. Cold-boot is mandatory because the guest's in-RAM FAT cache would otherwise overwrite your changes on the next sync.
 
-On Fedora install with `sudo dnf install libguestfs-tools xdg-utils`; on Debian/Ubuntu `sudo apt install libguestfs-tools xdg-utils`. If either tool is missing, F10 logs to stderr and is otherwise a no-op.
+Mount backend cascade (best path wins per card):
+
+1. **`gnome-disk-image-mounter`** if present (modern GNOME). Mount lands under `/run/media/$USER/<label>/` as a first-class removable volume that Nautilus / Files treat natively — drag/drop just works.
+2. **`udisksctl loop-setup + mount`** for non-GNOME desktops (KDE / XFCE). Same end result, no GTK dialog.
+3. **`guestmount`** (libguestfs) as last resort. Mount lives in `~/.cache/1984/mounts/`. GNOME Files refuses drag/drop into FUSE mounts so this tier is browse-from-CLI only.
+
+Floppies (`.DSK`) are not supported (AMSDOS filesystem, not FAT). M4 in directory mode (`m4_path` set, no `m4_image`) is skipped since the host directory is already directly accessible.
+
+Install:
+- Fedora: `sudo dnf install udisks2 gnome-disk-utility libguestfs-tools xdg-utils`
+- Debian/Ubuntu: `sudo apt install udisks2 gnome-disk-utility libguestfs-tools xdg-utils`
+
+If no backend is available, F10 logs to stderr and is otherwise a no-op.
 | Ctrl+Enter | Release captured mouse (if SYMBiFACE mouse is active) |
 
 ## Joystick / gamepad

--- a/USAGE.md
+++ b/USAGE.md
@@ -59,9 +59,18 @@ Passing an unrecognised option prints the usage summary to stderr and exits with
 | F6     | Toggle GIF screen recording (auto-named `1984-<timestamp>.gif` in CWD) |
 | F8     | Open/close memory monitor / debugger |
 | F9     | Open/close options overlay |
+| F10    | Mount the active card images (M4 SD / IDE / Albireo) on the host and open the file manager; press again to unmount and cold-boot. **Linux only**, needs `libguestfs-tools` (`guestmount`, `guestunmount`) and `xdg-utils` installed. |
 | F11    | Toggle fullscreen |
 | F12    | Quit |
 | Ctrl+V | Paste clipboard text into the emulator |
+
+### F10 — browse card images on the host
+
+Pressing **F10** pauses the emulated CPC and FUSE-mounts every active card image under `/run/user/$UID/1984/{m4,ide,albireo}/`, then opens that root in the host file manager (via `xdg-open`). Drag files in or out as you would with any folder. Press **F10 again** to unmount, sync, and cold-boot the emulator so the guest re-reads the FAT cleanly. Cold-boot is mandatory because the guest's in-RAM FAT cache would otherwise overwrite your changes on the next sync.
+
+Floppies (`.DSK`) are not supported (AMSDOS, not FAT — `guestmount` can't read them). M4 in directory mode (`m4_path` set, no `m4_image`) is skipped since the host directory is already directly accessible.
+
+On Fedora install with `sudo dnf install libguestfs-tools xdg-utils`; on Debian/Ubuntu `sudo apt install libguestfs-tools xdg-utils`. If either tool is missing, F10 logs to stderr and is otherwise a no-op.
 | Ctrl+Enter | Release captured mouse (if SYMBiFACE mouse is active) |
 
 ## Joystick / gamepad

--- a/src/display.c
+++ b/src/display.c
@@ -104,8 +104,10 @@ void display_flip(Display *d) {
 }
 
 void display_apply_greyscale(Display *d) {
-    /* XRGB8888 in CPU-native byte order. Rec. 601 luma:
-     * Y ≈ 0.299 R + 0.587 G + 0.114 B (fixed-point ×1024). */
+    /* XRGB8888 in CPU-native byte order. Rec. 601 luma then dim toward
+     * mid-grey so the foreground label has high contrast against the
+     * frozen frame. Without the dimming a bright CPC border (e.g. white
+     * paper mode) drowns out the label. */
     u32 *p = d->pixels;
     int  n = CPC_SCREEN_W * CPC_SCREEN_H;
     for (int i = 0; i < n; i++) {
@@ -114,8 +116,12 @@ void display_apply_greyscale(Display *d) {
         unsigned g = (px >>  8) & 0xFF;
         unsigned b =  px        & 0xFF;
         unsigned y = (306u * r + 601u * g + 117u * b) >> 10;   /* /1024 */
-        if (y > 255) y = 255;
-        p[i] = (y << 16) | (y << 8) | y;
+        /* Compress range to roughly 32..96 around mid-grey — keeps shapes
+         * recognisable but tones the whole frame down so white overlay
+         * text reads cleanly. */
+        unsigned dim = 32 + ((y * 64) >> 8);
+        if (dim > 255) dim = 255;
+        p[i] = (dim << 16) | (dim << 8) | dim;
     }
 }
 
@@ -123,18 +129,33 @@ void display_draw_paused_label(Display *d) {
     int ww, wh;
     SDL_GetWindowSize(d->window, &ww, &wh);
     /* SDL3's debug font glyphs are 8x8, scaled by the renderer's draw
-     * scale. Pick a chunky scale so "PAUSED" reads at any window size. */
-    float scale = (float)ww / 320.0f;
-    if (scale < 2.0f) scale = 2.0f;
-    SDL_SetRenderScale(d->renderer, scale, scale);
-    const char *txt = "PAUSED";
-    int text_w = (int)(strlen(txt) * 8);   /* in pre-scale pixels */
-    int text_h = 8;
-    float x = (ww / scale - text_w) / 2.0f;
-    float y = (wh / scale - text_h) / 2.0f;
+     * scale. Pick a chunky scale for "PAUSED"; the secondary hint sits
+     * just below at a smaller scale. */
+    float big   = (float)ww / 320.0f;       /* "PAUSED" — ~4x at 1280, 2.4x at 768 */
+    float small = (float)ww / 640.0f;       /* "Press F10 to resume" — half as big */
+    if (big   < 2.0f) big   = 2.0f;
+    if (small < 1.0f) small = 1.0f;
+
+    const char *main_txt = "PAUSED";
+    const char *hint_txt = "Press F10 to resume";
+
     SDL_SetRenderDrawBlendMode(d->renderer, SDL_BLENDMODE_NONE);
     SDL_SetRenderDrawColor(d->renderer, 0xFF, 0xFF, 0xFF, 0xFF);
-    SDL_RenderDebugText(d->renderer, x, y, txt);
+
+    /* "PAUSED" — slightly above centre so the hint fits below. */
+    SDL_SetRenderScale(d->renderer, big, big);
+    int main_w = (int)(strlen(main_txt) * 8);
+    float main_x = (ww / big - main_w) / 2.0f;
+    float main_y = (wh / big) / 2.0f - 12.0f;   /* shift up by ~ one glyph */
+    SDL_RenderDebugText(d->renderer, main_x, main_y, main_txt);
+
+    /* Hint line just below. */
+    SDL_SetRenderScale(d->renderer, small, small);
+    int hint_w = (int)(strlen(hint_txt) * 8);
+    float hint_x = (ww / small - hint_w) / 2.0f;
+    float hint_y = (wh / small) / 2.0f + 12.0f * (big / small);
+    SDL_RenderDebugText(d->renderer, hint_x, hint_y, hint_txt);
+
     SDL_SetRenderScale(d->renderer, 1.0f, 1.0f);
 }
 

--- a/src/display.c
+++ b/src/display.c
@@ -103,6 +103,41 @@ void display_flip(Display *d) {
     SDL_RenderPresent(d->renderer);
 }
 
+void display_apply_greyscale(Display *d) {
+    /* XRGB8888 in CPU-native byte order. Rec. 601 luma:
+     * Y ≈ 0.299 R + 0.587 G + 0.114 B (fixed-point ×1024). */
+    u32 *p = d->pixels;
+    int  n = CPC_SCREEN_W * CPC_SCREEN_H;
+    for (int i = 0; i < n; i++) {
+        u32 px = p[i];
+        unsigned r = (px >> 16) & 0xFF;
+        unsigned g = (px >>  8) & 0xFF;
+        unsigned b =  px        & 0xFF;
+        unsigned y = (306u * r + 601u * g + 117u * b) >> 10;   /* /1024 */
+        if (y > 255) y = 255;
+        p[i] = (y << 16) | (y << 8) | y;
+    }
+}
+
+void display_draw_paused_label(Display *d) {
+    int ww, wh;
+    SDL_GetWindowSize(d->window, &ww, &wh);
+    /* SDL3's debug font glyphs are 8x8, scaled by the renderer's draw
+     * scale. Pick a chunky scale so "PAUSED" reads at any window size. */
+    float scale = (float)ww / 320.0f;
+    if (scale < 2.0f) scale = 2.0f;
+    SDL_SetRenderScale(d->renderer, scale, scale);
+    const char *txt = "PAUSED";
+    int text_w = (int)(strlen(txt) * 8);   /* in pre-scale pixels */
+    int text_h = 8;
+    float x = (ww / scale - text_w) / 2.0f;
+    float y = (wh / scale - text_h) / 2.0f;
+    SDL_SetRenderDrawBlendMode(d->renderer, SDL_BLENDMODE_NONE);
+    SDL_SetRenderDrawColor(d->renderer, 0xFF, 0xFF, 0xFF, 0xFF);
+    SDL_RenderDebugText(d->renderer, x, y, txt);
+    SDL_SetRenderScale(d->renderer, 1.0f, 1.0f);
+}
+
 void display_save_ppm(Display *d, const char *path) {
     FILE *f = fopen(path, "wb");
     if (!f) return;

--- a/src/display.h
+++ b/src/display.h
@@ -37,3 +37,12 @@ void display_save_ppm(Display *d, const char *path);
 
 /* Switch texture scaling between linear (smooth) and nearest (sharp). */
 void display_set_smoothing(Display *d, bool smooth);
+
+/* In-place desaturate the current framebuffer (Rec. 601 luma). Used when
+ * the emulator pauses so the frozen frame visibly differs from a running
+ * one. The next live frame from cpc_frame() overwrites this. */
+void display_apply_greyscale(Display *d);
+
+/* Draw a "PAUSED" label centred on the renderer. Call after
+ * display_upload(), before display_flip(). */
+void display_draw_paused_label(Display *d);

--- a/src/host_mount.c
+++ b/src/host_mount.c
@@ -1,9 +1,22 @@
-/* F10 guestmount feature — see issue #142.
+/* F10 host-mount feature — see issue #142.
  *
- * Pauses the emulator, calls libguestfs's `guestmount` on every active FAT
- * card image (M4 SD, IDE, Albireo USB), and opens the host file manager
- * at the mount root. The caller (main.c) is responsible for triggering a
- * cold reboot on close so the guest's stale FAT cache is discarded. */
+ * Pauses the emulator and mounts every active FAT card image on the host
+ * so the user can drag files in / out from the file manager. On close,
+ * unmount + cold-boot drops the guest's stale FAT cache.
+ *
+ * Two mount backends, tried in this order:
+ *
+ *   1. udisksctl loop-setup + udisksctl mount.
+ *      Mount appears under /run/media/$USER/<label or UUID>/ as a
+ *      first-class removable volume that Nautilus, Files, Dolphin, etc.
+ *      treat natively — drag/drop works in the GUI without any FUSE
+ *      caveats. Needs udisks2 (default on every modern desktop).
+ *
+ *   2. libguestfs guestmount.
+ *      Works without a session bus / polkit, useful for headless setups
+ *      and minimal installs. Mount is in ~/.cache/1984/mounts/<label>/.
+ *      Note that GNOME Files refuses drag/drop into FUSE mounts.
+ */
 
 /* popen/pclose live behind POSIX feature flags under -std=c11. */
 #define _POSIX_C_SOURCE 200809L
@@ -20,19 +33,33 @@
 #include <sys/wait.h>
 #endif
 
-#define GUESTMOUNT_BIN "/usr/bin/guestmount"
-#define GUESTUNMOUNT_BIN "/usr/bin/guestunmount"
-#define XDG_OPEN_BIN   "/usr/bin/xdg-open"
+#define GUESTMOUNT_BIN     "/usr/bin/guestmount"
+#define GUESTUNMOUNT_BIN   "/usr/bin/guestunmount"
+#define UDISKSCTL_BIN      "/usr/bin/udisksctl"
+#define GNOME_MOUNTER_BIN  "/usr/bin/gnome-disk-image-mounter"
+#define XDG_OPEN_BIN       "/usr/bin/xdg-open"
+
+#ifdef __linux__
+static bool have_udisks(void) {
+    static int cached = -1;
+    if (cached < 0)
+        cached = (access(UDISKSCTL_BIN, X_OK) == 0) ? 1 : 0;
+    return cached == 1;
+}
+
+static bool have_guestmount(void) {
+    static int cached = -1;
+    if (cached < 0)
+        cached = (access(GUESTMOUNT_BIN, X_OK) == 0 &&
+                  access(GUESTUNMOUNT_BIN, X_OK) == 0) ? 1 : 0;
+    return cached == 1;
+}
+#endif
 
 bool host_mount_supported(void) {
 #ifdef __linux__
-    static int cached = -1;
-    if (cached < 0) {
-        cached = (access(GUESTMOUNT_BIN, X_OK) == 0
-               && access(GUESTUNMOUNT_BIN, X_OK) == 0
-               && access(XDG_OPEN_BIN, X_OK) == 0) ? 1 : 0;
-    }
-    return cached == 1;
+    if (access(XDG_OPEN_BIN, X_OK) != 0) return false;
+    return have_udisks() || have_guestmount();
 #else
     return false;
 #endif
@@ -40,18 +67,48 @@ bool host_mount_supported(void) {
 
 #ifdef __linux__
 
+/* Read all of `p` into `buf` (NUL-terminated, capped at sz-1). */
+static void slurp(FILE *p, char *buf, size_t sz) {
+    size_t n = fread(buf, 1, sz - 1, p);
+    buf[n] = '\0';
+}
+
+/* Run `cmd` synchronously, capture stdout+stderr into out. Returns the
+ * pclose exit status (0 on success). */
+static int run_capture(const char *cmd, char *out, size_t sz) {
+    out[0] = '\0';
+    FILE *p = popen(cmd, "r");
+    if (!p) return -1;
+    slurp(p, out, sz);
+    return pclose(p);
+}
+
+/* Scan `text` for the first match of `prefix`; copy the following
+ * non-whitespace token into `dst`. Returns true if found. */
+static bool extract_token_after(const char *text, const char *prefix,
+                                char *dst, size_t sz) {
+    const char *p = strstr(text, prefix);
+    if (!p) return false;
+    p += strlen(prefix);
+    while (*p == ' ' || *p == '\t') p++;
+    size_t i = 0;
+    while (*p && *p != ' ' && *p != '\t' && *p != '\n' && i + 1 < sz)
+        dst[i++] = *p++;
+    dst[i] = '\0';
+    /* Strip a trailing '.' that udisksctl prints. */
+    if (i && dst[i - 1] == '.') dst[i - 1] = '\0';
+    return dst[0] != '\0';
+}
+
 static void build_root(char *out, size_t sz) {
-    /* Mount under the user's home rather than /run/user/$UID. GNOME Files
-     * (Nautilus) treats /run/user/* with a different SELinux context and
-     * silently refuses pastes from the GUI even when the underlying FUSE
-     * mount is fully writable from the shell. ~/.cache is XDG-spec for
-     * ephemeral state and inherits user_home_t — Nautilus is happy. */
+    /* Used only for the guestmount fallback. ~/.cache is a user-home path
+     * with the right SELinux context (user_home_t), unlike /run/user
+     * which Nautilus treats as foreign. */
     const char *home = getenv("HOME");
     if (!home || !home[0]) home = ".";
     snprintf(out, sz, "%s/.cache/1984/mounts", home);
 }
 
-/* mkdir -p equivalent. Returns true if the directory exists / was made. */
 static bool mkdir_p(const char *path) {
     char tmp[256];
     snprintf(tmp, sizeof(tmp), "%s", path);
@@ -66,41 +123,132 @@ static bool mkdir_p(const char *path) {
     return access(path, W_OK) == 0;
 }
 
-/* Try to mount `image` at `path` via guestmount. Returns true on success.
- *
- * libguestfs's `-i` inspector wants to identify a "guest OS" (Linux,
- * Windows, …); CPC card images don't have one, so we mount the FS
- * directly. Try /dev/sda1 first (partitioned images: M4 SymbOS SD, IDE
- * formatted by CP/M Plus, …), then fall back to /dev/sda (bare-FAT
- * images with no partition table — common for small USB sticks). */
+/* Resolve the loop device backing a given image file by parsing
+ * `losetup -j <image>` output ("/dev/loopN: …"). Used after
+ * gnome-disk-image-mounter, which doesn't tell us what it attached. */
+static bool find_loop_for_image(const char *image, char *out, size_t sz) {
+    char cmd[512], buf[1024];
+    snprintf(cmd, sizeof(cmd), "losetup -j '%s' 2>/dev/null", image);
+    if (run_capture(cmd, buf, sizeof(buf)) != 0) return false;
+    char *colon = strchr(buf, ':');
+    if (!colon || colon == buf) return false;
+    size_t n = (size_t)(colon - buf);
+    if (n >= sz) n = sz - 1;
+    memcpy(out, buf, n);
+    out[n] = '\0';
+    return true;
+}
+
+/* Attach `image` as a loop device. Prefer gnome-disk-image-mounter (sets
+ * up the loop, auto-mounts via udisks, integrates with GNOME Files —
+ * user-confirmed "always works"); fall back to bare `udisksctl
+ * loop-setup` for non-GNOME / minimal installs. On success writes
+ * /dev/loopN into loop_dev_out. */
+static bool udisks_loop_setup(const char *image, char *loop_dev_out, size_t sz) {
+    char cmd[1024], out[1024];
+
+    if (access(GNOME_MOUNTER_BIN, X_OK) == 0) {
+        snprintf(cmd, sizeof(cmd),
+                 "%s --writable '%s' 2>&1",
+                 GNOME_MOUNTER_BIN, image);
+        if (run_capture(cmd, out, sizeof(out)) == 0) {
+            /* gnome-disk-image-mounter prints nothing useful — it just
+             * spawns the udisks call and returns. Find the loop device
+             * it attached by image path. */
+            if (find_loop_for_image(image, loop_dev_out, sz))
+                return true;
+        }
+        /* Fall through to bare udisksctl if the GNOME wrapper failed. */
+    }
+
+    snprintf(cmd, sizeof(cmd),
+             "%s loop-setup --file='%s' --no-user-interaction 2>&1",
+             UDISKSCTL_BIN, image);
+    int rc = run_capture(cmd, out, sizeof(out));
+    if (rc != 0) {
+        fprintf(stderr, "host_mount: loop-setup failed for %s: %s",
+                image, out);
+        return false;
+    }
+    /* "Mapped file <image> as /dev/loopN." */
+    return extract_token_after(out, "as ", loop_dev_out, sz);
+}
+
+/* Query the current mount point of a device via findmnt. Returns true if
+ * the device is mounted somewhere. */
+static bool findmnt_target(const char *dev, char *out, size_t sz) {
+    char cmd[256], buf[512];
+    snprintf(cmd, sizeof(cmd), "findmnt -n -o TARGET %s 2>/dev/null", dev);
+    if (run_capture(cmd, buf, sizeof(buf)) != 0) return false;
+    /* Strip trailing newline. */
+    size_t n = strlen(buf);
+    while (n && (buf[n-1] == '\n' || buf[n-1] == ' ')) buf[--n] = '\0';
+    if (!n) return false;
+    snprintf(out, sz, "%s", buf);
+    return true;
+}
+
+/* udisks mount of an attached loop device. Writes the resulting mount
+ * point into mountpoint_out. gnome-disk-image-mounter often auto-mounts
+ * before we get here, so we always check findmnt first. */
+static bool udisks_mount(const char *loop_dev, char *mountpoint_out, size_t sz) {
+    char cmd[512], out[1024];
+    char part[80];
+    snprintf(part, sizeof(part), "%sp1", loop_dev);
+
+    /* If already mounted (auto-mount by gnome-disk-image-mounter), we're
+     * done — just record where it ended up. */
+    if (findmnt_target(part,     mountpoint_out, sz)) return true;
+    if (findmnt_target(loop_dev, mountpoint_out, sz)) return true;
+
+    /* Not auto-mounted yet — issue an explicit udisksctl mount. Try
+     * partition first (most images), then bare device (no PT). */
+    const char *targets[] = { part, loop_dev };
+    for (size_t i = 0; i < sizeof(targets)/sizeof(targets[0]); i++) {
+        snprintf(cmd, sizeof(cmd),
+                 "%s mount -b %s --no-user-interaction 2>&1",
+                 UDISKSCTL_BIN, targets[i]);
+        int rc = run_capture(cmd, out, sizeof(out));
+        if (rc == 0 && extract_token_after(out, " at ", mountpoint_out, sz))
+            return true;
+        /* Race: another process auto-mounted between our findmnt and now. */
+        if (findmnt_target(targets[i], mountpoint_out, sz)) return true;
+    }
+    fprintf(stderr, "host_mount: udisksctl mount failed for %s: %s",
+            loop_dev, out);
+    return false;
+}
+
+/* Tear down a previously-attached loop. Order matters: unmount first,
+ * then delete the loop device. udisks-based unmount also nukes the
+ * auto-created /run/media/$USER/<label> directory. */
+static void udisks_teardown(const char *loop_dev) {
+    if (!loop_dev || !loop_dev[0]) return;
+    char cmd[512], out[1024];
+    /* Unmount partition (if present) and whole device. */
+    char part[80];
+    snprintf(part, sizeof(part), "%sp1", loop_dev);
+    snprintf(cmd, sizeof(cmd),
+             "%s unmount -b %s --no-user-interaction 2>&1",
+             UDISKSCTL_BIN, part);
+    (void)run_capture(cmd, out, sizeof(out));
+    snprintf(cmd, sizeof(cmd),
+             "%s unmount -b %s --no-user-interaction 2>&1",
+             UDISKSCTL_BIN, loop_dev);
+    (void)run_capture(cmd, out, sizeof(out));
+    snprintf(cmd, sizeof(cmd),
+             "%s loop-delete -b %s --no-user-interaction 2>&1",
+             UDISKSCTL_BIN, loop_dev);
+    (void)run_capture(cmd, out, sizeof(out));
+}
+
+/* guestmount fallback. Two axes of retry (backend + allow_other). */
 static bool guestmount_image(const char *image, const char *path) {
     static const char *mount_specs[] = { "/dev/sda1", "/dev/sda" };
-    char cmd[1024];
-    /* FUSE options for full user ownership:
-     *   uid/gid       — every file and directory appears owned by us
-     *   umask=0       — no permission bits are masked out (rwx for owner)
-     *   allow_other   — needed when the file manager runs in a separate
-     *                   sandbox/namespace (Flatpak Nautilus, etc.). FUSE
-     *                   only honours this if /etc/fuse.conf has
-     *                   `user_allow_other`; if it doesn't, the option is
-     *                   rejected, so we try with-and-without.
-     *
-     * LIBGUESTFS_BACKEND=direct forces libguestfs to spawn qemu itself
-     * rather than going through libvirt. Fedora ships libguestfs with the
-     * libvirt backend by default, which fails on most desktops (libvirtd
-     * permissions, qemu-system-x86_64 stdin closure, …); the direct
-     * backend is simpler, doesn't need libvirtd running, and is what most
-     * non-server users actually want. */
+    static const char *backends[]    = { "", "LIBGUESTFS_BACKEND=direct " };
     unsigned uid = (unsigned)getuid();
     unsigned gid = (unsigned)getgid();
-    /* Two axes of fallback:
-     *   - backend: system default first, then explicit `direct` (some
-     *     systems have a broken libvirt backend; others have a broken
-     *     direct backend — neither is universal).
-     *   - allow_other: off first (native Nautilus refuses GUI pastes on
-     *     FUSE mounts that advertise allow_other), on second (sandboxed
-     *     Flatpak file managers need it). */
-    static const char *backends[] = { "", "LIBGUESTFS_BACKEND=direct " };
+    char cmd[1024], errbuf[512];
     for (size_t b = 0; b < sizeof(backends)/sizeof(backends[0]); b++) {
         for (int try_allow_other = 0; try_allow_other <= 1; try_allow_other++) {
             for (size_t i = 0; i < sizeof(mount_specs)/sizeof(mount_specs[0]); i++) {
@@ -111,11 +259,7 @@ static bool guestmount_image(const char *image, const char *path) {
                          uid, gid,
                          try_allow_other ? ",allow_other" : "",
                          path);
-                FILE *p = popen(cmd, "r");
-                if (!p) continue;
-                char errbuf[512] = {0};
-                (void)fread(errbuf, 1, sizeof(errbuf) - 1, p);
-                int rc = pclose(p);
+                int rc = run_capture(cmd, errbuf, sizeof(errbuf));
                 if (rc == 0) return true;
                 if (errbuf[0])
                     fprintf(stderr, "host_mount: guestmount[%s%s,%s]: %s",
@@ -126,43 +270,30 @@ static bool guestmount_image(const char *image, const char *path) {
             }
         }
     }
-    fprintf(stderr, "host_mount: guestmount failed for %s\n", image);
     return false;
 }
 
-static void guestunmount_path(const char *path) {
-    char cmd[1024];
+static void guestmount_unmount(const char *path) {
+    char cmd[512], out[256];
     snprintf(cmd, sizeof(cmd), "%s '%s' 2>&1", GUESTUNMOUNT_BIN, path);
-    int rc = system(cmd);
-    if (rc != 0)
-        fprintf(stderr, "host_mount: guestunmount failed for %s (exit=%d)\n",
-                path, rc);
+    (void)run_capture(cmd, out, sizeof(out));
 }
 
-/* Fork + exec xdg-open so the file manager runs detached from us. We
- * don't wait for it — the user closes it when they're done. */
+/* Fork + exec xdg-open detached so the file manager runs independently. */
 static void spawn_filemanager(const char *path) {
     pid_t pid = fork();
-    if (pid < 0) {
-        fprintf(stderr, "host_mount: fork failed for xdg-open\n");
-        return;
-    }
+    if (pid < 0) return;
     if (pid == 0) {
-        /* Detach from controlling terminal so closing the emulator window
-         * later doesn't reap the file manager too. */
         setsid();
         execl(XDG_OPEN_BIN, "xdg-open", path, (char *)NULL);
-        _exit(127);   /* exec failed */
+        _exit(127);
     }
-    /* Parent: reap the immediate child (xdg-open is itself a launcher
-     * that double-forks; we won't get a zombie). */
     int status;
     waitpid(pid, &status, WNOHANG);
 }
 
 /* Append a slot to hm if `image` is a non-empty path to a readable file.
- * Creates the mount-point directory. Does NOT mount yet — that happens in
- * a second pass so we can short-circuit cleanly when nothing is eligible. */
+ * Doesn't mount — that happens in a second pass. */
 static void stage_slot(HostMount *hm, const char *label, const char *image) {
     if (!image || image[0] == '\0') return;
     if (access(image, R_OK) != 0) {
@@ -172,24 +303,17 @@ static void stage_slot(HostMount *hm, const char *label, const char *image) {
     if (hm->count >= HOST_MOUNT_MAX_SLOTS) return;
 
     HostMountSlot *s = &hm->slots[hm->count];
+    memset(s, 0, sizeof(*s));
     snprintf(s->label, sizeof(s->label), "%s", label);
-    snprintf(s->path,  sizeof(s->path),  "%s/%s", hm->root, label);
     s->image = image;
     hm->count++;
 }
 
 bool host_mount_open(HostMount *hm, const Config *cfg) {
     memset(hm, 0, sizeof(*hm));
-    build_root(hm->root, sizeof(hm->root));
 
-    /* Only mount cards whose hardware toggle is actually on. A stale
-     * cfg->*_image from a previously-enabled card would otherwise get
-     * mounted even when that card isn't wired this session — confusing
-     * for the user and a guaranteed guestmount failure if the file is
-     * a non-FAT format (e.g. a CP/M-formatted IDE image).
-     *
-     * M4 directory mode (cfg->m4_path set) serves files from a host
-     * directory already — no sector image, so skip the M4 slot. */
+    /* Only mount cards whose hardware toggle is actually on. M4 directory
+     * mode (cfg->m4_path) serves files from the host already — skip M4. */
     if (cfg->m4 && !cfg->m4_path[0])
         stage_slot(hm, "m4",      cfg->m4_image);
     if (cfg->symbiface_ide)
@@ -199,46 +323,92 @@ bool host_mount_open(HostMount *hm, const Config *cfg) {
 
     if (hm->count == 0) return false;
 
-    if (!mkdir_p(hm->root)) {
-        fprintf(stderr, "host_mount: cannot create %s\n", hm->root);
-        hm->count = 0;
-        return false;
-    }
-
     int mounted = 0;
+    char first_path[256] = "";
+
     for (int i = 0; i < hm->count; i++) {
         HostMountSlot *s = &hm->slots[i];
-        mkdir(s->path, 0700);   /* may already exist from a prior abort */
-        if (guestmount_image(s->image, s->path)) {
-            mounted++;
-        } else {
-            /* Mark this slot as not actually mounted so close() skips it. */
+
+        /* Primary: udisksctl. Mounts under /run/media/$USER/<label>/ as
+         * a first-class GNOME/KDE removable volume — Nautilus etc. treat
+         * drag/drop natively. */
+        if (have_udisks() && udisks_loop_setup(s->image, s->loop_dev,
+                                                sizeof(s->loop_dev))) {
+            if (udisks_mount(s->loop_dev, s->path, sizeof(s->path))) {
+                s->via = HOST_MOUNT_UDISKS;
+                mounted++;
+                if (!first_path[0])
+                    snprintf(first_path, sizeof(first_path), "%s", s->path);
+                continue;
+            }
+            /* mount failed — tear down the loop we just set up. */
+            udisks_teardown(s->loop_dev);
+            s->loop_dev[0] = '\0';
+        }
+
+        /* Fallback: guestmount under ~/.cache/1984/mounts/<label>/ */
+        if (have_guestmount()) {
+            if (!hm->root[0]) {
+                build_root(hm->root, sizeof(hm->root));
+                mkdir_p(hm->root);
+            }
+            snprintf(s->path, sizeof(s->path), "%s/%s", hm->root, s->label);
+            mkdir(s->path, 0700);
+            if (guestmount_image(s->image, s->path)) {
+                s->via = HOST_MOUNT_GUESTMOUNT;
+                mounted++;
+                if (!first_path[0])
+                    snprintf(first_path, sizeof(first_path), "%s", s->path);
+                continue;
+            }
             rmdir(s->path);
             s->path[0] = '\0';
         }
+
+        fprintf(stderr, "host_mount: no working mount backend for %s\n", s->image);
     }
 
     if (mounted == 0) {
-        rmdir(hm->root);
+        if (hm->root[0]) rmdir(hm->root);
         hm->count = 0;
         return false;
     }
 
-    spawn_filemanager(hm->root);
-    fprintf(stderr, "host_mount: mounted %d card(s) under %s\n",
-            mounted, hm->root);
+    /* udisks mounts land in /run/media/$USER/<label>; opening the parent
+     * shows every mounted card as a sibling. guestmount mounts live in
+     * hm->root. If we have a mix, pick whichever path actually exists. */
+    const char *open_target = NULL;
+    char parent[256];
+    if (mounted >= 1 && hm->slots[0].via == HOST_MOUNT_UDISKS) {
+        const char *slash = strrchr(first_path, '/');
+        if (slash && slash > first_path) {
+            size_t n = (size_t)(slash - first_path);
+            if (n < sizeof(parent)) {
+                memcpy(parent, first_path, n);
+                parent[n] = '\0';
+                open_target = parent;
+            }
+        }
+    }
+    if (!open_target) open_target = hm->root[0] ? hm->root : first_path;
+
+    spawn_filemanager(open_target);
+    fprintf(stderr, "host_mount: mounted %d card(s); opened %s\n",
+            mounted, open_target);
     return true;
 }
 
 bool host_mount_close(HostMount *hm) {
     for (int i = 0; i < hm->count; i++) {
         HostMountSlot *s = &hm->slots[i];
-        if (s->path[0]) {
-            guestunmount_path(s->path);
+        if (s->via == HOST_MOUNT_UDISKS) {
+            udisks_teardown(s->loop_dev);
+        } else if (s->via == HOST_MOUNT_GUESTMOUNT && s->path[0]) {
+            guestmount_unmount(s->path);
             rmdir(s->path);
         }
     }
-    rmdir(hm->root);
+    if (hm->root[0]) rmdir(hm->root);
     memset(hm, 0, sizeof(*hm));
     return true;
 }

--- a/src/host_mount.c
+++ b/src/host_mount.c
@@ -51,10 +51,16 @@ static void build_root(char *out, size_t sz) {
 static bool guestmount_image(const char *image, const char *path) {
     static const char *mount_specs[] = { "/dev/sda1", "/dev/sda" };
     char cmd[1024];
+    /* -o uid/gid: by default guestmount maps the FUSE mount as root, so the
+     * invoking user can't write. Pass our real uid/gid so dragging files
+     * into the file manager works. FAT doesn't preserve groups, but the
+     * permission check is on uid alone. */
+    unsigned uid = (unsigned)getuid();
+    unsigned gid = (unsigned)getgid();
     for (size_t i = 0; i < sizeof(mount_specs)/sizeof(mount_specs[0]); i++) {
         snprintf(cmd, sizeof(cmd),
-                 "%s -a '%s' -m %s --rw '%s' 2>/dev/null",
-                 GUESTMOUNT_BIN, image, mount_specs[i], path);
+                 "%s -a '%s' -m %s --rw -o uid=%u,gid=%u '%s' 2>/dev/null",
+                 GUESTMOUNT_BIN, image, mount_specs[i], uid, gid, path);
         if (system(cmd) == 0)
             return true;
     }

--- a/src/host_mount.c
+++ b/src/host_mount.c
@@ -93,30 +93,37 @@ static bool guestmount_image(const char *image, const char *path) {
      * non-server users actually want. */
     unsigned uid = (unsigned)getuid();
     unsigned gid = (unsigned)getgid();
-    /* Try WITHOUT allow_other first — native Nautilus refuses GUI pastes
-     * on FUSE mounts that advertise allow_other (treats them as foreign
-     * filesystems). The Flatpak-sandboxed file-manager case is rare and
-     * is still covered by the fallback. */
-    for (int try_allow_other = 0; try_allow_other <= 1; try_allow_other++) {
-        for (size_t i = 0; i < sizeof(mount_specs)/sizeof(mount_specs[0]); i++) {
-            snprintf(cmd, sizeof(cmd),
-                     "LIBGUESTFS_BACKEND=direct "
-                     "%s -a '%s' -m %s --rw "
-                     "-o uid=%u,gid=%u,umask=0%s '%s' 2>&1",
-                     GUESTMOUNT_BIN, image, mount_specs[i], uid, gid,
-                     try_allow_other ? ",allow_other" : "",
-                     path);
-            FILE *p = popen(cmd, "r");
-            if (!p) continue;
-            char errbuf[512] = {0};
-            (void)fread(errbuf, 1, sizeof(errbuf) - 1, p);
-            int rc = pclose(p);
-            if (rc == 0) return true;
-            if (errbuf[0])
-                fprintf(stderr, "host_mount: guestmount[%s,%s]: %s",
-                        mount_specs[i],
-                        try_allow_other ? "allow_other" : "no-allow_other",
-                        errbuf);
+    /* Two axes of fallback:
+     *   - backend: system default first, then explicit `direct` (some
+     *     systems have a broken libvirt backend; others have a broken
+     *     direct backend — neither is universal).
+     *   - allow_other: off first (native Nautilus refuses GUI pastes on
+     *     FUSE mounts that advertise allow_other), on second (sandboxed
+     *     Flatpak file managers need it). */
+    static const char *backends[] = { "", "LIBGUESTFS_BACKEND=direct " };
+    for (size_t b = 0; b < sizeof(backends)/sizeof(backends[0]); b++) {
+        for (int try_allow_other = 0; try_allow_other <= 1; try_allow_other++) {
+            for (size_t i = 0; i < sizeof(mount_specs)/sizeof(mount_specs[0]); i++) {
+                snprintf(cmd, sizeof(cmd),
+                         "%s%s -a '%s' -m %s --rw "
+                         "-o uid=%u,gid=%u,umask=0%s '%s' 2>&1",
+                         backends[b], GUESTMOUNT_BIN, image, mount_specs[i],
+                         uid, gid,
+                         try_allow_other ? ",allow_other" : "",
+                         path);
+                FILE *p = popen(cmd, "r");
+                if (!p) continue;
+                char errbuf[512] = {0};
+                (void)fread(errbuf, 1, sizeof(errbuf) - 1, p);
+                int rc = pclose(p);
+                if (rc == 0) return true;
+                if (errbuf[0])
+                    fprintf(stderr, "host_mount: guestmount[%s%s,%s]: %s",
+                            backends[b][0] ? "direct," : "default,",
+                            mount_specs[i],
+                            try_allow_other ? "allow_other" : "no-allow_other",
+                            errbuf);
+            }
         }
     }
     fprintf(stderr, "host_mount: guestmount failed for %s\n", image);
@@ -175,12 +182,20 @@ bool host_mount_open(HostMount *hm, const Config *cfg) {
     memset(hm, 0, sizeof(*hm));
     build_root(hm->root, sizeof(hm->root));
 
-    /* M4 directory mode (cfg->m4_path) serves files from a host directory
-     * already — no sector image to mount. Skip the M4 slot in that case. */
-    if (!cfg->m4_path[0])
+    /* Only mount cards whose hardware toggle is actually on. A stale
+     * cfg->*_image from a previously-enabled card would otherwise get
+     * mounted even when that card isn't wired this session — confusing
+     * for the user and a guaranteed guestmount failure if the file is
+     * a non-FAT format (e.g. a CP/M-formatted IDE image).
+     *
+     * M4 directory mode (cfg->m4_path set) serves files from a host
+     * directory already — no sector image, so skip the M4 slot. */
+    if (cfg->m4 && !cfg->m4_path[0])
         stage_slot(hm, "m4",      cfg->m4_image);
-    stage_slot(hm, "ide",     cfg->ide_image);
-    stage_slot(hm, "albireo", cfg->albireo_image);
+    if (cfg->symbiface_ide)
+        stage_slot(hm, "ide",     cfg->ide_image);
+    if (cfg->albireo)
+        stage_slot(hm, "albireo", cfg->albireo_image);
 
     if (hm->count == 0) return false;
 

--- a/src/host_mount.c
+++ b/src/host_mount.c
@@ -61,12 +61,20 @@ static bool guestmount_image(const char *image, const char *path) {
      *                   sandbox/namespace (Flatpak Nautilus, etc.). FUSE
      *                   only honours this if /etc/fuse.conf has
      *                   `user_allow_other`; if it doesn't, the option is
-     *                   rejected, so we try with-and-without. */
+     *                   rejected, so we try with-and-without.
+     *
+     * LIBGUESTFS_BACKEND=direct forces libguestfs to spawn qemu itself
+     * rather than going through libvirt. Fedora ships libguestfs with the
+     * libvirt backend by default, which fails on most desktops (libvirtd
+     * permissions, qemu-system-x86_64 stdin closure, …); the direct
+     * backend is simpler, doesn't need libvirtd running, and is what most
+     * non-server users actually want. */
     unsigned uid = (unsigned)getuid();
     unsigned gid = (unsigned)getgid();
     for (int try_allow_other = 1; try_allow_other >= 0; try_allow_other--) {
         for (size_t i = 0; i < sizeof(mount_specs)/sizeof(mount_specs[0]); i++) {
             snprintf(cmd, sizeof(cmd),
+                     "LIBGUESTFS_BACKEND=direct "
                      "%s -a '%s' -m %s --rw "
                      "-o uid=%u,gid=%u,umask=0%s '%s' 2>&1",
                      GUESTMOUNT_BIN, image, mount_specs[i], uid, gid,
@@ -74,7 +82,7 @@ static bool guestmount_image(const char *image, const char *path) {
                      path);
             FILE *p = popen(cmd, "r");
             if (!p) continue;
-            char errbuf[256] = {0};
+            char errbuf[512] = {0};
             (void)fread(errbuf, 1, sizeof(errbuf) - 1, p);
             int rc = pclose(p);
             if (rc == 0) return true;

--- a/src/host_mount.c
+++ b/src/host_mount.c
@@ -398,6 +398,23 @@ bool host_mount_open(HostMount *hm, const Config *cfg) {
     return true;
 }
 
+bool host_mount_externally_unmounted(const HostMount *hm) {
+    for (int i = 0; i < hm->count; i++) {
+        const HostMountSlot *s = &hm->slots[i];
+        if (!s->path[0]) continue;
+        /* findmnt returns 0 only if the path is currently a mount point.
+         * Nautilus eject removes the entry; we then know the user is done. */
+        char cmd[512], buf[256];
+        snprintf(cmd, sizeof(cmd),
+                 "findmnt -n --target '%s' -o TARGET 2>/dev/null", s->path);
+        if (run_capture(cmd, buf, sizeof(buf)) != 0) return true;
+        size_t n = strlen(buf);
+        while (n && (buf[n-1] == '\n' || buf[n-1] == ' ')) buf[--n] = '\0';
+        if (strcmp(buf, s->path) != 0) return true;
+    }
+    return false;
+}
+
 bool host_mount_close(HostMount *hm) {
     for (int i = 0; i < hm->count; i++) {
         HostMountSlot *s = &hm->slots[i];
@@ -424,6 +441,11 @@ bool host_mount_open(HostMount *hm, const Config *cfg) {
 bool host_mount_close(HostMount *hm) {
     (void)hm;
     return true;
+}
+
+bool host_mount_externally_unmounted(const HostMount *hm) {
+    (void)hm;
+    return false;
 }
 
 #endif

--- a/src/host_mount.c
+++ b/src/host_mount.c
@@ -5,6 +5,9 @@
  * at the mount root. The caller (main.c) is responsible for triggering a
  * cold reboot on close so the guest's stale FAT cache is discarded. */
 
+/* popen/pclose live behind POSIX feature flags under -std=c11. */
+#define _POSIX_C_SOURCE 200809L
+
 #include "host_mount.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -51,21 +54,38 @@ static void build_root(char *out, size_t sz) {
 static bool guestmount_image(const char *image, const char *path) {
     static const char *mount_specs[] = { "/dev/sda1", "/dev/sda" };
     char cmd[1024];
-    /* -o uid/gid: by default guestmount maps the FUSE mount as root, so the
-     * invoking user can't write. Pass our real uid/gid so dragging files
-     * into the file manager works. FAT doesn't preserve groups, but the
-     * permission check is on uid alone. */
+    /* FUSE options for full user ownership:
+     *   uid/gid       — every file and directory appears owned by us
+     *   umask=0       — no permission bits are masked out (rwx for owner)
+     *   allow_other   — needed when the file manager runs in a separate
+     *                   sandbox/namespace (Flatpak Nautilus, etc.). FUSE
+     *                   only honours this if /etc/fuse.conf has
+     *                   `user_allow_other`; if it doesn't, the option is
+     *                   rejected, so we try with-and-without. */
     unsigned uid = (unsigned)getuid();
     unsigned gid = (unsigned)getgid();
-    for (size_t i = 0; i < sizeof(mount_specs)/sizeof(mount_specs[0]); i++) {
-        snprintf(cmd, sizeof(cmd),
-                 "%s -a '%s' -m %s --rw -o uid=%u,gid=%u '%s' 2>/dev/null",
-                 GUESTMOUNT_BIN, image, mount_specs[i], uid, gid, path);
-        if (system(cmd) == 0)
-            return true;
+    for (int try_allow_other = 1; try_allow_other >= 0; try_allow_other--) {
+        for (size_t i = 0; i < sizeof(mount_specs)/sizeof(mount_specs[0]); i++) {
+            snprintf(cmd, sizeof(cmd),
+                     "%s -a '%s' -m %s --rw "
+                     "-o uid=%u,gid=%u,umask=0%s '%s' 2>&1",
+                     GUESTMOUNT_BIN, image, mount_specs[i], uid, gid,
+                     try_allow_other ? ",allow_other" : "",
+                     path);
+            FILE *p = popen(cmd, "r");
+            if (!p) continue;
+            char errbuf[256] = {0};
+            (void)fread(errbuf, 1, sizeof(errbuf) - 1, p);
+            int rc = pclose(p);
+            if (rc == 0) return true;
+            if (errbuf[0])
+                fprintf(stderr, "host_mount: guestmount[%s,%s]: %s",
+                        mount_specs[i],
+                        try_allow_other ? "allow_other" : "no-allow_other",
+                        errbuf);
+        }
     }
-    fprintf(stderr, "host_mount: guestmount failed for %s (tried -m /dev/sda1 and -m /dev/sda)\n",
-            image);
+    fprintf(stderr, "host_mount: guestmount failed for %s\n", image);
     return false;
 }
 

--- a/src/host_mount.c
+++ b/src/host_mount.c
@@ -1,0 +1,185 @@
+/* F10 guestmount feature — see issue #142.
+ *
+ * Pauses the emulator, calls libguestfs's `guestmount` on every active FAT
+ * card image (M4 SD, IDE, Albireo USB), and opens the host file manager
+ * at the mount root. The caller (main.c) is responsible for triggering a
+ * cold reboot on close so the guest's stale FAT cache is discarded. */
+
+#include "host_mount.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#ifdef __linux__
+#include <sys/wait.h>
+#endif
+
+#define GUESTMOUNT_BIN "/usr/bin/guestmount"
+#define GUESTUNMOUNT_BIN "/usr/bin/guestunmount"
+#define XDG_OPEN_BIN   "/usr/bin/xdg-open"
+
+bool host_mount_supported(void) {
+#ifdef __linux__
+    static int cached = -1;
+    if (cached < 0) {
+        cached = (access(GUESTMOUNT_BIN, X_OK) == 0
+               && access(GUESTUNMOUNT_BIN, X_OK) == 0
+               && access(XDG_OPEN_BIN, X_OK) == 0) ? 1 : 0;
+    }
+    return cached == 1;
+#else
+    return false;
+#endif
+}
+
+#ifdef __linux__
+
+static void build_root(char *out, size_t sz) {
+    snprintf(out, sz, "/run/user/%u/1984", (unsigned)getuid());
+}
+
+/* Try to mount `image` at `path` via guestmount. Returns true on success.
+ *
+ * libguestfs's `-i` inspector wants to identify a "guest OS" (Linux,
+ * Windows, …); CPC card images don't have one, so we mount the FS
+ * directly. Try /dev/sda1 first (partitioned images: M4 SymbOS SD, IDE
+ * formatted by CP/M Plus, …), then fall back to /dev/sda (bare-FAT
+ * images with no partition table — common for small USB sticks). */
+static bool guestmount_image(const char *image, const char *path) {
+    static const char *mount_specs[] = { "/dev/sda1", "/dev/sda" };
+    char cmd[1024];
+    for (size_t i = 0; i < sizeof(mount_specs)/sizeof(mount_specs[0]); i++) {
+        snprintf(cmd, sizeof(cmd),
+                 "%s -a '%s' -m %s --rw '%s' 2>/dev/null",
+                 GUESTMOUNT_BIN, image, mount_specs[i], path);
+        if (system(cmd) == 0)
+            return true;
+    }
+    fprintf(stderr, "host_mount: guestmount failed for %s (tried -m /dev/sda1 and -m /dev/sda)\n",
+            image);
+    return false;
+}
+
+static void guestunmount_path(const char *path) {
+    char cmd[1024];
+    snprintf(cmd, sizeof(cmd), "%s '%s' 2>&1", GUESTUNMOUNT_BIN, path);
+    int rc = system(cmd);
+    if (rc != 0)
+        fprintf(stderr, "host_mount: guestunmount failed for %s (exit=%d)\n",
+                path, rc);
+}
+
+/* Fork + exec xdg-open so the file manager runs detached from us. We
+ * don't wait for it — the user closes it when they're done. */
+static void spawn_filemanager(const char *path) {
+    pid_t pid = fork();
+    if (pid < 0) {
+        fprintf(stderr, "host_mount: fork failed for xdg-open\n");
+        return;
+    }
+    if (pid == 0) {
+        /* Detach from controlling terminal so closing the emulator window
+         * later doesn't reap the file manager too. */
+        setsid();
+        execl(XDG_OPEN_BIN, "xdg-open", path, (char *)NULL);
+        _exit(127);   /* exec failed */
+    }
+    /* Parent: reap the immediate child (xdg-open is itself a launcher
+     * that double-forks; we won't get a zombie). */
+    int status;
+    waitpid(pid, &status, WNOHANG);
+}
+
+/* Append a slot to hm if `image` is a non-empty path to a readable file.
+ * Creates the mount-point directory. Does NOT mount yet — that happens in
+ * a second pass so we can short-circuit cleanly when nothing is eligible. */
+static void stage_slot(HostMount *hm, const char *label, const char *image) {
+    if (!image || image[0] == '\0') return;
+    if (access(image, R_OK) != 0) {
+        fprintf(stderr, "host_mount: %s image not readable: %s\n", label, image);
+        return;
+    }
+    if (hm->count >= HOST_MOUNT_MAX_SLOTS) return;
+
+    HostMountSlot *s = &hm->slots[hm->count];
+    snprintf(s->label, sizeof(s->label), "%s", label);
+    snprintf(s->path,  sizeof(s->path),  "%s/%s", hm->root, label);
+    s->image = image;
+    hm->count++;
+}
+
+bool host_mount_open(HostMount *hm, const Config *cfg) {
+    memset(hm, 0, sizeof(*hm));
+    build_root(hm->root, sizeof(hm->root));
+
+    /* M4 directory mode (cfg->m4_path) serves files from a host directory
+     * already — no sector image to mount. Skip the M4 slot in that case. */
+    if (!cfg->m4_path[0])
+        stage_slot(hm, "m4",      cfg->m4_image);
+    stage_slot(hm, "ide",     cfg->ide_image);
+    stage_slot(hm, "albireo", cfg->albireo_image);
+
+    if (hm->count == 0) return false;
+
+    /* mkdir -p root */
+    if (mkdir(hm->root, 0700) != 0 && access(hm->root, W_OK) != 0) {
+        fprintf(stderr, "host_mount: cannot create %s\n", hm->root);
+        hm->count = 0;
+        return false;
+    }
+
+    int mounted = 0;
+    for (int i = 0; i < hm->count; i++) {
+        HostMountSlot *s = &hm->slots[i];
+        mkdir(s->path, 0700);   /* may already exist from a prior abort */
+        if (guestmount_image(s->image, s->path)) {
+            mounted++;
+        } else {
+            /* Mark this slot as not actually mounted so close() skips it. */
+            rmdir(s->path);
+            s->path[0] = '\0';
+        }
+    }
+
+    if (mounted == 0) {
+        rmdir(hm->root);
+        hm->count = 0;
+        return false;
+    }
+
+    spawn_filemanager(hm->root);
+    fprintf(stderr, "host_mount: mounted %d card(s) under %s\n",
+            mounted, hm->root);
+    return true;
+}
+
+bool host_mount_close(HostMount *hm) {
+    for (int i = 0; i < hm->count; i++) {
+        HostMountSlot *s = &hm->slots[i];
+        if (s->path[0]) {
+            guestunmount_path(s->path);
+            rmdir(s->path);
+        }
+    }
+    rmdir(hm->root);
+    memset(hm, 0, sizeof(*hm));
+    return true;
+}
+
+#else  /* !__linux__ */
+
+bool host_mount_open(HostMount *hm, const Config *cfg) {
+    (void)hm; (void)cfg;
+    fprintf(stderr, "host_mount: not supported on this platform\n");
+    return false;
+}
+
+bool host_mount_close(HostMount *hm) {
+    (void)hm;
+    return true;
+}
+
+#endif

--- a/src/host_mount.c
+++ b/src/host_mount.c
@@ -41,7 +41,29 @@ bool host_mount_supported(void) {
 #ifdef __linux__
 
 static void build_root(char *out, size_t sz) {
-    snprintf(out, sz, "/run/user/%u/1984", (unsigned)getuid());
+    /* Mount under the user's home rather than /run/user/$UID. GNOME Files
+     * (Nautilus) treats /run/user/* with a different SELinux context and
+     * silently refuses pastes from the GUI even when the underlying FUSE
+     * mount is fully writable from the shell. ~/.cache is XDG-spec for
+     * ephemeral state and inherits user_home_t — Nautilus is happy. */
+    const char *home = getenv("HOME");
+    if (!home || !home[0]) home = ".";
+    snprintf(out, sz, "%s/.cache/1984/mounts", home);
+}
+
+/* mkdir -p equivalent. Returns true if the directory exists / was made. */
+static bool mkdir_p(const char *path) {
+    char tmp[256];
+    snprintf(tmp, sizeof(tmp), "%s", path);
+    for (char *p = tmp + 1; *p; p++) {
+        if (*p == '/') {
+            *p = '\0';
+            mkdir(tmp, 0755);
+            *p = '/';
+        }
+    }
+    mkdir(tmp, 0755);
+    return access(path, W_OK) == 0;
 }
 
 /* Try to mount `image` at `path` via guestmount. Returns true on success.
@@ -71,7 +93,11 @@ static bool guestmount_image(const char *image, const char *path) {
      * non-server users actually want. */
     unsigned uid = (unsigned)getuid();
     unsigned gid = (unsigned)getgid();
-    for (int try_allow_other = 1; try_allow_other >= 0; try_allow_other--) {
+    /* Try WITHOUT allow_other first — native Nautilus refuses GUI pastes
+     * on FUSE mounts that advertise allow_other (treats them as foreign
+     * filesystems). The Flatpak-sandboxed file-manager case is rare and
+     * is still covered by the fallback. */
+    for (int try_allow_other = 0; try_allow_other <= 1; try_allow_other++) {
         for (size_t i = 0; i < sizeof(mount_specs)/sizeof(mount_specs[0]); i++) {
             snprintf(cmd, sizeof(cmd),
                      "LIBGUESTFS_BACKEND=direct "
@@ -158,8 +184,7 @@ bool host_mount_open(HostMount *hm, const Config *cfg) {
 
     if (hm->count == 0) return false;
 
-    /* mkdir -p root */
-    if (mkdir(hm->root, 0700) != 0 && access(hm->root, W_OK) != 0) {
+    if (!mkdir_p(hm->root)) {
         fprintf(stderr, "host_mount: cannot create %s\n", hm->root);
         hm->count = 0;
         return false;

--- a/src/host_mount.h
+++ b/src/host_mount.h
@@ -39,3 +39,8 @@ bool host_mount_open(HostMount *hm, const Config *cfg);
 
 /* Unmount every populated slot. Idempotent. */
 bool host_mount_close(HostMount *hm);
+
+/* Poll once per frame while the mount is active: return true if the user
+ * ejected any card from the host file manager (Nautilus etc.) so the
+ * caller can finish the close-and-cold-boot cycle automatically. */
+bool host_mount_externally_unmounted(const HostMount *hm);

--- a/src/host_mount.h
+++ b/src/host_mount.h
@@ -2,14 +2,22 @@
 #include <stdbool.h>
 #include "config.h"
 
-/* Per-card mount slot. `path` is the directory the image is FUSE-mounted
- * onto; empty when nothing is mounted. `image` is a borrowed pointer back
- * into the live Config so we know which file to call guestmount on (and
- * which one to leave alone on close). */
+/* Which backend mounted this slot — determines how to unmount. */
+typedef enum {
+    HOST_MOUNT_NONE       = 0,
+    HOST_MOUNT_UDISKS     = 1,   /* gnome-disk-image-mounter / udisksctl */
+    HOST_MOUNT_GUESTMOUNT = 2    /* libguestfs FUSE fallback */
+} HostMountVia;
+
+/* Per-card mount slot. `path` is the directory the image is mounted onto;
+ * empty when nothing is mounted. `image` is a borrowed pointer back into
+ * the live Config so we know which file the mount is backed by. */
 typedef struct {
-    char        path[256];
-    char        label[16];      /* "m4" | "ide" | "albireo" */
-    const char *image;
+    char         path[256];
+    char         label[16];     /* "m4" | "ide" | "albireo" */
+    char         loop_dev[64];  /* /dev/loopN — populated for HOST_MOUNT_UDISKS */
+    const char  *image;
+    HostMountVia via;
 } HostMountSlot;
 
 #define HOST_MOUNT_MAX_SLOTS 3
@@ -17,22 +25,17 @@ typedef struct {
 typedef struct {
     HostMountSlot slots[HOST_MOUNT_MAX_SLOTS];
     int           count;
-    char          root[256];
+    char          root[256];    /* used only for the guestmount fallback */
     bool          active;       /* F10 toggle state */
 } HostMount;
 
-/* True if the host has the tools we need (guestmount + xdg-open) and we
- * built with support for this feature. Result cached internally — cheap to
- * call repeatedly. */
+/* True if the host has at least one working mount backend plus xdg-open. */
 bool host_mount_supported(void);
 
-/* Mount every active FAT card image under /run/user/$UID/1984/<label>/ and
- * fork+exec xdg-open on the root. Returns true if at least one slot
- * mounted (so the caller knows to enter the "browsing" state); false if
- * nothing was eligible or every guestmount call failed. On false the
- * struct is left clean (no partial mounts to clean up). */
+/* Mount every active card image (M4 / IDE / Albireo) and open the host
+ * file manager at the mount root. Returns true if at least one slot
+ * mounted; false if nothing was eligible or every backend failed. */
 bool host_mount_open(HostMount *hm, const Config *cfg);
 
-/* fusermount-unmount every populated slot, rmdir the slot dirs and the
- * root. Idempotent: safe to call when nothing is mounted. */
+/* Unmount every populated slot. Idempotent. */
 bool host_mount_close(HostMount *hm);

--- a/src/host_mount.h
+++ b/src/host_mount.h
@@ -1,0 +1,38 @@
+#pragma once
+#include <stdbool.h>
+#include "config.h"
+
+/* Per-card mount slot. `path` is the directory the image is FUSE-mounted
+ * onto; empty when nothing is mounted. `image` is a borrowed pointer back
+ * into the live Config so we know which file to call guestmount on (and
+ * which one to leave alone on close). */
+typedef struct {
+    char        path[256];
+    char        label[16];      /* "m4" | "ide" | "albireo" */
+    const char *image;
+} HostMountSlot;
+
+#define HOST_MOUNT_MAX_SLOTS 3
+
+typedef struct {
+    HostMountSlot slots[HOST_MOUNT_MAX_SLOTS];
+    int           count;
+    char          root[256];
+    bool          active;       /* F10 toggle state */
+} HostMount;
+
+/* True if the host has the tools we need (guestmount + xdg-open) and we
+ * built with support for this feature. Result cached internally — cheap to
+ * call repeatedly. */
+bool host_mount_supported(void);
+
+/* Mount every active FAT card image under /run/user/$UID/1984/<label>/ and
+ * fork+exec xdg-open on the root. Returns true if at least one slot
+ * mounted (so the caller knows to enter the "browsing" state); false if
+ * nothing was eligible or every guestmount call failed. On false the
+ * struct is left clean (no partial mounts to clean up). */
+bool host_mount_open(HostMount *hm, const Config *cfg);
+
+/* fusermount-unmount every populated slot, rmdir the slot dirs and the
+ * root. Idempotent: safe to call when nothing is mounted. */
+bool host_mount_close(HostMount *hm);

--- a/src/main.c
+++ b/src/main.c
@@ -921,6 +921,17 @@ int main(int argc, char *argv[]) {
 
         overlay_tick(&overlay);
 
+        /* Auto-finish F10 mount session if the user ejected the card from
+         * the file manager (Nautilus, Files, …). Same effect as a second
+         * F10 press: tear down anything that's still mounted, unpause,
+         * cold-boot to drop the guest's stale FAT cache. */
+        if (host_mount.active &&
+                host_mount_externally_unmounted(&host_mount)) {
+            host_mount_close(&host_mount);
+            cpc.paused = false;
+            overlay.needs_cold_boot = true;
+        }
+
         if (overlay.needs_cold_boot) {
             overlay.needs_cold_boot = false;
             cpc.model = cfg.model;

--- a/src/main.c
+++ b/src/main.c
@@ -8,6 +8,7 @@
 #include <strings.h>     /* strcasecmp */
 #include "config.h"
 #include "overlay.h"
+#include "host_mount.h"
 #include "cpc.h"
 #include "mem.h"
 #include "paste.h"
@@ -600,6 +601,8 @@ int main(int argc, char *argv[]) {
     overlay_init(&overlay, &cfg, &cpc);
     SD_LOG("overlay_init OK");
 
+    HostMount host_mount = {0};   /* F10 toggle state; see host_mount.c */
+
     Monitor *monitor = monitor_create(&cpc);
     if (monitor_pty) {
         const char *pty_path = monitor_pty_open(monitor);
@@ -838,6 +841,29 @@ int main(int argc, char *argv[]) {
                     }
                 } else if (ev.key.scancode == SDL_SCANCODE_F5) {
                     cpc_reset(&cpc);
+                } else if (ev.key.scancode == SDL_SCANCODE_F10) {
+                    /* Toggle host-side card browse: pause the guest, mount
+                     * every active FAT card image (M4 SD / IDE / Albireo)
+                     * under /run/user/$UID/1984/<label>/ and open the host
+                     * file manager. Press F10 again to unmount + cold-boot
+                     * so the guest's stale FAT cache is dropped on resume. */
+                    if (host_mount.active) {
+                        host_mount_close(&host_mount);
+                        cpc.paused = false;
+                        overlay.needs_cold_boot = true;
+                    } else if (host_mount_supported()) {
+                        cpc.paused = true;
+                        if (host_mount_open(&host_mount, &cfg)) {
+                            host_mount.active = true;
+                        } else {
+                            cpc.paused = false;
+                            fprintf(stderr,
+                                "F10: nothing to mount (no active FAT card image)\n");
+                        }
+                    } else {
+                        fprintf(stderr,
+                            "F10: needs libguestfs (guestmount, guestunmount) and xdg-open\n");
+                    }
                 } else if (ev.key.scancode == SDL_SCANCODE_F6) {
                     /* Toggle video capture. Auto-name in CWD when starting
                      * outside the overlay file picker. */

--- a/src/main.c
+++ b/src/main.c
@@ -1038,7 +1038,21 @@ int main(int argc, char *argv[]) {
             if (!webmcap_frame(g_videocap_webm, cpc.display.pixels))
                 videocap_stop();
         }
+        /* Paused-state visual: greyscale the frozen frame and re-composite
+         * it each iteration (cpc_frame early-returns when paused, so it
+         * stops calling display_upload itself — the back buffer would
+         * otherwise show undefined content after RenderPresent). The
+         * PAUSED label is drawn below after overlay_render so it ends
+         * up on top of everything. */
+        static bool prev_paused = false;
+        if (cpc.paused) {
+            if (!prev_paused) display_apply_greyscale(&cpc.display);
+            display_upload(&cpc.display);
+        }
+        prev_paused = cpc.paused;
         overlay_render(&overlay, cpc.display.renderer);
+        if (cpc.paused)
+            display_draw_paused_label(&cpc.display);
         /* Debug-mode FPS overlay (bottom-left, just above the LED bar).
          * Doubles as a visual marker that debug machinery is live. */
         if (g_debug_enabled) {


### PR DESCRIPTION
## Summary
- New **F10** hotkey: pauses the guest, mounts every active card image (M4 SD / IDE / Albireo) on the host, opens the file manager so the user can drag files in / out. Press F10 again or eject the card from Nautilus to unmount + cold-boot.
- Backend cascade per card: `gnome-disk-image-mounter` (native GNOME integration) → `udisksctl` (KDE/XFCE) → `guestmount` (libguestfs fallback).
- Paused-state UI: dimmed greyscale of the frozen frame + 'PAUSED' / 'Press F10 to resume' labels.

## Test plan
- [x] F10 with M4 SymbOS image mounts under /run/media/$USER/, opens Nautilus, drag/drop in works
- [x] F10 again unmounts and triggers cold boot; SymbOS sees the new files
- [x] Eject button in Nautilus also triggers unmount + cold boot
- [x] No-active-card case logs and is a no-op
- [x] Greyscale + label overlay rendered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)