### PR TITLE
Add scripted joystick + headless capture for automated UI tests

### DIFF
--- a/src/joy.c
+++ b/src/joy.c
@@ -14,6 +14,61 @@
 
 #define AXIS_DEAD 8000   /* ±8000 out of ±32767 */
 
+/* --- Scripted joystick injection (--joy-script), see joy.h ------------------ */
+
+bool joyscript_init(JoyScript *js, const char *spec) {
+    memset(js, 0, sizeof(*js));
+    const char *p = spec;
+    while (*p && js->nsteps < JOYSCRIPT_MAX_STEPS) {
+        unsigned char mask = 0;
+        while (*p && *p != ':' && *p != ',') {       /* direction letters */
+            switch (*p) {
+            case 'u': case 'U': mask |= 1 << JOY_UP;    break;
+            case 'd': case 'D': mask |= 1 << JOY_DOWN;  break;
+            case 'l': case 'L': mask |= 1 << JOY_LEFT;  break;
+            case 'r': case 'R': mask |= 1 << JOY_RIGHT; break;
+            case '1':           mask |= 1 << JOY_FIRE1; break;
+            case '2':           mask |= 1 << JOY_FIRE2; break;
+            case '-': case 'n': case 'N': break;        /* neutral */
+            default:
+                fprintf(stderr, "[joy-script] bad direction '%c' in spec\n", *p);
+                memset(js, 0, sizeof(*js)); js->done = true; return false;
+            }
+            p++;
+        }
+        int frames = 0;
+        if (*p == ':') { p++; while (*p >= '0' && *p <= '9') frames = frames*10 + (*p++ - '0'); }
+        if (frames <= 0) frames = 1;
+        js->step[js->nsteps].mask   = mask;
+        js->step[js->nsteps].frames = frames;
+        js->nsteps++;
+        if (*p == ',') p++;
+    }
+    js->cur   = 0;
+    js->timer = js->nsteps ? js->step[0].frames : 0;
+    js->done  = (js->nsteps == 0);
+    return !js->done;
+}
+
+void joyscript_tick(JoyScript *js, Keyboard *k) {
+    if (js->done) return;
+    unsigned char mask = js->step[js->cur].mask;
+    for (int c = JOY_UP; c <= JOY_FIRE2; c++) {       /* set row 9 to this step */
+        if (mask & (1 << c)) kbd_key_down(k, JOY_ROW, c);
+        else                 kbd_key_up  (k, JOY_ROW, c);
+    }
+    if (--js->timer <= 0) {                           /* advance to the next step */
+        js->cur++;
+        if (js->cur >= js->nsteps) {
+            js->done = true;
+            for (int c = JOY_UP; c <= JOY_FIRE2; c++) /* release everything at the end */
+                kbd_key_up(k, JOY_ROW, c);
+        } else {
+            js->timer = js->step[js->cur].frames;
+        }
+    }
+}
+
 void joy_init(Joy *j) {
     memset(j, 0, sizeof(*j));
 

--- a/src/joy.h
+++ b/src/joy.h
@@ -23,3 +23,29 @@ void joy_destroy(Joy *j);
 
 /* Returns true if the event was a joystick event (caller should not re-process it). */
 bool joy_handle_event(Joy *j, const SDL_Event *ev, Keyboard *k);
+
+/*
+ * Scripted joystick injection (--joy-script). A deterministic, headless way to
+ * drive the CPC joystick (row 9) for automated UI tests - the joystick analogue
+ * of --paste. The script is a comma-separated list of "DIRS:FRAMES" steps held
+ * one after another; each frame joyscript_tick() sets row 9 to the current step.
+ *
+ * DIRS  = any of u d l r (directions), 1 2 (Fire1/Fire2), or - / n for neutral.
+ * FRAMES = how many emulated frames to hold that state (default 1).
+ * e.g. "d:150,-:30,u:150,-:30,1:5" = down 150f, rest, up 150f, rest, tap Fire1.
+ */
+#define JOYSCRIPT_MAX_STEPS 128
+
+typedef struct {
+    struct { unsigned char mask; int frames; } step[JOYSCRIPT_MAX_STEPS];
+    int  nsteps;
+    int  cur;       /* current step index */
+    int  timer;     /* frames left in the current step */
+    bool done;
+} JoyScript;
+
+/* Parse spec into js. Returns false (and leaves js empty/done) on a parse error. */
+bool joyscript_init(JoyScript *js, const char *spec);
+
+/* Call once per frame (next to paste_tick): drives row 9 from the script. */
+void joyscript_tick(JoyScript *js, Keyboard *k);

--- a/src/main.c
+++ b/src/main.c
@@ -267,6 +267,11 @@ static void usage(const char *prog, int code) {
         "  --save-sna-at=N:PATH  Save a .sna snapshot at frame N (typically pairs with --paste / --autostart)\n"
         "  --save-sna-at-ide=N:PATH  Save a .sna snapshot when the Nth ATA command is issued (for cross-emulator bisection)\n"
         "  --screenshot-at=N:PATH  Save a screenshot at frame N to PATH, then exit\n"
+        "  --joy-script=SPEC   Scripted joystick (row 9). SPEC = comma-separated DIRS:FRAMES\n"
+        "                      steps; DIRS = u d l r 1 2 (Fire1/2) or - (neutral).\n"
+        "                      e.g. --joy-script=d:150,-:30,u:150 (down, rest, up)\n"
+        "  --gif-out=PATH      Record a GIF from boot (finalised on exit; pairs with --exit-after)\n"
+        "  --exit-after=N      Quit after frame N (deterministic headless capture)\n"
         "  --monitor-pty       Open a PTY for the memory monitor (minicom -b 9600 -D <path>)\n"
         "  --kbd-pty           Open a PTY that injects writes as keystrokes and streams\n"
         "                      the firmware text-out (&BB5A) for external test harnesses\n"
@@ -313,6 +318,9 @@ int main(int argc, char *argv[]) {
     const char *save_sna_path    = NULL;
     int         save_sna_ide_cmd = -1;
     const char *save_sna_ide_path = NULL;
+    const char *joyscript_arg    = NULL;  /* --joy-script=SPEC: scripted joystick */
+    const char *gifout_arg       = NULL;  /* --gif-out=PATH: record a GIF from boot */
+    int         exit_after       = -1;    /* --exit-after=N: quit at frame N */
     bool        trace_io         = false;
     bool        monitor_pty      = false;
     bool        kbd_pty_enabled  = false;
@@ -409,6 +417,12 @@ int main(int argc, char *argv[]) {
             }
             screenshot_frame = atoi(arg);
             screenshot_path  = colon + 1;
+        } else if (strncmp(argv[i], "--joy-script=", 13) == 0 && argv[i][13] != '\0') {
+            joyscript_arg = argv[i] + 13;
+        } else if (strncmp(argv[i], "--gif-out=", 10) == 0 && argv[i][10] != '\0') {
+            gifout_arg = argv[i] + 10;
+        } else if (strncmp(argv[i], "--exit-after=", 13) == 0 && argv[i][13] != '\0') {
+            exit_after = atoi(argv[i] + 13);
         } else if (strncmp(argv[i], "--save-sna-at=", 14) == 0 && argv[i][14] != '\0') {
             const char *arg = argv[i] + 14;
             char *colon = strchr(arg, ':');
@@ -634,6 +648,21 @@ int main(int argc, char *argv[]) {
     Joy joy;
     joy_init(&joy);
 
+    /* --joy-script: deterministic scripted joystick (row 9), the joystick analogue
+     * of --paste. Drives automated UI tests headlessly (e.g. sweep the GEOBENCH
+     * pointer to a screen edge to reproduce a moving-cursor artifact). */
+    JoyScript joyscript;
+    bool have_joyscript = false;
+    if (joyscript_arg) {
+        if (joyscript_init(&joyscript, joyscript_arg)) {
+            have_joyscript = true;
+            fprintf(stderr, "[joy-script] %d step(s) queued\n", joyscript.nsteps);
+        } else {
+            fprintf(stderr, "%s: invalid --joy-script spec\n", argv[0]);
+            return 1;
+        }
+    }
+
     /* Load a snapshot AFTER all machine init (ROMs, IDE, Albireo, joysticks
      * etc.) is done — the snapshot overrides only the CPU + GA + CRTC + PPI
      * + RAM state. Suppress autostart/paste so a typed sequence doesn't fight
@@ -670,6 +699,8 @@ int main(int argc, char *argv[]) {
 
     int  frame_count = 0;
     bool running = true;
+    if (gifout_arg)            /* --gif-out: record from boot (finalised on exit) */
+        videocap_start(gifout_arg);
     SD_LOG("entering main loop — startup complete");
     while (running) {
         SDL_Event ev;
@@ -1039,6 +1070,7 @@ int main(int argc, char *argv[]) {
         kbd_pty_tick(&paste);
         screen_text_tick(&cpc);
         paste_tick(&paste, &cpc.kbd);
+        if (have_joyscript) joyscript_tick(&joyscript, &cpc.kbd);
         bool was_paused   = cpc.paused;
         bool was_stepping = cpc.step_once;
         net4cpc_poll();
@@ -1181,6 +1213,8 @@ int main(int argc, char *argv[]) {
         monitor_render(monitor);
 
         frame_count++;
+        if (exit_after >= 0 && frame_count >= exit_after)
+            running = false;        /* --exit-after: deterministic headless quit */
         if (trace_io && frame_count == 210)
             cpc_trace_io = 1;
         if (trace_io && frame_count == 600)


### PR DESCRIPTION
## Summary
- `--joy-script=SPEC` drives the CPC joystick from a comma-separated `DIRS:FRAMES` script, applied once per frame next to `paste_tick()`
- `--gif-out=PATH` starts GIF capture at boot and finalises on exit
- `--exit-after=N` quits after frame N for fully deterministic captures

Built to reproduce a GEOBENCH moving-cursor artifact frame-by-frame; useful more broadly as the joystick analogue of `--paste` for headless UI regressions.

No new translation units (`joy.c` was already in the build).

## Test plan
- [ ] `1984 --joy-script=d:150,-:30,u:150 --gif-out=/tmp/sweep.gif --exit-after=400` produces a GIF showing the joystick sweep
- [ ] Running without any of the new flags is unchanged (smoke: BASIC boots normally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)