### PR TITLE
leds: 3-segment M4 LED at 1.5× width (#154)

### DIFF
--- a/src/leds.c
+++ b/src/leds.c
@@ -15,6 +15,7 @@ static const LedPalette palette[LED_COUNT] = {
     [LED_SD]     = { 25, 50,110,   90, 160, 255 },
     [LED_NET]    = { 80, 70, 18,  255, 224,  32 },   /* Net4CPC — yellow */
     [LED_USIFAC] = { 0 },   /* Split LED renders both halves; entries unused. */
+    [LED_M4]     = { 0 },   /* Triple LED renders three segments; entries unused. */
 };
 
 /* Idle/active colours for the split-LED halves (USIfAC RS232). The left
@@ -22,6 +23,14 @@ static const LedPalette palette[LED_COUNT] = {
  * TX. Colours chosen to read at a glance against the dark LED bar. */
 static const LedPalette palette_usifac_rx = { 70, 18, 18,  255,  70,  70 };
 static const LedPalette palette_usifac_tx = { 18, 70, 18,   80, 255,  80 };
+
+/* M4 LED: three segments left-to-right.
+ *   power : blue,  steady-on while M4 enabled (no idle state used)
+ *   disk  : red,   ping on SD / file API command
+ *   net   : white, ping on M4 networking command */
+static const LedPalette palette_m4_power = { 25, 50,110,   90, 160, 255 };
+static const LedPalette palette_m4_disk  = { 70, 18, 18,  255,  70,  70 };
+static const LedPalette palette_m4_net   = { 70, 70, 70,  240, 240, 240 };
 
 static bool   g_enabled  [LED_COUNT];
 static Uint64 g_last_ms  [LED_COUNT];   /* Generic, also used for LED_USIFAC RX half */
@@ -40,6 +49,9 @@ void leds_ping_split(LedId id, bool tx) {
         (tx ? g_last_ms_b : g_last_ms)[id] = SDL_GetTicks();
 }
 
+void leds_ping_m4_disk(void) { g_last_ms  [LED_M4] = SDL_GetTicks(); }
+void leds_ping_m4_net (void) { g_last_ms_b[LED_M4] = SDL_GetTicks(); }
+
 void leds_render(SDL_Renderer *r, int x, int y, int w, int h) {
     /* Bar background */
     SDL_SetRenderDrawColor(r, 18, 18, 18, 255);
@@ -51,29 +63,63 @@ void leds_render(SDL_Renderer *r, int x, int y, int w, int h) {
     SDL_FRect line = { (float)x, (float)y, (float)w, 1.0f };
     SDL_RenderFillRect(r, &line);
 
-    /* Count enabled LEDs to centre them in the bar */
-    int n = 0;
-    for (int i = 0; i < LED_COUNT; i++) if (g_enabled[i]) n++;
-    if (n == 0) return;
+    const int led_w    = 24;
+    const int led_w_m4 = led_w * 3 / 2;     /* M4 is 1.5× wide */
+    const int led_h    = 10;
+    const int pad      = 8;
 
-    const int led_w   = 24;
-    const int led_h   = 10;
-    const int pad     = 8;
-    const int total_w = n * led_w + (n - 1) * pad;
-    int       cx      = x + (w - total_w) / 2;
-    const int cy      = y + (h - led_h) / 2;
+    /* Sum widths + padding for centring. LED_M4 contributes the wider
+     * footprint; everything else uses led_w. */
+    int n = 0, total_w = 0;
+    for (int i = 0; i < LED_COUNT; i++) {
+        if (!g_enabled[i]) continue;
+        total_w += (i == LED_M4) ? led_w_m4 : led_w;
+        n++;
+    }
+    if (n == 0) return;
+    total_w += (n - 1) * pad;
+
+    int       cx = x + (w - total_w) / 2;
+    const int cy = y + (h - led_h) / 2;
 
     Uint64 now = SDL_GetTicks();
     for (int i = 0; i < LED_COUNT; i++) {
         if (!g_enabled[i]) continue;
 
-        SDL_FRect led = { (float)cx, (float)cy, (float)led_w, (float)led_h };
+        const int this_w = (i == LED_M4) ? led_w_m4 : led_w;
+        SDL_FRect led = { (float)cx, (float)cy, (float)this_w, (float)led_h };
 
-        if (i == LED_USIFAC) {
+        if (i == LED_M4) {
+            /* Triple-segment LED: blue power (steady), red disk, white net.
+             * Three equal slices, single outline around the whole footprint. */
+            const int seg_w = led_w_m4 / 3;
+            const LedPalette *segs[3] = {
+                &palette_m4_power, &palette_m4_disk, &palette_m4_net
+            };
+            for (int s = 0; s < 3; s++) {
+                const LedPalette *p = segs[s];
+                bool active;
+                if (s == 0) {
+                    active = true;                          /* power: always on */
+                } else {
+                    Uint64 ts = (s == 1) ? g_last_ms[i] : g_last_ms_b[i];
+                    active = ts != 0 && (now - ts) < LED_GLOW_MS;
+                }
+                uint8_t R = active ? p->br : p->dr;
+                uint8_t G = active ? p->bg : p->dg;
+                uint8_t B = active ? p->bb : p->db;
+                SDL_FRect seg = { (float)(cx + s * seg_w), (float)cy,
+                                  (float)seg_w, (float)led_h };
+                SDL_SetRenderDrawColor(r, R, G, B, 255);
+                SDL_RenderFillRect(r, &seg);
+            }
+            SDL_SetRenderDrawColor(r, 0, 0, 0, 255);
+            SDL_RenderRect(r, &led);
+        } else if (i == LED_USIFAC) {
             /* Split LED: left half red (RX), right half green (TX). Same
              * outer footprint as a normal LED so the bar layout is
              * unchanged. */
-            const int half_w = led_w / 2;
+            const int half_w = this_w / 2;
             for (int side = 0; side < 2; side++) {
                 const LedPalette *p = side == 0 ? &palette_usifac_rx
                                                 : &palette_usifac_tx;
@@ -106,6 +152,6 @@ void leds_render(SDL_Renderer *r, int x, int y, int w, int h) {
             SDL_RenderRect(r, &led);
         }
 
-        cx += led_w + pad;
+        cx += this_w + pad;
     }
 }

--- a/src/leds.h
+++ b/src/leds.h
@@ -25,6 +25,7 @@ typedef enum {
     LED_SD,
     LED_NET,
     LED_USIFAC,    /* Split red/green: left half = RX, right half = TX. */
+    LED_M4,        /* Triple-segment, 1.5× width: blue=power, red=disk, white=net. */
     LED_COUNT
 } LedId;
 
@@ -38,6 +39,11 @@ void leds_ping(LedId id);
  * Currently only LED_USIFAC is split. Calling with tx=false lights the
  * red (RX) half; tx=true lights the green (TX) half. */
 void leds_ping_split(LedId id, bool tx);
+
+/* M4 board has three segments: power (always lit while enabled), disk,
+ * and network. These ping the disk and net segments respectively. */
+void leds_ping_m4_disk(void);
+void leds_ping_m4_net(void);
 
 /* Render the LED bar across (x,y,w,h). The caller has already cleared the
  * renderer and drawn the CPC screen above this rect. */

--- a/src/m4.c
+++ b/src/m4.c
@@ -899,7 +899,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_READ: {
-        leds_ping(LED_SD);
+        leds_ping_m4_disk();
         /* Request:  data[0]=fd, data[1..2]=size
          * Response: resp+3 = result (0=OK)
          *           resp+4 onwards = exactly `size` bytes (zero-padded on EOF).
@@ -938,7 +938,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_READ2: {
-        leds_ping(LED_SD);
+        leds_ping_m4_disk();
         /* Same as C_READ but skips AMSDOS header detection. Used by
          * char_in for unbuffered reads.
          * Request:  data[0]=fd, data[1..2]=size
@@ -983,7 +983,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_WRITE: {
-        leds_ping(LED_SD);
+        leds_ping_m4_disk();
         if (plen < 1) { err = M4_ERR_IO; break; }
         u8 fd = p[0];
         if (!valid_fd(m, fd)) { err = M4_ERR_BADFD; break; }
@@ -998,7 +998,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_WRITE2: {
-        leds_ping(LED_SD);
+        leds_ping_m4_disk();
         if (plen < 2) { err = M4_ERR_IO; break; }
         u8 fd = p[0];
         u8 ch = p[1];
@@ -1107,7 +1107,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_SDREAD: {
-        leds_ping(LED_SD);
+        leds_ping_m4_disk();
         /* Raw block read from the SD card image.
          * Request:  data[0..3]=LBA (little-endian 32-bit), data[4]=num sectors
          * Response: resp+3 = status (0=OK, 3=not ready, 4=invalid param)
@@ -1141,7 +1141,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_SDWRITE: {
-        leds_ping(LED_SD);
+        leds_ping_m4_disk();
         /* Raw block write to the SD card image.
          * Request:  data[0..3]=LBA, data[4]=num sectors, data[5..]=sector data
          * Response: resp+3 = status (0=OK, 1=R/W err, 2=write-protected). */
@@ -1264,6 +1264,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
         break;
 
     case C_NETSOCKET: {
+        leds_ping_m4_net();
         /* Allocate a TCP socket. Return socket id 1..4 at resp+3, or 0xFF. */
         int idx = -1;
         for (int i = 1; i < M4_NSOCKS; i++)
@@ -1291,6 +1292,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_NETCONNECT: {
+        leds_ping_m4_net();
         u8 ok = 0xFF;
         if (plen >= 7) {
             int s = p[0];
@@ -1337,6 +1339,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_NETCLOSE: {
+        leds_ping_m4_net();
         if (plen >= 1) {
             int s = p[0];
             /* SymbOS daemon workaround: it appears to pass arbitrary garbage
@@ -1359,6 +1362,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_NETSEND: {
+        leds_ping_m4_net();
         u8 ok = 0xFF;
         if (plen >= 3) {
             int s = p[0];
@@ -1388,6 +1392,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_NETRECV: {
+        leds_ping_m4_net();
         /* Response: resp+3 = result (0=OK), resp+4..5 = actual size,
          *           resp+6.. = data (up to 2KB). Both cpc-sdcc's net_recv
          *           and the SymbOS daemon's m4ctrx (which fetches from
@@ -1438,6 +1443,7 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_NETHOSTIP: {
+        leds_ping_m4_net();
         /* Synchronous resolution into socket 0's sock_info entry. */
         if (plen < 1) { err = M4_OK; resp_u8(m, &roff, 0xFF); break; }
         char host[256];

--- a/src/main.c
+++ b/src/main.c
@@ -207,7 +207,8 @@ static void apply_led_enables(const Config *cfg) {
     bool mx4 = cfg->rom_board;
     leds_set_enabled(LED_IDE, mx4 && cfg->symbiface_ide);
     leds_set_enabled(LED_USB, mx4 && cfg->albireo);
-    leds_set_enabled(LED_SD,  mx4 && cfg->m4);
+    leds_set_enabled(LED_SD,  false);            /* retired — replaced by LED_M4 */
+    leds_set_enabled(LED_M4,  mx4 && cfg->m4);
     leds_set_enabled(LED_NET, mx4 && cfg->net4cpc);
     leds_set_enabled(LED_USIFAC, mx4 && cfg->usifac);
 }


### PR DESCRIPTION
## Summary
Implements issue #154: replaces M4's share of the generic blue LED_SD with a dedicated LED_M4 footprint that is 1.5× the standard width, divided into three equal segments.

| Segment | Colour | Lit when |
|---|---|---|
| Power | Blue | M4 is enabled (steady) |
| Disk | Red | M4 SD / file API command |
| Net | White | M4 networking command |

## Implementation notes
- New `LED_M4` enum + `leds_ping_m4_disk()` / `leds_ping_m4_net()` API in `src/leds.{h,c}`.
- `leds_render()` now computes `total_w` per-LED so the bar centres correctly when LED_M4 is enabled.
- Three colour palettes: blue power (always bright), red disk, white net.
- M4's old `leds_ping(LED_SD)` calls in `src/m4.c` (6 sites) now use `leds_ping_m4_disk()`.
- Net pings added at `C_NETSOCKET/CONNECT/CLOSE/SEND/RECV/HOSTIP`.
- `src/main.c` retires `LED_SD` (set to false) and enables `LED_M4` when M4 is on.

## Test plan
- [x] Build clean
- [x] User-verified visually: 1.5× M4 LED renders with blue power steady, red disk pulses on SD I/O, white net pulses on M4 net commands
- [x] No regression on USIfAC split LED or other LEDs

Closes #154

Generated with Claude Code