### PR TITLE
display: monochrome tint (green/amber/white) — #158

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>      /* strcasecmp */
 #include <ctype.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -100,6 +101,23 @@ static char *trim(char *s) {
     while (end > s && isspace((unsigned char)*(end - 1))) end--;
     *end = '\0';
     return s;
+}
+
+static const char *mono_to_str(MonoMode m) {
+    switch (m) {
+        case MONO_GREEN: return "green";
+        case MONO_AMBER: return "amber";
+        case MONO_WHITE: return "white";
+        default:         return "off";
+    }
+}
+
+static bool parse_mono(const char *val, MonoMode *out) {
+    if (!strcasecmp(val, "off"))   { *out = MONO_OFF;   return true; }
+    if (!strcasecmp(val, "green")) { *out = MONO_GREEN; return true; }
+    if (!strcasecmp(val, "amber")) { *out = MONO_AMBER; return true; }
+    if (!strcasecmp(val, "white")) { *out = MONO_WHITE; return true; }
+    return false;
 }
 
 static bool parse_bool(const char *val, bool *out) {
@@ -209,6 +227,9 @@ static void config_create_default(const char *path, const char *home) {
         "fullscreen=false\n"
         "# Smooth (linear) vs sharp (nearest) texture scaling\n"
         "fullscreen_smoothing=true\n"
+        "# Monochrome monitor tint: off | green | amber | white\n"
+        "# Maps the CPC palette to shades of one phosphor colour.\n"
+        "monochrome=off\n"
         "\n"
         "[advanced]\n"
         "# Enable the Advanced overlay tab with low-level toggles\n"
@@ -429,6 +450,10 @@ int config_load_from(Config *cfg, const char *path_override) {
                 bool b;
                 if (parse_bool(val, &b)) cfg->fullscreen_smoothing = b;
                 else { fprintf(stderr, "1984.conf:%d: fullscreen_smoothing must be true/false\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "monochrome")) {
+                MonoMode m;
+                if (parse_mono(val, &m)) cfg->monochrome = m;
+                else { fprintf(stderr, "1984.conf:%d: monochrome must be off/green/amber/white\n", lineno); rc = -1; }
             }
         } else if (!strcmp(section, "advanced")) {
             if (!strcmp(key, "tinker")) {
@@ -566,7 +591,8 @@ int config_save(const Config *cfg) {
         "[display]\n"
         "scale=%d\n"
         "fullscreen=%s\n"
-        "fullscreen_smoothing=%s\n\n"
+        "fullscreen_smoothing=%s\n"
+        "monochrome=%s\n\n"
         "[advanced]\n"
         "tinker=%s\n"
         "debug=%s\n",
@@ -601,6 +627,7 @@ int config_save(const Config *cfg) {
         cfg->scale,
         cfg->fullscreen ? "true" : "false",
         cfg->fullscreen_smoothing ? "true" : "false",
+        mono_to_str(cfg->monochrome),
         cfg->tinker     ? "true" : "false",
         cfg->debug      ? "true" : "false"
     );

--- a/src/config.h
+++ b/src/config.h
@@ -92,6 +92,7 @@ typedef struct {
     int  scale;             /* 1, 2, or 3 */
     bool fullscreen;
     bool fullscreen_smoothing; /* linear (smooth) vs nearest (sharp) texture scale */
+    MonoMode monochrome;       /* off / green / amber / white phosphor tint */
 
     /* [advanced] */
     bool tinker;             /* enable Advanced overlay tab with low-level toggles */

--- a/src/gate_array.c
+++ b/src/gate_array.c
@@ -14,8 +14,30 @@ const u32 ga_hw_palette[32] = {
     0x800000, 0x8000FF, 0x808000, 0x8080FF,
 };
 
+/* Map a colour RGB through the active monochrome tint. MONO_OFF returns
+ * rgb unchanged so the cold path is a single compare + branch. */
+static u32 apply_mono(u32 rgb, MonoMode m) {
+    if (m == MONO_OFF) return rgb;
+    u32 r = (rgb >> 16) & 0xff, g = (rgb >> 8) & 0xff, b = rgb & 0xff;
+    /* Rec. 601 luma; matches display_apply_greyscale in src/display.c. */
+    u32 L = (306u * r + 601u * g + 117u * b) >> 10;
+    if (L > 255) L = 255;
+    switch (m) {
+        case MONO_GREEN: return L << 8;                            /* 0,L,0 */
+        case MONO_AMBER: return (L << 16) | ((L * 3 / 4) << 8);    /* L,0.75L,0 */
+        case MONO_WHITE: return (L << 16) | (L << 8) | L;
+        default:         return rgb;
+    }
+}
+
 void ga_init(GateArray *ga) {
+    /* Preserve the user's monochrome selection across hard resets: a
+     * warm reboot via the overlay shouldn't flip the screen back to
+     * colour. ga_set_monochrome() is still the one entrypoint that
+     * changes the field. */
+    MonoMode keep_mono = ga->monochrome;
     memset(ga, 0, sizeof(*ga));
+    ga->monochrome = keep_mono;
     ga->lower_rom = true;
     ga->upper_rom = true;
     ga->screen_mode = 1;
@@ -26,7 +48,14 @@ void ga_init(GateArray *ga) {
     ga->ink[0]  = 0x1A;   /* typical border */
     ga->ink[1]  = 0x04;
     for (int i = 0; i < GA_NUM_INKS; i++)
-        ga->resolved_ink[i] = ga_hw_palette[ga->ink[i] & 0x1F];
+        ga->resolved_ink[i] = apply_mono(ga_hw_palette[ga->ink[i] & 0x1F],
+                                          ga->monochrome);
+}
+
+void ga_set_monochrome(GateArray *ga, MonoMode m) {
+    ga->monochrome = m;
+    for (int i = 0; i < GA_NUM_INKS; i++)
+        ga->resolved_ink[i] = apply_mono(ga_hw_palette[ga->ink[i] & 0x1F], m);
 }
 
 void ga_write(GateArray *ga, u8 val) {
@@ -38,7 +67,8 @@ void ga_write(GateArray *ga, u8 val) {
         case 0x01:   /* Set ink colour */
             if (ga->selected_pen < GA_NUM_INKS) {
                 ga->ink[ga->selected_pen] = val & 0x1F;
-                ga->resolved_ink[ga->selected_pen] = ga_hw_palette[val & 0x1F];
+                ga->resolved_ink[ga->selected_pen] =
+                    apply_mono(ga_hw_palette[val & 0x1F], ga->monochrome);
             }
             break;
         case 0x02:   /* Screen mode + ROM control */

--- a/src/gate_array.h
+++ b/src/gate_array.h
@@ -13,12 +13,24 @@
 
 #define GA_NUM_INKS 17   /* 16 inks + 1 border */
 
+/* Monochrome display tint applied to resolved_ink[]. MONO_OFF preserves
+ * the original colour palette bit-for-bit. The non-off modes map each
+ * CPC ink to a shade of the chosen tint via a Rec. 601 luma transform,
+ * emulating a period-typical monochrome monitor (e.g. CPC GT65 green). */
+typedef enum {
+    MONO_OFF = 0,
+    MONO_GREEN,
+    MONO_AMBER,
+    MONO_WHITE,
+} MonoMode;
+
 typedef struct {
     u8  ink[GA_NUM_INKS];    /* hardware colour index (0-31) */
     /* Resolved RGB888 cache of ink[]; kept in sync by ga_init / ga_write so
      * the per-pixel render path can do a single u32 load instead of two
      * dependent array lookups (ink[pen] then ga_hw_palette[idx]). */
     u32 resolved_ink[GA_NUM_INKS];
+    MonoMode monochrome;     /* tint applied when resolving inks; OFF = colour */
     u8  selected_pen;        /* current pen register (bit 4 = border) */
     u8  screen_mode;         /* 0/1/2 — active mode (latched on HSYNC) */
     u8  requested_mode;      /* mode written via ga_write; copied to screen_mode on next HSYNC */
@@ -34,6 +46,11 @@ extern const u32 ga_hw_palette[32];
 
 void ga_init(GateArray *ga);
 void ga_write(GateArray *ga, u8 val);   /* port 0x7F (A15=0) */
+
+/* Switch the monochrome tint mode. Re-resolves all 17 inks so the new
+ * tint takes effect on the next rendered frame without waiting for the
+ * program to rewrite its palette. */
+void ga_set_monochrome(GateArray *ga, MonoMode m);
 u8   ga_mode(GateArray *ga);
 void ga_hsync(GateArray *ga);           /* called by CRTC on each HSYNC */
 void ga_vsync_start(GateArray *ga);     /* called on CRTC VSYNC rising edge */

--- a/src/main.c
+++ b/src/main.c
@@ -526,6 +526,7 @@ int main(int argc, char *argv[]) {
         return 1;
     }
     SD_LOG("cpc_init OK");
+    ga_set_monochrome(&cpc.ga, cfg.monochrome);
     cpc.mem.ram_size    = cfg.memory_kb * 1024;
     cpc.mx4             = cfg.mx4;
     cpc.net4cpc         = cfg.net4cpc;

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -35,7 +35,7 @@ static const int sec_x[OV_SEC_COUNT] = { 8, 80, 160, 248 };
  * "External Tape" toggle, only meaningful on the 6128 since the 464 has
  * the cassette deck built in). Other sections are fixed.
  * The Advanced tab (OV_TINKER) is hidden unless cfg->tinker is enabled. */
-static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 12, 10 };
+static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 12, 11 };
 
 static int ov_section_rows(const Overlay *ov, OvSection s) {
     if (s == OV_GENERAL && ov->cfg->model != MODEL_464) return 8;
@@ -403,6 +403,15 @@ static void item_text(const Overlay *ov, int row,
             }
             break;
         case 9:
+            snprintf(lbl, lsz, "Monochrome");
+            switch (ov->cfg->monochrome) {
+                case MONO_GREEN: snprintf(val, vsz, "green"); break;
+                case MONO_AMBER: snprintf(val, vsz, "amber"); break;
+                case MONO_WHITE: snprintf(val, vsz, "white"); break;
+                default:         snprintf(val, vsz, "off");   break;
+            }
+            break;
+        case 10:
             snprintf(lbl, lsz, "Version");
             snprintf(val, vsz, "%s (commit %s)", PACKAGE_VERSION, PROG_GIT_COMMIT);
             *readonly = true;
@@ -940,6 +949,19 @@ static void activate_item(Overlay *ov) {
             }
             ov->dirty = true;
             break;
+        case 9: {
+            MonoMode next;
+            switch (ov->cfg->monochrome) {
+                case MONO_OFF:   next = MONO_GREEN; break;
+                case MONO_GREEN: next = MONO_AMBER; break;
+                case MONO_AMBER: next = MONO_WHITE; break;
+                default:         next = MONO_OFF;   break;
+            }
+            ov->cfg->monochrome = next;
+            if (ov->cpc) ga_set_monochrome(&ov->cpc->ga, next);
+            ov->dirty = true;
+            break;
+        }
         }
         break;
 
@@ -1612,10 +1634,24 @@ void overlay_render(const Overlay *ov, SDL_Renderer *r) {
 
         float ty = iy + (ITEM_H - FONT_H) / 2.0f;
         draw_text(r, DROP_PAD, ty, lbl, 220, 220, 240);
-        if (readonly)
+        if (readonly) {
             draw_text(r, VAL_X, ty, val, 90, 90, 110);
-        else
+        } else if (ov->section == OV_TINKER && i == 9
+                   && ov->cfg->monochrome != MONO_OFF) {
+            /* Render the tint name in its own phosphor colour so the
+             * choice is recognisable at a glance. Bright values picked
+             * to read against both the selected-row blue and the bar. */
+            Uint8 R = 255, G = 200, B = 50;
+            switch (ov->cfg->monochrome) {
+                case MONO_GREEN: R =  90; G = 255; B =  90; break;
+                case MONO_AMBER: R = 255; G = 191; B =   0; break;
+                case MONO_WHITE: R = 255; G = 255; B = 255; break;
+                default: break;
+            }
+            draw_text(r, VAL_X, ty, val, R, G, B);
+        } else {
             draw_text(r, VAL_X, ty, val, 255, 200, 50);
+        }
     }
 
     /* ---- Confirm dialog ---- */


### PR DESCRIPTION
## Summary

Closes #158. Adds a phosphor-monitor emulation knob in the overlay
Advanced tab: **Monochrome: off / green / amber / white**. Maps the
CPC's hardware palette to shades of one phosphor colour via a Rec. 601
luma transform, so every program — including the border — renders in
monochrome with no per-game tweaks. Off keeps the colour palette
bit-for-bit.

- Tint applied at \`ga->resolved_ink[]\` write time (not per pixel), so
  the render hot path is unchanged.
- Survives warm reset; persists via \`monochrome=\` in 1984.conf
  `[display]` section.
- Overlay row renders the value name in its own phosphor colour for
  at-a-glance feedback.

## Test plan

- [x] Build clean in distrobox (no new warnings).
- [x] Overlay → Advanced → Monochrome cycles Off → Green → Amber →
      White live with no reset.
- [x] Border tints along with inks.
- [x] Cycling back to Off restores colour exactly.
- [x] Last-picked tint survives restart via 1984.conf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)