### PR TITLE
net4cpc: randomize ephemeral source port per-process

### DIFF
--- a/src/net4cpc.c
+++ b/src/net4cpc.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 
 int net4cpc_trace = 0;
 
@@ -314,7 +315,14 @@ static void handle_command(int s, u8 cmd) {
              * mirror back to the register so reads stay consistent. */
             u16 lport = get16(SOCK_BASE[s] + 0x04);
             if (lport == 0) {
-                static u16 ephemeral_next = 49152;
+                /* Seeded from time+pid on first call so successive 1984
+                 * processes don't all start at 49152 and collide with
+                 * stale half-open conns on long-lived servers. */
+                static u16 ephemeral_next = 0;
+                if (ephemeral_next == 0) {
+                    u32 mix = (u32)time(NULL) ^ ((u32)getpid() << 8);
+                    ephemeral_next = (u16)(49152 + (mix % (65536u - 49152u)));
+                }
                 lport = ephemeral_next++;
                 if (ephemeral_next == 0) ephemeral_next = 49152;
                 set16(SOCK_BASE[s] + 0x04, lport);


### PR DESCRIPTION
## Summary
- The Sn_PORT auto-assign added in PR #150 used a static counter starting at 49152 at compile time, so every 1984 process started picking ephemeral ports from the same place.
- Reconnecting to a server that still held the prior half-open connection (e.g. after we SIGTERMed 1984 without a clean FIN) produced a server-side challenge-ACK per RFC 5961 instead of a SYN-ACK, leaving FUZIX hung in connect().
- Seed the counter from time() ^ pid on first use; subsequent OPENs in the same process still increment.

## Test plan
- [x] Reproduced the hang: three back-to-back 1984 launches all sent SYN from port 49152; pcap showed challenge-ACKs from the server.
- [x] After patch: each launch uses a different starting port (verified 64523, 61537, 55950 in test runs); SYN-ACKs come back normally.
- [x] Cross-server: bare telnet + telnet -a both confirmed working to bananapim1 and Telehack with the patch.
- [x] No FUZIX kernel changes; backward compatible with all existing W5100S clients.

Caught while investigating Antonio's telnet -a freeze report. The freeze itself turned out to be Telehack/server silence, not a 1984 bug. This port-reuse issue is a real regression worth fixing on its own.

Generated with Claude Code