### PR TITLE
Fix FUZIX over Net4CPC: W5100S handshake, ephemeral port, Sn_IR clear, chip-wide IR summary

### DIFF
--- a/src/n4c_stack.c
+++ b/src/n4c_stack.c
@@ -1185,8 +1185,14 @@ static void tcp_tick(void) {
                     continue;
                 }
                 tcp_tx(s, TCP_SYN, NULL, 0);
-                /* snd_nxt got bumped — undo so we retransmit identically */
-                cb->snd_nxt = cb->snd_una;
+                /* SYN logically occupies 1 sequence number. tcp_tx bumped
+                 * snd_nxt; for a SYN retransmit we want snd_nxt to stay at
+                 * ISN+1 (not ISN+N after N retries) so the inbound SYN-ACK
+                 * handler's `ack == snd_nxt` check matches and we send a
+                 * proper ACK rather than mis-detecting simultaneous-open
+                 * and emitting another SYN-ACK. Pin to snd_una+1, which is
+                 * the invariant after the first successful SYN transmit. */
+                cb->snd_nxt = cb->snd_una + 1;
             }
         }
         /* Retransmit pending data */

--- a/src/net4cpc.c
+++ b/src/net4cpc.c
@@ -689,6 +689,20 @@ static u8 reg_read(u16 addr) {
     if (addr == 0x0082 || addr == 0x0083) {
         set16(0x0082, tcntr_read());
     }
+    /* Chip-wide IR at 0x0015: bits 0-3 ("Sn_INT" summary) reflect
+     * "socket n has at least one pending Sn_IR bit". FUZIX's
+     * net_w5x00 driver polls this register and short-circuits if
+     * zero — without this summary, FUZIX never knows there's data
+     * waiting in the RX ring and the screen stays blank even though
+     * TCP-level data has arrived. Computed on-read from the live
+     * Sn_IR state of each socket; bits 4-7 (other chip-wide sources)
+     * stay as stored. Matches W5100 datasheet § 4.2.4 behaviour. */
+    if (addr == 0x0015) {
+        u8 ir = regs[0x0015] & 0xF0;
+        for (int s = 0; s < 4; s++)
+            if (regs[SOCK_BASE[s] + SR_IR] != 0) ir |= (u8)(1u << s);
+        regs[0x0015] = ir;
+    }
     for (int s = 0; s < 4; s++) {
         if (addr == SOCK_BASE[s] + SR_SR) {
             poll_connect(s);

--- a/src/net4cpc.c
+++ b/src/net4cpc.c
@@ -297,7 +297,22 @@ static void handle_command(int s, u8 cmd) {
          * call inside SCMD_SEND, so we still want the host socket open
          * to receive DHCP-style replies before SIPR is set. */
         if (mode == SMODE_TCP && n4c_stack_active()) {
-            n4c_stack_tcp_open(s, get16(SOCK_BASE[s] + 0x04));
+            /* Sn_PORT (offset 0x04) is the local TCP port. Some guests
+             * (FUZIX cpcsme) don't set it for outbound connects and
+             * expect the chip to use an ephemeral port; real W5100S
+             * likely accepts port 0 because routers/peers don't care,
+             * but it confuses host-side NAT trackers and breaks
+             * conntrack on at least some kernels. Auto-assign a port
+             * in the IANA ephemeral range (49152-65535) when zero, and
+             * mirror back to the register so reads stay consistent. */
+            u16 lport = get16(SOCK_BASE[s] + 0x04);
+            if (lport == 0) {
+                static u16 ephemeral_next = 49152;
+                lport = ephemeral_next++;
+                if (ephemeral_next == 0) ephemeral_next = 49152;
+                set16(SOCK_BASE[s] + 0x04, lport);
+            }
+            n4c_stack_tcp_open(s, lport);
             regs[SOCK_BASE[s] + SR_SR] = SSTAT_INIT;
             set16(SOCK_BASE[s] + SR_TX_FSR, BUF_SIZE);
             set16(SOCK_BASE[s] + SR_TX_WR,  0);

--- a/src/net4cpc.c
+++ b/src/net4cpc.c
@@ -291,6 +291,13 @@ static void handle_command(int s, u8 cmd) {
 
     case SCMD_OPEN:
         close_sock(s);
+        /* Real W5100S OPEN clears Sn_IR (datasheet § 4.2.10). Without
+         * this, a stale DISCON bit from a prior CLOSE survives into
+         * the new socket; FUZIX's net_w5x00 driver sees it on the
+         * first event poll after OPEN, calls w5x00_eof() and
+         * connect() returns ECONNREFUSED. Matches the "first telnet
+         * refused, second works" pattern observed 2026-06-20. */
+        regs[SOCK_BASE[s] + SR_IR] = 0;
         /* TAP backend for TCP: tell the stack about the new socket and
          * reflect INIT immediately. UDP keeps using the POSIX backend
          * even with TAP because n4c_stack_send_udp() is selected per


### PR DESCRIPTION
## Summary

Four W5100S emulation bugs that prevented FUZIX cpcsme from completing a usable telnet session through 1984's Net4CPC TAP backend. SymbOS and HDCPM were unaffected because they each happened to avoid the relevant code paths. Real-CPC FUZIX (per Antonio) works fine, confirming our emulation was the gap.

Verified end-to-end against telehack (`telnet 64.13.139.230`): clean three-way handshake, telnet IAC negotiation, login banner renders on the FUZIX terminal. SymbOS + HDCPM independently re-tested post-fix and still work.

## What broke

| Commit | File | Bug |
|---|---|---|
| `5bd6003` | `n4c_stack.c` | SYN retransmit rolled `snd_nxt` back to `snd_una`, breaking ACK validation when the peer's SYN-ACK arrived. Pin to `snd_una + 1` (SYN occupies 1 sequence number whether sent once or N times). |
| `5bd6003` | `net4cpc.c` | FUZIX issues `SCMD_OPEN` without writing `Sn_PORT`, so source port leaked through as 0. Auto-assign from the IANA ephemeral range (49152-65535) when zero. |
| `0a3923a` | `net4cpc.c` | Stale `Sn_IR` DISCON bit from a prior CLOSE survived into a fresh `SCMD_OPEN`; FUZIX's net_w5x00 driver saw it on first event poll and surfaced `ECONNREFUSED` to userspace ("first try refused, second works"). Zero `Sn_IR` at OPEN per datasheet § 4.2.10. |
| `68995ac` | `net4cpc.c` | We never populated the chip-wide IR register at 0x0015. FUZIX's RX poll reads it as the bitmask of sockets with pending events; if IR==0 it bails. RX data sat in our ring forever → blank screen. Compute IR's low nibble on read from live `Sn_IR` state. Datasheet § 4.2.4. |

## Why SymbOS/HDCPM escaped each one

- Bug 1: SymbOS/HDCPM ARP via DHCP before connect, so first `tcp_tx` succeeds and the rollback path never fires.
- Bug 2: SymbOS/HDCPM set `Sn_PORT` explicitly before `SCMD_OPEN`.
- Bug 3: They don't reuse sockets in the tight pattern that exposes the lingering DISCON.
- Bug 4: They use the W5100S's raw register access for RX without relying on the chip-wide IR summary.

## Test plan
- [x] FUZIX `telnet 64.13.139.230` from a clean boot → handshake completes, telehack banner renders on screen
- [x] FUZIX repeated telnet attempts → no spurious "Connection refused" on first try
- [x] SymbOS Net4CPC sanity (netd, telnet) → unchanged
- [x] HDCPM Net4CPC sanity → unchanged

## Evidence

pcap diffs in `debug/fuzix-net4cpc/logs/` (uncommitted local harness, gitignored). Compare `tcpdump2-…` (pre-fix: source port 0, [S.] response loop) with `verify-fix-…` (post-fix: ephemeral port, clean handshake, full data transfer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)