### PR TITLE
Fix FUZIX-on-M4 boot: implement C_ROMLOW (0x433D) so v2.0.7+ detection passes

### DIFF
--- a/src/m4.c
+++ b/src/m4.c
@@ -57,6 +57,7 @@ int m4_trace = 0;
 #define C_NETRECV     0x4335
 #define C_NETHOSTIP   0x4336
 #define C_NETRSSI     0x4337
+#define C_ROMLOW      0x433D
 #define C_NETBIND     0x4338
 #define C_NETLISTEN   0x4339
 #define C_NETACCEPT   0x433A
@@ -571,6 +572,26 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
         m->nmi_enabled = (plen > 0) ? (p[0] == 0) : false;
         if (m4_trace) fprintf(stderr, "[m4]      NMI -> %s\n",
                               m->nmi_enabled ? "ENABLED" : "DISABLED");
+        err = M4_OK;
+        break;
+
+    case C_ROMLOW:
+        /* M4 firmware v2.0.7+ board-detection helper used by FUZIX.
+         * arg = 2 → "hack" mode: route subsequent lower-ROM reads to
+         *           the M4 snapshot-ROM image instead of OS_6128.ROM.
+         *           FUZIX reads byte 0x100 expecting 'M' ("MV - SNA"
+         *           header) and byte 0x0 expecting the M4 rom number.
+         * arg = 1 → restore default lower ROM.
+         * We back this with a stub (mem->m4_snapshot_rom_stub) that
+         * has just the two bytes FUZIX checks; enough to pass
+         * detection. */
+        if (plen > 0) {
+            if (p[0] == 2) mem->lower_rom_override = mem->m4_snapshot_rom_stub;
+            else if (p[0] == 1) mem->lower_rom_override = NULL;
+        }
+        if (m4_trace) fprintf(stderr, "[m4]      ROMLOW arg=%u -> override %s\n",
+                              plen ? p[0] : 0,
+                              mem->lower_rom_override ? "STUB" : "OFF");
         err = M4_OK;
         break;
 

--- a/src/mem.c
+++ b/src/mem.c
@@ -26,6 +26,13 @@ void mem_init(Mem *m) {
     m->upper_rom_select  = 0;
     m->ram_bank          = 0;
     m->ram_size          = 0x20000;  /* default 128 KB; caller sets from config */
+    /* Populate the M4 snapshot-ROM stub: FUZIX reads two bytes —
+     * 'M' (0x4D) at 0x100 (the "MV - SNA" header), and a rom slot
+     * number at 0x0. Filling rest with 0xFF mirrors blank ROM. */
+    memset(m->m4_snapshot_rom_stub, 0xFF, sizeof(m->m4_snapshot_rom_stub));
+    m->m4_snapshot_rom_stub[0x000] = 0x06;  /* M4_ROM_SLOT in m4.h — must match where M4ROM.ROM loads */
+    m->m4_snapshot_rom_stub[0x100] = 0x4D;  /* 'M' — start of "MV - SNA" */
+    m->lower_rom_override = NULL;
 }
 
 int mem_load_os(Mem *m, const char *path) {
@@ -152,8 +159,11 @@ static inline u8 read_ram(const Mem *m, u32 off) {
 
 u8 mem_read(Mem *m, u16 addr) {
     /* Lower ROM overlay */
-    if (addr < 0x4000 && m->lower_rom_enabled)
+    if (addr < 0x4000 && m->lower_rom_enabled) {
+        if (m->lower_rom_override)
+            return m->lower_rom_override[addr];
         return m->rom_os[addr];
+    }
 
     /* Upper ROM overlay — always wins on reads at 0xC000 when enabled,
      * even when banking is active (writes still go to banked RAM). */

--- a/src/mem.h
+++ b/src/mem.h
@@ -38,6 +38,19 @@ typedef struct {
     bool upper_rom_enabled;
     u8   upper_rom_select;  /* current upper ROM slot (written via port 0xDFxx) */
     u8   ram_bank;          /* 6128 banking config (Gate Array port 0x7F) */
+    /* When non-NULL and the lower ROM is enabled, reads in 0x0000-0x3FFF
+     * come from this buffer instead of rom_os. Used by the M4 board's
+     * C_ROMLOW (0x433D) "hack low rom" mode that FUZIX v2.0.7+ uses to
+     * detect the board (reads byte 0x100, expects 'M' — start of the
+     * "MV - SNA" snapshot header) and to fetch the M4 rom slot number
+     * from offset 0x0. Set/cleared by m4.c's C_ROMLOW handler. */
+    const u8 *lower_rom_override;
+    /* Stub "M4 snapshot ROM" used by FUZIX detection. Real M4 firmware
+     * exposes a full snapshot loader here; FUZIX only reads two bytes
+     * (rom number at 0x0, 'M' identifier at 0x100) so a 16 KB blob with
+     * just those is enough to pass detection and let FUZIX proceed to
+     * use C_SDREAD/C_SDWRITE, which we already emulate. */
+    u8   m4_snapshot_rom_stub[ROM_OS_SIZE];
 } Mem;
 
 void mem_init(Mem *m);


### PR DESCRIPTION
## Summary

FUZIX cpcsme's M4 detection (`Kernel/platform/platform-cpcsme/m4board.s _m4_init`) probes the board via M4 firmware v2.0.7+ command `C_ROMLOW` with arg=2, then reads byte 0x100 of the lower ROM expecting `'M'` (start of "MV - SNA"). We didn't emulate `C_ROMLOW`, so FUZIX saw whatever happened to be at 0x100 in OS_6128.ROM (`0x2F`) and bailed:

```
M4Board not found, read: 2F from address 0x100 at low rom.
hda: I/O error
```

After this fix:

```
M4Board found, date: 11:56:00 2026-06-20
hda: hda1 hda2 hda3 (swap) hda4
```

FUZIX then boots to a shell from `hda1` over the existing M4 SD-card I/O path.

## What changed

- `src/mem.h` — `Mem.lower_rom_override` (NULL by default) + `Mem.m4_snapshot_rom_stub[16K]` buffer
- `src/mem.c` — init the stub with the two bytes FUZIX reads (rom slot `0x06` at offset 0, `'M'` at offset 0x100; rest `0xFF`); `mem_read()` consults the override when the lower ROM is enabled
- `src/m4.c` — `C_ROMLOW` (0x433D) handler: arg=2 → points override at the stub; arg=1 → restores NULL

Real M4 firmware exposes a full snapshot loader in that slot; the stub is the minimum to pass detection and let FUZIX use the existing `C_SDREAD`/`C_SDWRITE`.

## What this does NOT fix

FUZIX networking on this disk still reports `ifconfig: networking not enabled.` — that's a FUZIX-kernel-side build option (the disk Antonio shipped wasn't built with the network stack), not a 1984 emulation gap. We'd still need to implement `C_NETBIND`/`C_NETLISTEN`/`C_NETACCEPT`/`C_GETNETWORK`/`C_UPGRADE` before a network-enabled FUZIX-M4 disk would work, but those are blocked on Antonio's upstream FUZIX work (his M4 networking is still in development pending M4 firmware 2.0.8).

## Test plan
- [x] FUZIX on M4 disk (fuzix_m4_sfide_albsd_usiser_sfrtc_floppy.dsk): boot to bootdev, type hda1, shell appears
- [x] M4 board detection logs "M4Board found, date: <valid time>"
- [x] hda1-hda4 enumerate
- [ ] M4 networking — left for follow-up once Antonio's FUZIX kernel supports it

🤖 Generated with [Claude Code](https://claude.com/claude-code)