### PR TITLE
docs: add 1984(1) man page — #159

### DIFF
--- a/1984.1
+++ b/1984.1
@@ -1,0 +1,314 @@
+.TH 1984 1 "June 2026" "1984 0.4.7" "User Commands"
+.SH NAME
+1984 \- Amstrad CPC 464/664/6128 emulator
+.SH SYNOPSIS
+.B 1984
+.RI [ OPTIONS ]
+.SH DESCRIPTION
+.B 1984
+is a cycle-stepped Amstrad CPC 464/664/6128 emulator written in C
+with SDL3. It boots commercial games, BASIC, AMSDOS, CP/M 2.2 and
+CP/M Plus disk images, and a wide range of expansion hardware
+(M4 board, Albireo USB host, SYMBiFACE II / Cyboard, Net4CPC
+W5100S Ethernet, USIfAC II serial, RTC, mouse). The emulated core
+covers the Z80 CPU (including undocumented IX/IY half-register
+opcodes), MC6845 CRTC, AY-3-8912 PSG audio, \[mc]PD765 FDC, the
+Gate Array, the keyboard matrix, joystick/gamepad input, and
+cassette tape (.cdt / TZX images, with the loading screech mixed
+into PSG audio).
+.PP
+On first run
+.B 1984
+creates a configuration file at
+.IR ~/.config/1984/1984.conf
+with sensible defaults; the in-emulator overlay (F9) is the
+recommended way to edit it.
+.SH OPTIONS
+.SS Model selection
+.TP
+.B --464
+Boot as CPC 464 (overrides config).
+.TP
+.B --664
+Boot as CPC 664 (overrides config).
+.TP
+.B --6128
+Boot as CPC 6128 (overrides config).
+.TP
+.B --dd1
+Enable the DDI-1 floppy interface on the CPC 464 (overrides config).
+.TP
+.BI --memory= KB
+RAM size in kilobytes: 64, 128, 256, 512 or 576 (overrides config).
+.SS Files
+.TP
+.BI --config= PATH
+Read configuration from
+.I PATH
+instead of
+.IR ~/.config/1984/1984.conf .
+The override is read-only;
+.B 1984
+still writes saved settings to the default path.
+.TP
+.BI --disk-a= PATH
+Mount a .dsk image in drive A (overrides config).
+.TP
+.BI --disk-b= PATH
+Mount a .dsk image in drive B (overrides config).
+.TP
+.BI --rom-os= PATH
+Replace the OS (lower) ROM image.
+.TP
+.BI --rom-slot= N:PATH
+Load a ROM image into upper ROM slot
+.I N
+(0\(en31). May be repeated.
+.SS Networking
+.TP
+.BI --tap= DEVNAME
+Bind Net4CPC to a Linux TAP device for real LAN access. Pass
+.B --tap=
+(empty) to let the kernel auto-name (tap0\(en).
+Requires
+.B CAP_NET_ADMIN
+or a pre-created persistent TAP device. See
+.B NET4CPC
+for the built-in DHCP/DNS proxy options.
+.SS Automation and headless capture
+.TP
+.BI --autostart= NAME
+After boot, type
+.RB \(lq run\(rq NAME
+into BASIC.
+.TP
+.BI --paste= TEXT
+After boot, type
+.I TEXT
+verbatim (\fB\\n\fR becomes Enter).
+.TP
+.BI --load-sna= PATH
+Load an Amstrad .sna snapshot after init (v1 / v2 / v3).
+.TP
+.BI --save-sna-at= N:PATH
+Save a .sna snapshot at frame
+.IR N .
+Typically pairs with
+.B --paste
+or
+.BR --autostart .
+.TP
+.BI --save-sna-at-ide= N:PATH
+Save a .sna snapshot when the
+.IR N -th
+ATA command is issued (used for cross-emulator bisection).
+.TP
+.BI --screenshot-at= N:PATH
+Save a PPM screenshot at frame
+.IR N ,
+then exit.
+.TP
+.BI --gif-out= PATH
+Record a GIF from boot to
+.IR PATH ,
+finalised on exit. Pairs with
+.BR --exit-after .
+.TP
+.BI --exit-after= N
+Quit after frame
+.I N
+(deterministic headless capture).
+.TP
+.BI --joy-script= SPEC
+Scripted joystick (row 9). SPEC is a comma-separated list of
+.IB DIRS : FRAMES
+steps where
+.I DIRS
+is one or more of
+.BR u\ d\ l\ r\ 1\ 2
+(Fire1 / Fire2) or
+.B -
+(neutral). Example:
+.B --joy-script=d:150,-:30,u:150
+\(em down 150 frames, rest 30, up 150.
+.SS Debugging
+.TP
+.B --trace-io
+Log CRTC / Gate Array register writes to stderr.
+.TP
+.B --trace-palette
+Log palette writes and the firmware-flush fallback.
+.TP
+.B --trace-input
+Log keyboard, joystick, and gamepad events.
+.TP
+.B --trace-m4
+Log every M4 board command and response.
+.TP
+.B --trace-albireo
+Log every Albireo (CH376) command and response.
+.TP
+.B --trace-net4cpc
+Log every Net4CPC (W5100S) register access and socket command.
+.TP
+.B --trace-tap
+Log TAP-backed network stack events (ARP, IP, UDP, ICMP, TCP).
+.TP
+.B --trace-symbos-msg
+Log SymbOS RST #10 message sends (net-daemon range).
+.TP
+.BI --symbols= PATH
+Load an SDCC
+.B .map
+file and annotate the disassembler / monitor with the nearest
+preceding symbol. Repeatable. Use
+.BI --symbols= HEX:PATH
+to apply the map only when the live RAM bank (GA MMR) equals
+.IR HEX ,
+useful for paged operating systems such as FUZIX.
+.TP
+.B --monitor-pty
+Open a PTY for the memory monitor
+.RB ( "minicom -b 9600 -D" " " <path>).
+.TP
+.B --kbd-pty
+Open a PTY that injects writes as keystrokes and streams the
+firmware text-out
+.RB ( &BB5A )
+for external test harnesses.
+.TP
+.B --ocr-monitor
+Adds an in-memory screen-text reader: each frame the emulator
+scans video RAM, decodes it against the firmware font, and streams
+the 80x25 (or 40x25) character grid out the kbd PTY whenever it
+changes. Lets probes follow CP/M+ output that bypasses
+.BR &BB5A .
+Implies
+.BR --kbd-pty .
+.TP
+.BR -h ", " --help
+Show help and exit.
+.SH KEYBOARD SHORTCUTS
+.TP
+.B F4
+Save screenshot (.ppm).
+.TP
+.B F5
+Warm reset.
+.TP
+.B F6
+Toggle video capture (.gif in the current directory).
+.TP
+.B F8
+Open / close the memory monitor and disassembler.
+.TP
+.B F9
+Open the options overlay.
+.TP
+.B F11
+Toggle fullscreen.
+.TP
+.B F12
+Quit.
+.TP
+.B Ctrl+V
+Paste clipboard text into the emulator.
+.SH OVERLAY
+Press
+.B F9
+to open the in-emulator settings overlay. Four tabs are available:
+.TP
+.B General
+Model (464 / 664 / 6128), RAM size, MX4 expansion bus, Roms Board,
+DDI-1.
+.TP
+.B Media
+Floppy drives A and B, cassette tape, external tape toggle (CPC
+6128).
+.TP
+.B Extensions
+M4 board, Albireo USB, SYMBiFACE II IDE / mouse, Cyboard RTC,
+Net4CPC, USIfAC II, SymbNet, expansion ROM slots 0\(en31.
+.TP
+.B Advanced
+Smoothing (linear vs nearest scaling), snapshot load/save, Net4CPC
+TAP toggle, debug machinery, video capture, USIfAC mode (PTY /
+TCP), and the
+.B Monochrome
+phosphor tint (off, green, amber, white). The Advanced tab is
+hidden unless
+.B tinker=true
+is set in the config.
+.SH CONFIGURATION FILE
+.I ~/.config/1984/1984.conf
+is a small INI-style file with sections
+.BR [machine] ", " [roms] ", " [expansion_roms] ", "
+.BR [storage] ", " [hardware] ", " [display] ", and " [advanced] .
+A self-documented default is written on first run; the overlay
+edits it in place. Per-board ROM groupings are stored under
+.BI [board: NAME ]
+sections (m4, albireo, cyboard) and follow the matching hardware
+toggle automatically.
+.SH ENVIRONMENT
+Most environment variables are
+.B debug-only
+and are silently ignored unless
+.B debug=true
+is set in the
+.B [advanced]
+section of the config (or toggled via
+.BR "Overlay -> Advanced -> Debugging" ).
+.TP
+.B ONE_K_TRACE_*
+Per-subsystem trace flags
+.RB ( ONE_K_TRACE_IDE ", " ONE_K_TRACE_HDCPM ", "
+.BR ONE_K_TRACE_AUDIO ", " ONE_K_TRACE_PSG ", "
+.BR ONE_K_TRACE_PALETTE ", " ONE_K_TRACE_IRQ ", "
+.BR ONE_K_TRACE_KBDPTY ", " ONE_K_TRACE_SDL_EV ", " "and others)" .
+Set to any non-empty value to enable.
+.TP
+.B ONE_K_CAP_TEXT
+Capture the firmware text stream to stderr (frame-stamped).
+.TP
+.BR ONE_K_DUMP_PC ", " ONE_K_DUMP_RAM
+Panic-time PC trace and RAM dump.
+.TP
+.BR ONE_K_STOP_AT_LOOP ", " ONE_K_RESET_SNA
+Bisection helpers for tight loops and snapshot replay.
+.TP
+.B FAKE_RTC, FAKE_RTC_TIME
+Force the emulated RTC to a fixed wall-clock time (always honoured,
+not gated on debug).
+.TP
+.B CC_TABLES
+Force a specific cycle table variant. Always honoured.
+.TP
+.B AUTOSTART_FRAMES, PASTE_GAP
+Tune the autostart / paste pacing. Always honoured.
+.SH FILES
+.TP
+.I ~/.config/1984/1984.conf
+Configuration file.
+.TP
+.I ~/.config/1984/roms/
+Default location for user-supplied CPC ROMs and expansion ROMs.
+.TP
+.I /usr/share/1984/roms/
+System-wide ROM directory used when the user directory is empty
+(populated by the
+.B 1984
+RPM and equivalents with the bundled CPC firmware, M4ROM, and the
+Amstrad Diagnostics ROM).
+.SH BUGS
+Report issues at
+.UR https://github.com/salvogendut/1984/issues
+.UE .
+.SH AUTHOR
+Salvatore Bognanni
+.MT salvogendut@gmail.com
+.ME .
+.SH COPYRIGHT
+Copyright (C) 2025\(en2026 Salvatore Bognanni. License GPL-2.0-only.
+.SH SEE ALSO
+.BR caprice32 (1),
+.BR mame (6)

--- a/1984.spec
+++ b/1984.spec
@@ -1,5 +1,5 @@
 Name:           1984
-Version:        0.4.5
+Version:        0.4.7
 Release:        1%{?dist}
 Summary:        Amstrad CPC 464/6128 emulator
 
@@ -65,20 +65,31 @@ appstream-util validate-relax --nonet %{buildroot}%{_datadir}/metainfo/io.github
 %license LICENSE
 %doc README.md INSTALL.md USAGE.md
 %{_bindir}/%{name}
+%{_mandir}/man1/%{name}.1*
 %{_datadir}/applications/io.github.salvogendut.Emulator1984.desktop
 %{_datadir}/metainfo/io.github.salvogendut.Emulator1984.metainfo.xml
 %{_datadir}/icons/hicolor/*/apps/io.github.salvogendut.Emulator1984.png
 %dir %{_datadir}/%{name}
 %dir %{_datadir}/%{name}/roms
 %{_datadir}/%{name}/roms/AMSDOS.ROM
+%{_datadir}/%{name}/roms/AMSDOS_664.ROM
 %{_datadir}/%{name}/roms/AmstradDiagLower.rom
 %{_datadir}/%{name}/roms/BASIC_1.0.ROM
 %{_datadir}/%{name}/roms/BASIC_1.1.ROM
+%{_datadir}/%{name}/roms/BASIC_664.ROM
 %{_datadir}/%{name}/roms/M4ROM.ROM
 %{_datadir}/%{name}/roms/OS_464.ROM
+%{_datadir}/%{name}/roms/OS_664.ROM
 %{_datadir}/%{name}/roms/OS_6128.ROM
 
 %changelog
+* Sat Jun 20 2026 Salvatore Bognanni <salvogendut@gmail.com> - 0.4.7-1
+- Add 1984(1) man page (#159)
+- Add Monochrome display tint: off / green / amber / white (#158)
+- Ship 664 ROMs (OS_664, BASIC_664, AMSDOS_664) in the package
+- Distribute all in-tree headers and USAGE.md so `make dist` produces
+  a buildable tarball
+
 * Tue Jun 10 2026 Salvatore Bognanni <salvogendut@gmail.com> - 0.4.5-1
 - Segfault fixes: file-dialog cancel state, NULL videocap path, dead
   FDC ternary, unguarded snapshot load (#120)

--- a/Makefile
+++ b/Makefile
@@ -110,12 +110,12 @@ am__CONFIG_DISTCLEAN_FILES = config.status config.cache config.log \
 mkinstalldirs = $(install_sh) -d
 CONFIG_CLEAN_FILES =
 CONFIG_CLEAN_VPATH_FILES =
-am__installdirs = "$(DESTDIR)$(bindir)" "$(DESTDIR)$(desktopdir)" \
-	"$(DESTDIR)$(icon128dir)" "$(DESTDIR)$(icon16dir)" \
-	"$(DESTDIR)$(icon256dir)" "$(DESTDIR)$(icon32dir)" \
-	"$(DESTDIR)$(icon48dir)" "$(DESTDIR)$(icon512dir)" \
-	"$(DESTDIR)$(icon64dir)" "$(DESTDIR)$(metainfodir)" \
-	"$(DESTDIR)$(romsdir)"
+am__installdirs = "$(DESTDIR)$(bindir)" "$(DESTDIR)$(man1dir)" \
+	"$(DESTDIR)$(desktopdir)" "$(DESTDIR)$(icon128dir)" \
+	"$(DESTDIR)$(icon16dir)" "$(DESTDIR)$(icon256dir)" \
+	"$(DESTDIR)$(icon32dir)" "$(DESTDIR)$(icon48dir)" \
+	"$(DESTDIR)$(icon512dir)" "$(DESTDIR)$(icon64dir)" \
+	"$(DESTDIR)$(metainfodir)" "$(DESTDIR)$(romsdir)"
 PROGRAMS = $(bin_PROGRAMS)
 am__dirstamp = $(am__leading_dot)dirstamp
 am_1984_OBJECTS = src/1984-config.$(OBJEXT) src/1984-cpc.$(OBJEXT) \
@@ -228,6 +228,9 @@ am__uninstall_files_from_dir = { \
   || { echo " ( cd '$$dir' && rm -f" $$files ")"; \
        $(am__cd) "$$dir" && echo $$files | $(am__xargs_n) 40 $(am__rm_f); }; \
   }
+man1dir = $(mandir)/man1
+NROFF = nroff
+MANS = $(dist_man1_MANS)
 DATA = $(dist_desktop_DATA) $(dist_icon128_DATA) $(dist_icon16_DATA) \
 	$(dist_icon256_DATA) $(dist_icon32_DATA) $(dist_icon48_DATA) \
 	$(dist_icon512_DATA) $(dist_icon64_DATA) $(dist_metainfo_DATA) \
@@ -251,7 +254,7 @@ am__define_uniq_tagged_files = \
     if test -f "$$i"; then echo $$i; else echo $(srcdir)/$$i; fi; \
   done | $(am__uniquify_input)`
 AM_RECURSIVE_TARGETS = cscope
-am__DIST_COMMON = $(srcdir)/Makefile.in \
+am__DIST_COMMON = $(dist_man1_MANS) $(srcdir)/Makefile.in \
 	$(top_srcdir)/build-aux/compile \
 	$(top_srcdir)/build-aux/config.guess \
 	$(top_srcdir)/build-aux/config.sub \
@@ -327,7 +330,7 @@ PATH_SEPARATOR = :
 PKG_CONFIG = /usr/bin/pkg-config
 PKG_CONFIG_LIBDIR = 
 PKG_CONFIG_PATH = 
-PROG_GIT_COMMIT = 1728715
+PROG_GIT_COMMIT = 85133e2
 SDL3_CFLAGS = 
 SDL3_LIBS = -lSDL3
 SET_MAKE = 
@@ -390,6 +393,9 @@ target_alias =
 top_build_prefix = 
 top_builddir = .
 top_srcdir = .
+
+# Man page — installed under $(mandir)/man1/, included in `make dist`.
+dist_man1_MANS = 1984.1
 1984_SOURCES = \
 	src/config.c \
 	src/cpc.c \
@@ -433,6 +439,7 @@ top_srcdir = .
 
 noinst_HEADERS = \
 	src/ch376.h \
+	src/compat_win.h \
 	src/config.h \
 	src/cpc.h \
 	src/crtc.h \
@@ -447,6 +454,7 @@ noinst_HEADERS = \
 	src/ide.h \
 	src/joy.h \
 	src/kbd.h \
+	src/kbd_pty.h \
 	src/leds.h \
 	src/m4.h \
 	src/mem.h \
@@ -460,12 +468,16 @@ noinst_HEADERS = \
 	src/ppi.h \
 	src/psg.h \
 	src/rtc.h \
+	src/screen_text.h \
 	src/shutter_wav.h \
 	src/snapshot.h \
+	src/startup_debug.h \
 	src/symbnet.h \
+	src/symbols.h \
 	src/symbos_trace.h \
 	src/tape.h \
 	src/types.h \
+	src/usifac.h \
 	src/z80.h \
 	src/z80dis.h
 
@@ -519,7 +531,7 @@ dist_icon512_DATA = icons/512x512/apps/io.github.salvogendut.Emulator1984.png
 
 # Files shipped in the dist tarball but not built (license, hand-written
 # Makefile alternative, project docs).
-EXTRA_DIST = Makefile LICENSE Development.md icons/1984.rc icons/1984.ico
+EXTRA_DIST = Makefile LICENSE Development.md USAGE.md icons/1984.rc icons/1984.ico
 all: all-am
 
 .SUFFIXES:
@@ -1302,6 +1314,47 @@ src/1984-z80.obj: src/z80.c
 #	$(AM_V_CC)source='src/z80.c' object='src/1984-z80.obj' libtool=no \
 #	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) \
 #	$(AM_V_CC_no)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-z80.obj `if test -f 'src/z80.c'; then $(CYGPATH_W) 'src/z80.c'; else $(CYGPATH_W) '$(srcdir)/src/z80.c'; fi`
+install-man1: $(dist_man1_MANS)
+	@$(NORMAL_INSTALL)
+	@list1='$(dist_man1_MANS)'; \
+	list2=''; \
+	test -n "$(man1dir)" \
+	  && test -n "`echo $$list1$$list2`" \
+	  || exit 0; \
+	echo " $(MKDIR_P) '$(DESTDIR)$(man1dir)'"; \
+	$(MKDIR_P) "$(DESTDIR)$(man1dir)" || exit 1; \
+	{ for i in $$list1; do echo "$$i"; done;  \
+	if test -n "$$list2"; then \
+	  for i in $$list2; do echo "$$i"; done \
+	    | sed -n '/\.1[a-z]*$$/p'; \
+	fi; \
+	} | while read p; do \
+	  if test -f $$p; then d=; else d="$(srcdir)/"; fi; \
+	  echo "$$d$$p"; echo "$$p"; \
+	done | \
+	sed -e 'n;s,.*/,,;p;h;s,.*\.,,;s,^[^1][0-9a-z]*$$,1,;x' \
+	      -e 's,\.[0-9a-z]*$$,,;$(transform);G;s,\n,.,' | \
+	sed 'N;N;s,\n, ,g' | { \
+	list=; while read file base inst; do \
+	  if test "$$base" = "$$inst"; then list="$$list $$file"; else \
+	    echo " $(INSTALL_DATA) '$$file' '$(DESTDIR)$(man1dir)/$$inst'"; \
+	    $(INSTALL_DATA) "$$file" "$(DESTDIR)$(man1dir)/$$inst" || exit $$?; \
+	  fi; \
+	done; \
+	for i in $$list; do echo "$$i"; done | $(am__base_list) | \
+	while read files; do \
+	  test -z "$$files" || { \
+	    echo " $(INSTALL_DATA) $$files '$(DESTDIR)$(man1dir)'"; \
+	    $(INSTALL_DATA) $$files "$(DESTDIR)$(man1dir)" || exit $$?; }; \
+	done; }
+
+uninstall-man1:
+	@$(NORMAL_UNINSTALL)
+	@list='$(dist_man1_MANS)'; test -n "$(man1dir)" || exit 0; \
+	files=`{ for i in $$list; do echo "$$i"; done; \
+	} | sed -e 's,.*/,,;h;s,.*\.,,;s,^[^1][0-9a-z]*$$,1,;x' \
+	      -e 's,\.[0-9a-z]*$$,,;$(transform);G;s,\n,.,'`; \
+	dir='$(DESTDIR)$(man1dir)'; $(am__uninstall_files_from_dir)
 install-dist_desktopDATA: $(dist_desktop_DATA)
 	@$(NORMAL_INSTALL)
 	@list='$(dist_desktop_DATA)'; test -n "$(desktopdir)" || list=; \
@@ -1752,9 +1805,9 @@ distcleancheck: distclean
 	       exit 1; } >&2
 check-am: all-am
 check: check-am
-all-am: Makefile $(PROGRAMS) $(DATA) $(HEADERS)
+all-am: Makefile $(PROGRAMS) $(MANS) $(DATA) $(HEADERS)
 installdirs:
-	for dir in "$(DESTDIR)$(bindir)" "$(DESTDIR)$(desktopdir)" "$(DESTDIR)$(icon128dir)" "$(DESTDIR)$(icon16dir)" "$(DESTDIR)$(icon256dir)" "$(DESTDIR)$(icon32dir)" "$(DESTDIR)$(icon48dir)" "$(DESTDIR)$(icon512dir)" "$(DESTDIR)$(icon64dir)" "$(DESTDIR)$(metainfodir)" "$(DESTDIR)$(romsdir)"; do \
+	for dir in "$(DESTDIR)$(bindir)" "$(DESTDIR)$(man1dir)" "$(DESTDIR)$(desktopdir)" "$(DESTDIR)$(icon128dir)" "$(DESTDIR)$(icon16dir)" "$(DESTDIR)$(icon256dir)" "$(DESTDIR)$(icon32dir)" "$(DESTDIR)$(icon48dir)" "$(DESTDIR)$(icon512dir)" "$(DESTDIR)$(icon64dir)" "$(DESTDIR)$(metainfodir)" "$(DESTDIR)$(romsdir)"; do \
 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
 	done
 install: install-am
@@ -1855,7 +1908,7 @@ install-data-am: install-dist_desktopDATA install-dist_icon128DATA \
 	install-dist_icon16DATA install-dist_icon256DATA \
 	install-dist_icon32DATA install-dist_icon48DATA \
 	install-dist_icon512DATA install-dist_icon64DATA \
-	install-dist_metainfoDATA install-dist_romsDATA
+	install-dist_metainfoDATA install-dist_romsDATA install-man
 
 install-dvi: install-dvi-am
 
@@ -1871,7 +1924,7 @@ install-info: install-info-am
 
 install-info-am:
 
-install-man:
+install-man: install-man1
 
 install-pdf: install-pdf-am
 
@@ -1945,7 +1998,9 @@ uninstall-am: uninstall-binPROGRAMS uninstall-dist_desktopDATA \
 	uninstall-dist_icon256DATA uninstall-dist_icon32DATA \
 	uninstall-dist_icon48DATA uninstall-dist_icon512DATA \
 	uninstall-dist_icon64DATA uninstall-dist_metainfoDATA \
-	uninstall-dist_romsDATA
+	uninstall-dist_romsDATA uninstall-man
+
+uninstall-man: uninstall-man1
 
 .MAKE: install-am install-strip
 
@@ -1964,9 +2019,9 @@ uninstall-am: uninstall-binPROGRAMS uninstall-dist_desktopDATA \
 	install-dist_icon64DATA install-dist_metainfoDATA \
 	install-dist_romsDATA install-dvi install-dvi-am install-exec \
 	install-exec-am install-html install-html-am install-info \
-	install-info-am install-man install-pdf install-pdf-am \
-	install-ps install-ps-am install-strip installcheck \
-	installcheck-am installdirs maintainer-clean \
+	install-info-am install-man install-man1 install-pdf \
+	install-pdf-am install-ps install-ps-am install-strip \
+	installcheck installcheck-am installdirs maintainer-clean \
 	maintainer-clean-generic mostlyclean mostlyclean-compile \
 	mostlyclean-generic pdf pdf-am ps ps-am tags tags-am uninstall \
 	uninstall-am uninstall-binPROGRAMS uninstall-dist_desktopDATA \
@@ -1974,7 +2029,7 @@ uninstall-am: uninstall-binPROGRAMS uninstall-dist_desktopDATA \
 	uninstall-dist_icon256DATA uninstall-dist_icon32DATA \
 	uninstall-dist_icon48DATA uninstall-dist_icon512DATA \
 	uninstall-dist_icon64DATA uninstall-dist_metainfoDATA \
-	uninstall-dist_romsDATA
+	uninstall-dist_romsDATA uninstall-man uninstall-man1
 
 .PRECIOUS: Makefile
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,8 @@
 bin_PROGRAMS = 1984
 
+# Man page — installed under $(mandir)/man1/, included in `make dist`.
+dist_man1_MANS = 1984.1
+
 1984_SOURCES = \
 	src/config.c \
 	src/cpc.c \
@@ -43,6 +46,7 @@ bin_PROGRAMS = 1984
 
 noinst_HEADERS = \
 	src/ch376.h \
+	src/compat_win.h \
 	src/config.h \
 	src/cpc.h \
 	src/crtc.h \
@@ -57,6 +61,7 @@ noinst_HEADERS = \
 	src/ide.h \
 	src/joy.h \
 	src/kbd.h \
+	src/kbd_pty.h \
 	src/leds.h \
 	src/m4.h \
 	src/mem.h \
@@ -70,12 +75,16 @@ noinst_HEADERS = \
 	src/ppi.h \
 	src/psg.h \
 	src/rtc.h \
+	src/screen_text.h \
 	src/shutter_wav.h \
 	src/snapshot.h \
+	src/startup_debug.h \
 	src/symbnet.h \
+	src/symbols.h \
 	src/symbos_trace.h \
 	src/tape.h \
 	src/types.h \
+	src/usifac.h \
 	src/z80.h \
 	src/z80dis.h
 
@@ -134,4 +143,4 @@ dist_icon512_DATA  = icons/512x512/apps/io.github.salvogendut.Emulator1984.png
 
 # Files shipped in the dist tarball but not built (license, hand-written
 # Makefile alternative, project docs).
-EXTRA_DIST = Makefile LICENSE Development.md icons/1984.rc icons/1984.ico
+EXTRA_DIST = Makefile LICENSE Development.md USAGE.md icons/1984.rc icons/1984.ico

--- a/Makefile.in
+++ b/Makefile.in
@@ -110,12 +110,12 @@ am__CONFIG_DISTCLEAN_FILES = config.status config.cache config.log \
 mkinstalldirs = $(install_sh) -d
 CONFIG_CLEAN_FILES =
 CONFIG_CLEAN_VPATH_FILES =
-am__installdirs = "$(DESTDIR)$(bindir)" "$(DESTDIR)$(desktopdir)" \
-	"$(DESTDIR)$(icon128dir)" "$(DESTDIR)$(icon16dir)" \
-	"$(DESTDIR)$(icon256dir)" "$(DESTDIR)$(icon32dir)" \
-	"$(DESTDIR)$(icon48dir)" "$(DESTDIR)$(icon512dir)" \
-	"$(DESTDIR)$(icon64dir)" "$(DESTDIR)$(metainfodir)" \
-	"$(DESTDIR)$(romsdir)"
+am__installdirs = "$(DESTDIR)$(bindir)" "$(DESTDIR)$(man1dir)" \
+	"$(DESTDIR)$(desktopdir)" "$(DESTDIR)$(icon128dir)" \
+	"$(DESTDIR)$(icon16dir)" "$(DESTDIR)$(icon256dir)" \
+	"$(DESTDIR)$(icon32dir)" "$(DESTDIR)$(icon48dir)" \
+	"$(DESTDIR)$(icon512dir)" "$(DESTDIR)$(icon64dir)" \
+	"$(DESTDIR)$(metainfodir)" "$(DESTDIR)$(romsdir)"
 PROGRAMS = $(bin_PROGRAMS)
 am__dirstamp = $(am__leading_dot)dirstamp
 am_1984_OBJECTS = src/1984-config.$(OBJEXT) src/1984-cpc.$(OBJEXT) \
@@ -228,6 +228,9 @@ am__uninstall_files_from_dir = { \
   || { echo " ( cd '$$dir' && rm -f" $$files ")"; \
        $(am__cd) "$$dir" && echo $$files | $(am__xargs_n) 40 $(am__rm_f); }; \
   }
+man1dir = $(mandir)/man1
+NROFF = nroff
+MANS = $(dist_man1_MANS)
 DATA = $(dist_desktop_DATA) $(dist_icon128_DATA) $(dist_icon16_DATA) \
 	$(dist_icon256_DATA) $(dist_icon32_DATA) $(dist_icon48_DATA) \
 	$(dist_icon512_DATA) $(dist_icon64_DATA) $(dist_metainfo_DATA) \
@@ -251,7 +254,7 @@ am__define_uniq_tagged_files = \
     if test -f "$$i"; then echo $$i; else echo $(srcdir)/$$i; fi; \
   done | $(am__uniquify_input)`
 AM_RECURSIVE_TARGETS = cscope
-am__DIST_COMMON = $(srcdir)/Makefile.in \
+am__DIST_COMMON = $(dist_man1_MANS) $(srcdir)/Makefile.in \
 	$(top_srcdir)/build-aux/compile \
 	$(top_srcdir)/build-aux/config.guess \
 	$(top_srcdir)/build-aux/config.sub \
@@ -390,6 +393,9 @@ target_alias = @target_alias@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
+
+# Man page — installed under $(mandir)/man1/, included in `make dist`.
+dist_man1_MANS = 1984.1
 1984_SOURCES = \
 	src/config.c \
 	src/cpc.c \
@@ -433,6 +439,7 @@ top_srcdir = @top_srcdir@
 
 noinst_HEADERS = \
 	src/ch376.h \
+	src/compat_win.h \
 	src/config.h \
 	src/cpc.h \
 	src/crtc.h \
@@ -447,6 +454,7 @@ noinst_HEADERS = \
 	src/ide.h \
 	src/joy.h \
 	src/kbd.h \
+	src/kbd_pty.h \
 	src/leds.h \
 	src/m4.h \
 	src/mem.h \
@@ -460,12 +468,16 @@ noinst_HEADERS = \
 	src/ppi.h \
 	src/psg.h \
 	src/rtc.h \
+	src/screen_text.h \
 	src/shutter_wav.h \
 	src/snapshot.h \
+	src/startup_debug.h \
 	src/symbnet.h \
+	src/symbols.h \
 	src/symbos_trace.h \
 	src/tape.h \
 	src/types.h \
+	src/usifac.h \
 	src/z80.h \
 	src/z80dis.h
 
@@ -519,7 +531,7 @@ dist_icon512_DATA = icons/512x512/apps/io.github.salvogendut.Emulator1984.png
 
 # Files shipped in the dist tarball but not built (license, hand-written
 # Makefile alternative, project docs).
-EXTRA_DIST = Makefile LICENSE Development.md icons/1984.rc icons/1984.ico
+EXTRA_DIST = Makefile LICENSE Development.md USAGE.md icons/1984.rc icons/1984.ico
 all: all-am
 
 .SUFFIXES:
@@ -1302,6 +1314,47 @@ src/1984-z80.obj: src/z80.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/z80.c' object='src/1984-z80.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-z80.obj `if test -f 'src/z80.c'; then $(CYGPATH_W) 'src/z80.c'; else $(CYGPATH_W) '$(srcdir)/src/z80.c'; fi`
+install-man1: $(dist_man1_MANS)
+	@$(NORMAL_INSTALL)
+	@list1='$(dist_man1_MANS)'; \
+	list2=''; \
+	test -n "$(man1dir)" \
+	  && test -n "`echo $$list1$$list2`" \
+	  || exit 0; \
+	echo " $(MKDIR_P) '$(DESTDIR)$(man1dir)'"; \
+	$(MKDIR_P) "$(DESTDIR)$(man1dir)" || exit 1; \
+	{ for i in $$list1; do echo "$$i"; done;  \
+	if test -n "$$list2"; then \
+	  for i in $$list2; do echo "$$i"; done \
+	    | sed -n '/\.1[a-z]*$$/p'; \
+	fi; \
+	} | while read p; do \
+	  if test -f $$p; then d=; else d="$(srcdir)/"; fi; \
+	  echo "$$d$$p"; echo "$$p"; \
+	done | \
+	sed -e 'n;s,.*/,,;p;h;s,.*\.,,;s,^[^1][0-9a-z]*$$,1,;x' \
+	      -e 's,\.[0-9a-z]*$$,,;$(transform);G;s,\n,.,' | \
+	sed 'N;N;s,\n, ,g' | { \
+	list=; while read file base inst; do \
+	  if test "$$base" = "$$inst"; then list="$$list $$file"; else \
+	    echo " $(INSTALL_DATA) '$$file' '$(DESTDIR)$(man1dir)/$$inst'"; \
+	    $(INSTALL_DATA) "$$file" "$(DESTDIR)$(man1dir)/$$inst" || exit $$?; \
+	  fi; \
+	done; \
+	for i in $$list; do echo "$$i"; done | $(am__base_list) | \
+	while read files; do \
+	  test -z "$$files" || { \
+	    echo " $(INSTALL_DATA) $$files '$(DESTDIR)$(man1dir)'"; \
+	    $(INSTALL_DATA) $$files "$(DESTDIR)$(man1dir)" || exit $$?; }; \
+	done; }
+
+uninstall-man1:
+	@$(NORMAL_UNINSTALL)
+	@list='$(dist_man1_MANS)'; test -n "$(man1dir)" || exit 0; \
+	files=`{ for i in $$list; do echo "$$i"; done; \
+	} | sed -e 's,.*/,,;h;s,.*\.,,;s,^[^1][0-9a-z]*$$,1,;x' \
+	      -e 's,\.[0-9a-z]*$$,,;$(transform);G;s,\n,.,'`; \
+	dir='$(DESTDIR)$(man1dir)'; $(am__uninstall_files_from_dir)
 install-dist_desktopDATA: $(dist_desktop_DATA)
 	@$(NORMAL_INSTALL)
 	@list='$(dist_desktop_DATA)'; test -n "$(desktopdir)" || list=; \
@@ -1752,9 +1805,9 @@ distcleancheck: distclean
 	       exit 1; } >&2
 check-am: all-am
 check: check-am
-all-am: Makefile $(PROGRAMS) $(DATA) $(HEADERS)
+all-am: Makefile $(PROGRAMS) $(MANS) $(DATA) $(HEADERS)
 installdirs:
-	for dir in "$(DESTDIR)$(bindir)" "$(DESTDIR)$(desktopdir)" "$(DESTDIR)$(icon128dir)" "$(DESTDIR)$(icon16dir)" "$(DESTDIR)$(icon256dir)" "$(DESTDIR)$(icon32dir)" "$(DESTDIR)$(icon48dir)" "$(DESTDIR)$(icon512dir)" "$(DESTDIR)$(icon64dir)" "$(DESTDIR)$(metainfodir)" "$(DESTDIR)$(romsdir)"; do \
+	for dir in "$(DESTDIR)$(bindir)" "$(DESTDIR)$(man1dir)" "$(DESTDIR)$(desktopdir)" "$(DESTDIR)$(icon128dir)" "$(DESTDIR)$(icon16dir)" "$(DESTDIR)$(icon256dir)" "$(DESTDIR)$(icon32dir)" "$(DESTDIR)$(icon48dir)" "$(DESTDIR)$(icon512dir)" "$(DESTDIR)$(icon64dir)" "$(DESTDIR)$(metainfodir)" "$(DESTDIR)$(romsdir)"; do \
 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
 	done
 install: install-am
@@ -1855,7 +1908,7 @@ install-data-am: install-dist_desktopDATA install-dist_icon128DATA \
 	install-dist_icon16DATA install-dist_icon256DATA \
 	install-dist_icon32DATA install-dist_icon48DATA \
 	install-dist_icon512DATA install-dist_icon64DATA \
-	install-dist_metainfoDATA install-dist_romsDATA
+	install-dist_metainfoDATA install-dist_romsDATA install-man
 
 install-dvi: install-dvi-am
 
@@ -1871,7 +1924,7 @@ install-info: install-info-am
 
 install-info-am:
 
-install-man:
+install-man: install-man1
 
 install-pdf: install-pdf-am
 
@@ -1945,7 +1998,9 @@ uninstall-am: uninstall-binPROGRAMS uninstall-dist_desktopDATA \
 	uninstall-dist_icon256DATA uninstall-dist_icon32DATA \
 	uninstall-dist_icon48DATA uninstall-dist_icon512DATA \
 	uninstall-dist_icon64DATA uninstall-dist_metainfoDATA \
-	uninstall-dist_romsDATA
+	uninstall-dist_romsDATA uninstall-man
+
+uninstall-man: uninstall-man1
 
 .MAKE: install-am install-strip
 
@@ -1964,9 +2019,9 @@ uninstall-am: uninstall-binPROGRAMS uninstall-dist_desktopDATA \
 	install-dist_icon64DATA install-dist_metainfoDATA \
 	install-dist_romsDATA install-dvi install-dvi-am install-exec \
 	install-exec-am install-html install-html-am install-info \
-	install-info-am install-man install-pdf install-pdf-am \
-	install-ps install-ps-am install-strip installcheck \
-	installcheck-am installdirs maintainer-clean \
+	install-info-am install-man install-man1 install-pdf \
+	install-pdf-am install-ps install-ps-am install-strip \
+	installcheck installcheck-am installdirs maintainer-clean \
 	maintainer-clean-generic mostlyclean mostlyclean-compile \
 	mostlyclean-generic pdf pdf-am ps ps-am tags tags-am uninstall \
 	uninstall-am uninstall-binPROGRAMS uninstall-dist_desktopDATA \
@@ -1974,7 +2029,7 @@ uninstall-am: uninstall-binPROGRAMS uninstall-dist_desktopDATA \
 	uninstall-dist_icon256DATA uninstall-dist_icon32DATA \
 	uninstall-dist_icon48DATA uninstall-dist_icon512DATA \
 	uninstall-dist_icon64DATA uninstall-dist_metainfoDATA \
-	uninstall-dist_romsDATA
+	uninstall-dist_romsDATA uninstall-man uninstall-man1
 
 .PRECIOUS: Makefile
 


### PR DESCRIPTION
## Summary

Closes #159. Adds a full `1984(1)` man page covering the SYNOPSIS,
all CLI options grouped (Model / Files / Networking / Automation /
Debugging), keyboard shortcuts, overlay tabs (General / Media /
Extensions / Advanced incl. the new Monochrome row), the config
file layout, and the debug-gated `ONE_K_*` env vars.

Wired into Autotools via `dist_man1_MANS` (installed to
`$(mandir)/man1/` and shipped in the dist tarball). Spec `%files`
gets `%{_mandir}/man1/1984.1*` so the RPM packages it (auto-gzipped
by rpmbuild).

### Drive-by fixes (needed to make the RPM actually build)

- `noinst_HEADERS` was missing 6 headers (`usifac.h`,
  `compat_win.h`, `kbd_pty.h`, `screen_text.h`, `startup_debug.h`,
  `symbols.h`) — `make dist` produced an unbuildable tarball.
- `EXTRA_DIST` was missing `USAGE.md` (referenced by spec `%doc`).
- Spec `%files` was missing the 664 ROMs that `Makefile.am` has
  been installing since 0.4.7.
- Spec `Version` bumped 0.4.5 → 0.4.7 to match `configure.ac`.

## Test plan

- [x] `man -l 1984.1` renders cleanly, no troff warnings
- [x] `make install` lays down `$(mandir)/man1/1984.1`
- [x] `make dist` includes `1984.1` in the tarball
- [x] `rpmbuild -ba 1984.spec` succeeds end-to-end
- [x] `rpm -qlp 1984-0.4.7-1.fc44.x86_64.rpm | grep man` →
      `/usr/share/man/man1/1984.1.gz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)