### PR TITLE
printer: Centronics → PDF / CUPS host sink (closes #162)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,7 @@ dist_man1_MANS = 1984.1
 	src/overlay.c \
 	src/paste.c \
 	src/kbd_pty.c \
+	src/printer.c \
 	src/screen_text.c \
 	src/ppi.c \
 	src/psg.c \
@@ -73,6 +74,7 @@ noinst_HEADERS = \
 	src/tap.h \
 	src/paste.h \
 	src/ppi.h \
+	src/printer.h \
 	src/psg.h \
 	src/rtc.h \
 	src/screen_text.h \
@@ -88,14 +90,20 @@ noinst_HEADERS = \
 	src/z80.h \
 	src/z80dis.h
 
-1984_CFLAGS  = $(AM_CFLAGS) $(SDL3_CFLAGS) -Wall -Wextra \
+if WITH_CAIRO
+CAIRO_DEFINE = -DHAVE_CAIRO=1
+else
+CAIRO_DEFINE =
+endif
+
+1984_CFLAGS  = $(AM_CFLAGS) $(SDL3_CFLAGS) $(CAIRO_CFLAGS) $(CAIRO_DEFINE) -Wall -Wextra \
                -DROM_INSTALL_DIR=\"$(pkgdatadir)/roms\" \
                -DPROG_GIT_COMMIT=\"$(PROG_GIT_COMMIT)\"
 # On Windows the resource object compiled below carries the .ico into
 # the .exe; SDL3's -mwindows (linked via $(SDL3_LIBS)) suppresses the
 # console window. _DEPENDENCIES is needed so make builds the .o before
 # the link step — items only in _LDADD are linked but not built.
-1984_LDADD        = $(SDL3_LIBS) -lm $(WIN_LIBS) $(WIN_RC_OBJ)
+1984_LDADD        = $(SDL3_LIBS) $(CAIRO_LIBS) -lm $(WIN_LIBS) $(WIN_RC_OBJ)
 1984_DEPENDENCIES = $(WIN_RC_OBJ)
 
 icons/1984-rc.o: $(srcdir)/icons/1984.rc $(srcdir)/icons/1984.ico

--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,22 @@ PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES([SDL3], [sdl3], [], [AC_MSG_ERROR([SDL3 not found])])
 AC_CHECK_LIB([m], [sqrt], [], [AC_MSG_ERROR([libm not found])])
 
+# Cairo is optional: it backs the host-side PDF printer sink. Without
+# it, the printer compiles to a no-op (port 0xEFxx writes are still
+# decoded for status/LED purposes but nothing is captured to disk).
+# Pass --without-cairo to skip detection.
+AC_ARG_WITH([cairo],
+  [AS_HELP_STRING([--without-cairo],
+                  [build without the PDF printer backend])],
+  [], [with_cairo=yes])
+if test "x$with_cairo" != "xno"; then
+  PKG_CHECK_MODULES([CAIRO], [cairo], [],
+    [AC_MSG_WARN([cairo not found — building without PDF printer])
+     with_cairo=no])
+fi
+AM_CONDITIONAL([WITH_CAIRO], [test "x$with_cairo" = "xyes"])
+AC_MSG_NOTICE([PDF printer backend: $with_cairo])
+
 # Platform-specific socket linkage and Windows extras.
 #   - Windows (MinGW): sockets live in ws2_32. The build picks up SDL3's
 #     -mwindows (no console window). icons/1984.rc is compiled with

--- a/src/config.c
+++ b/src/config.c
@@ -437,6 +437,18 @@ int config_load_from(Config *cfg, const char *path_override) {
                 if (parse_bool(val, &b)) cfg->albireo_disable_disk_read = b;
                 else { fprintf(stderr, "1984.conf:%d: albireo_disable_disk_read must be true/false\n", lineno); rc = -1; }
             }
+        } else if (!strcmp(section, "printer")) {
+            if (!strcmp(key, "pdf_printer")) {
+                bool b;
+                if (parse_bool(val, &b)) cfg->pdf_printer = b;
+                else { fprintf(stderr, "1984.conf:%d: pdf_printer must be true/false\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "pdf_printer_dir")) {
+                if (val[0]) expand_path(val, cfg->pdf_printer_dir, sizeof(cfg->pdf_printer_dir));
+            } else if (!strcmp(key, "print_sink")) {
+                if (!strcasecmp(val, "pdf"))            cfg->print_sink = PRINTER_SINK_PDF;
+                else if (!strcasecmp(val, "real"))      cfg->print_sink = PRINTER_SINK_REAL_PRINTER;
+                else { fprintf(stderr, "1984.conf:%d: print_sink must be pdf/real\n", lineno); rc = -1; }
+            }
         } else if (!strcmp(section, "display")) {
             if (!strcmp(key, "scale")) {
                 int sc = atoi(val);
@@ -588,6 +600,10 @@ int config_save(const Config *cfg) {
         "albireo_image=%s\n"
         "albireo_mouse=%s\n"
         "albireo_disable_disk_read=%s\n\n"
+        "[printer]\n"
+        "pdf_printer=%s\n"
+        "pdf_printer_dir=%s\n"
+        "print_sink=%s\n\n"
         "[display]\n"
         "scale=%d\n"
         "fullscreen=%s\n"
@@ -624,6 +640,9 @@ int config_save(const Config *cfg) {
         cfg->albireo_image,
         cfg->albireo_mouse    ? "true" : "false",
         cfg->albireo_disable_disk_read ? "true" : "false",
+        cfg->pdf_printer ? "true" : "false",
+        cfg->pdf_printer_dir,
+        cfg->print_sink == PRINTER_SINK_REAL_PRINTER ? "real" : "pdf",
         cfg->scale,
         cfg->fullscreen ? "true" : "false",
         cfg->fullscreen_smoothing ? "true" : "false",

--- a/src/config.h
+++ b/src/config.h
@@ -2,6 +2,10 @@
 #include <stdbool.h>
 #include "cpc.h"
 
+/* Re-declared here because including printer.h pulls in <limits.h>
+ * and we want config.h to stay narrow. PrintSink: see src/printer.h. */
+typedef enum { PRINTER_SINK_PDF = 0, PRINTER_SINK_REAL_PRINTER } ConfigPrintSink;
+
 #define CONFIG_PATH_MAX 512
 
 typedef struct {
@@ -93,6 +97,16 @@ typedef struct {
     bool fullscreen;
     bool fullscreen_smoothing; /* linear (smooth) vs nearest (sharp) texture scale */
     MonoMode monochrome;       /* off / green / amber / white phosphor tint */
+
+    /* [printer] — host-side Centronics capture (port 0xEFxx).
+     * pdf_printer=true  + pdf_printer_dir non-empty: write PDFs there.
+     * sink=real         spools the PDF to the host's default CUPS
+     *                   printer via `lp` (Linux/macOS).
+     * Disabling pdf_printer makes the emulated port a no-op host-side
+     * (the guest still sees "not busy" via PPI port B). */
+    bool            pdf_printer;
+    char            pdf_printer_dir[CONFIG_PATH_MAX];
+    ConfigPrintSink print_sink;
 
     /* [advanced] */
     bool tinker;             /* enable Advanced overlay tab with low-level toggles */

--- a/src/cpc.c
+++ b/src/cpc.c
@@ -334,6 +334,15 @@ static void bus_io_write(void *ctx, u16 port, u8 val) {
     CPC *cpc = ctx;
     u8 hi = port >> 8;
 
+    /* Parallel printer port: any write with A12 LOW (0xEFxx). The
+     * printer module handles the strobe-edge detect and bit-7 invert.
+     * Side-effect only — fall through so any expansion that happens to
+     * decode the same address space (none in the stock CPC, but the
+     * decoder is permissive) still sees the write. Caprice32
+     * cap32.cpp:768. */
+    if (!(hi & 0x10))
+        printer_out(&cpc->printer, val);
+
     /* Gate Array: A15=0, A14=1 → 0x7Fxx */
     if (!(hi & 0x80) && (hi & 0x40)) {
         if (cpc_trace_palette && cpc_frame_count > 520 && (val & 0xC0) == 0x40)
@@ -634,6 +643,7 @@ int cpc_init(CPC *cpc, CpcModel model, const char *rom_os, const char *rom_basic
     ch376_init(&cpc->ch376_b);
     cpc->ch376_b.tag = "albireo-b";
     tape_init(&cpc->tape);
+    printer_init(&cpc->printer);
     net4cpc_reset();
 
     cpc->bus.mem_read       = bus_mem_read;

--- a/src/cpc.h
+++ b/src/cpc.h
@@ -20,6 +20,7 @@
 #include "ch376.h"
 #include "usifac.h"
 #include "tape.h"
+#include "printer.h"
 
 typedef enum { MODEL_464, MODEL_664, MODEL_6128 } CpcModel;
 
@@ -56,6 +57,7 @@ typedef struct {
     CH376      ch376_b;        /* Right chip @ 0xFE40/41 — storage in
                                   dual-chip mouse mode                     */
     USIfAC     usifac;         /* USIfAC II RS232 serial @ 0xFBD0/D1       */
+    Printer    printer;        /* Centronics @ 0xEFxx (Cairo → PDF host sink) */
     Tape       tape;           /* cassette / .cdt image */
     /* Per-sample snapshot of the cassette data line, captured inside the
      * Z80 step loop at audio rate. Mixed into the PSG output frame so the

--- a/src/leds.c
+++ b/src/leds.c
@@ -16,6 +16,7 @@ static const LedPalette palette[LED_COUNT] = {
     [LED_NET]    = { 80, 70, 18,  255, 224,  32 },   /* Net4CPC — yellow */
     [LED_USIFAC] = { 0 },   /* Split LED renders both halves; entries unused. */
     [LED_M4]     = { 0 },   /* Triple LED renders three segments; entries unused. */
+    [LED_PRINTER]= { 70, 50, 18,  255, 200,  90 },   /* warm amber */
 };
 
 /* Idle/active colours for the split-LED halves (USIfAC RS232). The left

--- a/src/leds.h
+++ b/src/leds.h
@@ -26,6 +26,7 @@ typedef enum {
     LED_NET,
     LED_USIFAC,    /* Split red/green: left half = RX, right half = TX. */
     LED_M4,        /* Triple-segment, 1.5× width: blue=power, red=disk, white=net. */
+    LED_PRINTER,   /* Centronics parallel printer activity (port 0xEFxx). */
     LED_COUNT
 } LedId;
 

--- a/src/main.c
+++ b/src/main.c
@@ -211,8 +211,9 @@ static void apply_led_enables(const Config *cfg) {
     leds_set_enabled(LED_M4,  mx4 && cfg->m4);
     leds_set_enabled(LED_NET, mx4 && cfg->net4cpc);
     leds_set_enabled(LED_USIFAC, mx4 && cfg->usifac);
-    /* Printer port is part of the stock CPC: always on. */
-    leds_set_enabled(LED_PRINTER, true);
+    /* Printer is gated on the MX4 expansion bus (parallel port wired
+     * through the MX4 connector in this emulator). */
+    leds_set_enabled(LED_PRINTER, mx4);
 }
 
 /* OS title is just "1984" now; the model name and F-key hints render
@@ -580,6 +581,7 @@ int main(int argc, char *argv[]) {
         cfg.m4 = false;
     }
     usifac_init(&cpc.usifac, cfg.usifac, cfg.usifac_backend, cfg.usifac_tcp_port);
+    printer_set_connected(&cpc.printer, cfg.mx4);
     printer_set_pdf_output_dir(&cpc.printer, cfg.pdf_printer_dir);
     printer_set_pdf_enabled(&cpc.printer, cfg.pdf_printer && cfg.pdf_printer_dir[0]);
     printer_set_sink(&cpc.printer,

--- a/src/main.c
+++ b/src/main.c
@@ -211,6 +211,8 @@ static void apply_led_enables(const Config *cfg) {
     leds_set_enabled(LED_M4,  mx4 && cfg->m4);
     leds_set_enabled(LED_NET, mx4 && cfg->net4cpc);
     leds_set_enabled(LED_USIFAC, mx4 && cfg->usifac);
+    /* Printer port is part of the stock CPC: always on. */
+    leds_set_enabled(LED_PRINTER, true);
 }
 
 /* OS title is just "1984" now; the model name and F-key hints render
@@ -274,6 +276,8 @@ static void usage(const char *prog, int code) {
         "                      e.g. --joy-script=d:150,-:30,u:150 (down, rest, up)\n"
         "  --gif-out=PATH      Record a GIF from boot (finalised on exit; pairs with --exit-after)\n"
         "  --exit-after=N      Quit after frame N (deterministic headless capture)\n"
+        "  --printer-pdf=DIR   Capture parallel-printer output to timestamped PDFs in DIR\n"
+        "  --printer-real      Spool captured pages to the host's default CUPS printer (lp)\n"
         "  --symbols=PATH      Load an SDCC .map file and annotate the disassembler/monitor\n"
         "                      output with the closest preceding symbol. Repeatable.\n"
         "                      Use --symbols=HEX:PATH to apply the map only when the live\n"
@@ -327,6 +331,8 @@ int main(int argc, char *argv[]) {
     const char *joyscript_arg    = NULL;  /* --joy-script=SPEC: scripted joystick */
     const char *gifout_arg       = NULL;  /* --gif-out=PATH: record a GIF from boot */
     int         exit_after       = -1;    /* --exit-after=N: quit at frame N */
+    const char *printer_pdf_dir_arg = NULL; /* --printer-pdf=DIR */
+    bool        printer_real_arg = false;   /* --printer-real */
     bool        trace_io         = false;
     bool        monitor_pty      = false;
     bool        kbd_pty_enabled  = false;
@@ -447,6 +453,10 @@ int main(int argc, char *argv[]) {
             joyscript_arg = argv[i] + 13;
         } else if (strncmp(argv[i], "--gif-out=", 10) == 0 && argv[i][10] != '\0') {
             gifout_arg = argv[i] + 10;
+        } else if (strncmp(argv[i], "--printer-pdf=", 14) == 0 && argv[i][14] != '\0') {
+            printer_pdf_dir_arg = argv[i] + 14;
+        } else if (strcmp(argv[i], "--printer-real") == 0) {
+            printer_real_arg = true;
         } else if (strncmp(argv[i], "--exit-after=", 13) == 0 && argv[i][13] != '\0') {
             exit_after = atoi(argv[i] + 13);
         } else if (strncmp(argv[i], "--save-sna-at=", 14) == 0 && argv[i][14] != '\0') {
@@ -505,6 +515,14 @@ int main(int argc, char *argv[]) {
     if (disk_a_arg) snprintf(cfg.disk_a, sizeof(cfg.disk_a), "%s", disk_a_arg);
     if (disk_b_arg) snprintf(cfg.disk_b, sizeof(cfg.disk_b), "%s", disk_b_arg);
     if (rom_os_arg) snprintf(cfg.rom_os, sizeof(cfg.rom_os), "%s", rom_os_arg);
+    if (printer_pdf_dir_arg) {
+        snprintf(cfg.pdf_printer_dir, sizeof(cfg.pdf_printer_dir), "%s", printer_pdf_dir_arg);
+        cfg.pdf_printer = true;
+    }
+    if (printer_real_arg) {
+        cfg.print_sink  = PRINTER_SINK_REAL_PRINTER;
+        cfg.pdf_printer = true;   /* needed so capture is active */
+    }
 
     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
     SD_LOG("calling SDL_Init(VIDEO|AUDIO|GAMEPAD)");
@@ -562,6 +580,11 @@ int main(int argc, char *argv[]) {
         cfg.m4 = false;
     }
     usifac_init(&cpc.usifac, cfg.usifac, cfg.usifac_backend, cfg.usifac_tcp_port);
+    printer_set_pdf_output_dir(&cpc.printer, cfg.pdf_printer_dir);
+    printer_set_pdf_enabled(&cpc.printer, cfg.pdf_printer && cfg.pdf_printer_dir[0]);
+    printer_set_sink(&cpc.printer,
+                     cfg.print_sink == PRINTER_SINK_REAL_PRINTER ? PRINT_SINK_REAL
+                                                                 : PRINT_SINK_PDF);
     apply_led_enables(&cfg);
     /* Cassette: always wired on 464; requires external_tape toggle on 664/6128. */
     if (cfg.tape[0] &&
@@ -1102,6 +1125,7 @@ int main(int argc, char *argv[]) {
         bool was_stepping = cpc.step_once;
         net4cpc_poll();
         usifac_poll(&cpc.usifac);
+        printer_tick(&cpc.printer);
         cpc_frame(&cpc);
         /* Auto-open monitor on breakpoint hit */
         if (!was_paused && cpc.paused) {
@@ -1326,6 +1350,7 @@ int main(int argc, char *argv[]) {
     if (sfx_stream) SDL_DestroyAudioStream(sfx_stream);
     if (sfx_buf)    SDL_free(sfx_buf);
     videocap_stop();   /* finalise GIF if recording */
+    printer_shutdown(&cpc.printer);
     cpc_destroy(&cpc);
     SDL_Quit();
     return 0;

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -35,7 +35,7 @@ static const int sec_x[OV_SEC_COUNT] = { 8, 80, 160, 248 };
  * "External Tape" toggle, only meaningful on the 6128 since the 464 has
  * the cassette deck built in). Other sections are fixed.
  * The Advanced tab (OV_TINKER) is hidden unless cfg->tinker is enabled. */
-static const int sec_row_count[OV_SEC_COUNT] = { 7, 5, 12, 11 };
+static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 14, 11 };
 
 static int ov_section_rows(const Overlay *ov, OvSection s) {
     if (s == OV_GENERAL && ov->cfg->model != MODEL_464) return 8;
@@ -186,24 +186,6 @@ static void item_text(const Overlay *ov, int row,
                 snprintf(val, vsz, "[empty]  Enter=load");
             }
             break;
-        case 3:
-            snprintf(lbl, lsz, "PDF printer");
-            if (!ov->cfg->pdf_printer)
-                snprintf(val, vsz, "off  Enter=on");
-            else if (ov->cfg->pdf_printer_dir[0]) {
-                char tmp[CONFIG_PATH_MAX];
-                snprintf(tmp, sizeof(tmp), "%s", ov->cfg->pdf_printer_dir);
-                trunc_path(tmp, val, vsz);
-            } else {
-                snprintf(val, vsz, "on (no dir set — see ~/.config/1984/1984.conf)");
-            }
-            break;
-        case 4:
-            snprintf(lbl, lsz, "Printer mode");
-            snprintf(val, vsz, "%s",
-                     ov->cfg->print_sink == PRINTER_SINK_REAL_PRINTER
-                         ? "Real printer (CUPS lp)" : "PDF file");
-            break;
         }
         break;
     }
@@ -340,6 +322,32 @@ static void item_text(const Overlay *ov, int row,
             }
             break;
         }
+        case 12:
+            snprintf(lbl, lsz, "PDF printer");
+            if (!ov->cfg->mx4) {
+                snprintf(val, vsz, "[needs MX4]");
+                *readonly = true;
+            } else if (!ov->cfg->pdf_printer) {
+                snprintf(val, vsz, "off  Enter=on");
+            } else if (ov->cfg->pdf_printer_dir[0]) {
+                char tmp[CONFIG_PATH_MAX];
+                snprintf(tmp, sizeof(tmp), "%s", ov->cfg->pdf_printer_dir);
+                trunc_path(tmp, val, vsz);
+            } else {
+                snprintf(val, vsz, "on (no dir)");
+            }
+            break;
+        case 13:
+            snprintf(lbl, lsz, "Printer mode");
+            if (!ov->cfg->mx4) {
+                snprintf(val, vsz, "[needs MX4]");
+                *readonly = true;
+            } else {
+                snprintf(val, vsz, "%s",
+                         ov->cfg->print_sink == PRINTER_SINK_REAL_PRINTER
+                             ? "Real printer (CUPS lp)" : "PDF file");
+            }
+            break;
         }
         break;
 
@@ -481,6 +489,11 @@ static void activate_item(Overlay *ov) {
         }
         case 2:
             ov->cfg->mx4 = !ov->cfg->mx4;
+            if (ov->cpc) {
+                ov->cpc->mx4 = ov->cfg->mx4;
+                printer_set_connected(&ov->cpc->printer, ov->cfg->mx4);
+            }
+            leds_set_enabled(LED_PRINTER, ov->cfg->mx4);
             ov->dirty = true;
             break;
         case 3:
@@ -553,31 +566,6 @@ static void activate_item(Overlay *ov) {
             SDL_ShowOpenFileDialog(overlay_file_callback, ov,
                 ov->cpc ? ov->cpc->display.window : NULL,
                 tape_filters, 2, NULL, false);
-        } else if (ov->row == 3) {
-            /* Toggle PDF printer capture. Default the dir to $HOME on
-             * first enable so the user doesn't have to edit the conf
-             * just to try it. Picking a different dir is handled via
-             * 1984.conf or --printer-pdf=DIR for now. */
-            ov->cfg->pdf_printer = !ov->cfg->pdf_printer;
-            if (ov->cfg->pdf_printer && !ov->cfg->pdf_printer_dir[0]) {
-                const char *home = getenv("HOME");
-                snprintf(ov->cfg->pdf_printer_dir, sizeof(ov->cfg->pdf_printer_dir),
-                         "%s", (home && home[0]) ? home : ".");
-            }
-            if (ov->cpc) {
-                printer_set_pdf_output_dir(&ov->cpc->printer, ov->cfg->pdf_printer_dir);
-                printer_set_pdf_enabled(&ov->cpc->printer,
-                                        ov->cfg->pdf_printer && ov->cfg->pdf_printer_dir[0]);
-            }
-            ov->dirty = true;
-        } else if (ov->row == 4) {
-            ov->cfg->print_sink = (ov->cfg->print_sink == PRINTER_SINK_PDF)
-                                  ? PRINTER_SINK_REAL_PRINTER : PRINTER_SINK_PDF;
-            if (ov->cpc)
-                printer_set_sink(&ov->cpc->printer,
-                                 ov->cfg->print_sink == PRINTER_SINK_REAL_PRINTER
-                                     ? PRINT_SINK_REAL : PRINT_SINK_PDF);
-            ov->dirty = true;
         }
         break;
 
@@ -908,6 +896,37 @@ static void activate_item(Overlay *ov) {
             }
             break;
         }
+        case 12:
+            /* PDF printer: when turning ON, pop a folder picker so the
+             * user can name the output directory. Picker callback path
+             * (DIALOG_PRINTER_DIR in overlay_tick) finishes the enable
+             * by setting pdf_printer + pdf_printer_dir and arming the
+             * printer module. Turning OFF is immediate. */
+            if (!ov->cfg->mx4) break;
+            if (ov->cfg->pdf_printer) {
+                ov->cfg->pdf_printer = false;
+                if (ov->cpc)
+                    printer_set_pdf_enabled(&ov->cpc->printer, false);
+                ov->dirty = true;
+            } else {
+                ov->dialog_kind  = DIALOG_PRINTER_DIR;
+                ov->dialog_ready = false;
+                SDL_ShowOpenFolderDialog(overlay_file_callback, ov,
+                    ov->cpc ? ov->cpc->display.window : NULL,
+                    ov->cfg->pdf_printer_dir[0] ? ov->cfg->pdf_printer_dir : NULL,
+                    false);
+            }
+            break;
+        case 13:
+            if (!ov->cfg->mx4) break;
+            ov->cfg->print_sink = (ov->cfg->print_sink == PRINTER_SINK_PDF)
+                                  ? PRINTER_SINK_REAL_PRINTER : PRINTER_SINK_PDF;
+            if (ov->cpc)
+                printer_set_sink(&ov->cpc->printer,
+                                 ov->cfg->print_sink == PRINTER_SINK_REAL_PRINTER
+                                     ? PRINT_SINK_REAL : PRINT_SINK_PDF);
+            ov->dirty = true;
+            break;
         }
         break;
 
@@ -1097,6 +1116,15 @@ void overlay_tick(Overlay *ov) {
     } else if (ov->dialog_kind == DIALOG_TAPE) {
         /* Stub — just record the path. PSG cassette input not wired yet. */
         snprintf(ov->cfg->tape, CONFIG_PATH_MAX, "%s", ov->dialog_path);
+        ov->dirty = true;
+    } else if (ov->dialog_kind == DIALOG_PRINTER_DIR) {
+        snprintf(ov->cfg->pdf_printer_dir, sizeof(ov->cfg->pdf_printer_dir),
+                 "%s", ov->dialog_path);
+        ov->cfg->pdf_printer = true;
+        if (ov->cpc) {
+            printer_set_pdf_output_dir(&ov->cpc->printer, ov->cfg->pdf_printer_dir);
+            printer_set_pdf_enabled(&ov->cpc->printer, true);
+        }
         ov->dirty = true;
     } else if (ov->dialog_kind == DIALOG_LOWER_ROM) {
         snprintf(ov->cfg->rom_os, CONFIG_PATH_MAX, "%s", ov->dialog_path);

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -35,7 +35,7 @@ static const int sec_x[OV_SEC_COUNT] = { 8, 80, 160, 248 };
  * "External Tape" toggle, only meaningful on the 6128 since the 464 has
  * the cassette deck built in). Other sections are fixed.
  * The Advanced tab (OV_TINKER) is hidden unless cfg->tinker is enabled. */
-static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 12, 11 };
+static const int sec_row_count[OV_SEC_COUNT] = { 7, 5, 12, 11 };
 
 static int ov_section_rows(const Overlay *ov, OvSection s) {
     if (s == OV_GENERAL && ov->cfg->model != MODEL_464) return 8;
@@ -185,6 +185,24 @@ static void item_text(const Overlay *ov, int row,
             } else {
                 snprintf(val, vsz, "[empty]  Enter=load");
             }
+            break;
+        case 3:
+            snprintf(lbl, lsz, "PDF printer");
+            if (!ov->cfg->pdf_printer)
+                snprintf(val, vsz, "off  Enter=on");
+            else if (ov->cfg->pdf_printer_dir[0]) {
+                char tmp[CONFIG_PATH_MAX];
+                snprintf(tmp, sizeof(tmp), "%s", ov->cfg->pdf_printer_dir);
+                trunc_path(tmp, val, vsz);
+            } else {
+                snprintf(val, vsz, "on (no dir set — see ~/.config/1984/1984.conf)");
+            }
+            break;
+        case 4:
+            snprintf(lbl, lsz, "Printer mode");
+            snprintf(val, vsz, "%s",
+                     ov->cfg->print_sink == PRINTER_SINK_REAL_PRINTER
+                         ? "Real printer (CUPS lp)" : "PDF file");
             break;
         }
         break;
@@ -535,6 +553,31 @@ static void activate_item(Overlay *ov) {
             SDL_ShowOpenFileDialog(overlay_file_callback, ov,
                 ov->cpc ? ov->cpc->display.window : NULL,
                 tape_filters, 2, NULL, false);
+        } else if (ov->row == 3) {
+            /* Toggle PDF printer capture. Default the dir to $HOME on
+             * first enable so the user doesn't have to edit the conf
+             * just to try it. Picking a different dir is handled via
+             * 1984.conf or --printer-pdf=DIR for now. */
+            ov->cfg->pdf_printer = !ov->cfg->pdf_printer;
+            if (ov->cfg->pdf_printer && !ov->cfg->pdf_printer_dir[0]) {
+                const char *home = getenv("HOME");
+                snprintf(ov->cfg->pdf_printer_dir, sizeof(ov->cfg->pdf_printer_dir),
+                         "%s", (home && home[0]) ? home : ".");
+            }
+            if (ov->cpc) {
+                printer_set_pdf_output_dir(&ov->cpc->printer, ov->cfg->pdf_printer_dir);
+                printer_set_pdf_enabled(&ov->cpc->printer,
+                                        ov->cfg->pdf_printer && ov->cfg->pdf_printer_dir[0]);
+            }
+            ov->dirty = true;
+        } else if (ov->row == 4) {
+            ov->cfg->print_sink = (ov->cfg->print_sink == PRINTER_SINK_PDF)
+                                  ? PRINTER_SINK_REAL_PRINTER : PRINTER_SINK_PDF;
+            if (ov->cpc)
+                printer_set_sink(&ov->cpc->printer,
+                                 ov->cfg->print_sink == PRINTER_SINK_REAL_PRINTER
+                                     ? PRINT_SINK_REAL : PRINT_SINK_PDF);
+            ov->dirty = true;
         }
         break;
 

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -29,7 +29,8 @@ typedef enum {
     DIALOG_TAPE      = 8,
     DIALOG_SNAPSHOT_LOAD = 9,
     DIALOG_SNAPSHOT_SAVE = 10,
-    DIALOG_VIDEO_CAPTURE = 11
+    DIALOG_VIDEO_CAPTURE = 11,
+    DIALOG_PRINTER_DIR   = 12
 } DialogKind;
 
 typedef struct {

--- a/src/ppi.c
+++ b/src/ppi.c
@@ -39,10 +39,15 @@ u8 ppi_read(PPI *p, u8 port) {
     switch (port & 0x03) {
         case 0: return p->port_a;
         case 1: {
-            /* bit 7: cassette data input; bit 6: printer not busy;
+            /* bit 7: cassette data input; bit 6: printer BUSY (active
+             * high — firmware's MC BUSY PRINTER rotates this bit into
+             * carry and treats carry=1 as busy);
              * bits 4-1: jumpers (0x1E = 50Hz PAL, no expansion);
-             * bit 0: VSYNC */
-            u8 b = 0x1E | 0x40;
+             * bit 0: VSYNC.
+             * We hold BUSY=0 so the firmware printer routine always
+             * proceeds to the OUT (&EFxx),A write — the host-side
+             * capture happens in src/printer.c. */
+            u8 b = 0x1E;
             if (p->vsync_signal) b |= 0x01;
             b |= (p->tape_level & 0x80);
             return b;

--- a/src/printer.c
+++ b/src/printer.c
@@ -76,7 +76,6 @@ static void printer_reset_text(Printer *p) {
 void printer_init(Printer *p) {
     memset(p, 0, sizeof(*p));
     p->connected = true;
-    p->strobe_high = true;
     printer_reset_text(p);
 }
 
@@ -263,13 +262,10 @@ static void printer_emit(Printer *p, u8 val) {
 
 void printer_out(Printer *p, u8 val) {
     if (!p->connected) return;
-
-    /* The CPC inverts the strobe line: bit 7 LOW means asserted. We
-     * detect the high→low edge and clock the low 7 bits in. Bit 7 of
-     * the data side isn't wired to the connector at all, so dropping
-     * it is faithful, not a workaround (Caprice32 cap32.cpp:768-773). */
-    bool strobe_high_now = (val & 0x80) != 0;
-    if (p->strobe_high && !strobe_high_now)
+    /* Bit 7 of the raw Z80 byte asserts the strobe (cable LOW because
+     * the connector inverts it). Emit whenever bit 7 is set; bit-7=0
+     * writes are "data lines set, strobe deasserted" idle pokes that
+     * the OS does at init / between chars — silent on real paper. */
+    if (val & 0x80)
         printer_emit(p, val & 0x7F);
-    p->strobe_high = strobe_high_now;
 }

--- a/src/printer.c
+++ b/src/printer.c
@@ -1,0 +1,275 @@
+#include "printer.h"
+#include "leds.h"
+
+#if HAVE_CAIRO
+#include <cairo.h>
+#include <cairo-pdf.h>
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#ifndef _WIN32
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <signal.h>
+#include <sys/types.h>
+#endif
+
+static bool printer_capture_active(const Printer *p) {
+    return p->pdf_enabled || p->sink == PRINT_SINK_REAL;
+}
+
+/* Hand the finalised PDF to CUPS via `lp`. Detaches the child so the
+ * emulator doesn't stutter while CUPS queues; when the PDF is ephemeral
+ * (no user-visible file), we wait for lp and unlink afterwards. */
+static void printer_spool_to_lp(const char *pdf_path, bool wait_then_unlink) {
+#ifdef _WIN32
+    (void)pdf_path; (void)wait_then_unlink;
+    fprintf(stderr, "printer: real-printer sink not implemented on Windows yet\n");
+#else
+    if (!pdf_path || !pdf_path[0]) return;
+    pid_t pid = fork();
+    if (pid < 0) { perror("printer: fork"); return; }
+    if (pid == 0) {
+        int devnull = open("/dev/null", O_WRONLY);
+        if (devnull >= 0) {
+            dup2(devnull, STDOUT_FILENO);
+            dup2(devnull, STDERR_FILENO);
+            if (devnull > 2) close(devnull);
+        }
+        execlp("lp", "lp", pdf_path, (char *)NULL);
+        _exit(127);
+    }
+    if (wait_then_unlink) {
+        int status;
+        waitpid(pid, &status, 0);
+        unlink(pdf_path);
+    } else {
+        static bool signal_set = false;
+        if (!signal_set) { signal(SIGCHLD, SIG_IGN); signal_set = true; }
+    }
+#endif
+}
+
+/* US Letter at 72 dpi PDF points. The CPC printer port is just a byte
+ * pipe — no physical paper geometry is implied — so we pick a sensible
+ * page size for captured text. */
+#define PAGE_W_PT       612.0f
+#define PAGE_H_PT       792.0f
+#define TEXT_MARGIN_PT   36.0f
+#define TEXT_TOP_PT      54.0f
+#define TEXT_FONT_PT     10.0f
+#define TEXT_LINE_PT     12.0f
+#define TEXT_CHAR_PT      6.0f
+
+#define IDLE_FRAMES_TO_FINALISE 100   /* ~2 s at 50 Hz */
+
+static void printer_reset_text(Printer *p) {
+    p->text_x = TEXT_MARGIN_PT;
+    p->text_y = TEXT_TOP_PT;
+    p->text_esc_skip = 0;
+}
+
+void printer_init(Printer *p) {
+    memset(p, 0, sizeof(*p));
+    p->connected = true;
+    p->strobe_high = true;
+    printer_reset_text(p);
+}
+
+static void printer_make_pdf_path(Printer *p) {
+    time_t now = time(NULL);
+    struct tm *lt = localtime(&now);
+    char base[64];
+    if (!lt || !strftime(base, sizeof(base), "1984-print-%Y%m%d-%H%M%S", lt))
+        snprintf(base, sizeof(base), "1984-print");
+
+    p->pdf_ephemeral = !p->pdf_enabled;
+    const char *tmp_env = p->pdf_ephemeral ? getenv("TMPDIR") : NULL;
+    const char *dir = p->pdf_ephemeral ? (tmp_env && tmp_env[0] ? tmp_env : "/tmp")
+                                       : (p->pdf_output_dir[0] ? p->pdf_output_dir : ".");
+    size_t dir_len = strlen(dir);
+    const char *sep = (dir_len > 0 && (dir[dir_len - 1] == '/' || dir[dir_len - 1] == '\\'))
+                    ? "" : "/";
+    for (int n = 0; n < 100; n++) {
+        if (n == 0)
+            snprintf(p->pdf_path, sizeof(p->pdf_path), "%s%s%s.pdf", dir, sep, base);
+        else
+            snprintf(p->pdf_path, sizeof(p->pdf_path), "%s%s%s-%02d.pdf", dir, sep, base, n);
+        FILE *f = fopen(p->pdf_path, "rb");
+        if (!f) return;
+        fclose(f);
+    }
+    snprintf(p->pdf_path, sizeof(p->pdf_path), "%s%s%s-last.pdf", dir, sep, base);
+}
+
+#if HAVE_CAIRO
+static bool printer_pdf_open(Printer *p) {
+    if (!printer_capture_active(p)) return false;
+    if (p->pdf_cr) return true;
+
+    printer_make_pdf_path(p);
+    p->pdf_surface = cairo_pdf_surface_create(p->pdf_path, PAGE_W_PT, PAGE_H_PT);
+    cairo_status_t st = cairo_surface_status(p->pdf_surface);
+    if (st != CAIRO_STATUS_SUCCESS) {
+        fprintf(stderr, "printer: PDF open failed for %s: %s\n",
+                p->pdf_path, cairo_status_to_string(st));
+        cairo_surface_destroy(p->pdf_surface);
+        p->pdf_surface = NULL;
+        p->pdf_path[0] = 0;
+        return false;
+    }
+    p->pdf_cr = cairo_create(p->pdf_surface);
+    st = cairo_status(p->pdf_cr);
+    if (st != CAIRO_STATUS_SUCCESS) {
+        fprintf(stderr, "printer: PDF context failed for %s: %s\n",
+                p->pdf_path, cairo_status_to_string(st));
+        cairo_destroy(p->pdf_cr);
+        cairo_surface_destroy(p->pdf_surface);
+        p->pdf_cr = NULL;
+        p->pdf_surface = NULL;
+        p->pdf_path[0] = 0;
+        return false;
+    }
+    cairo_set_source_rgb(p->pdf_cr, 0.0, 0.0, 0.0);
+    return true;
+}
+
+static bool printer_pdf_ensure_page(Printer *p) {
+    if (!printer_pdf_open(p)) return false;
+    p->pdf_page_open = true;
+    cairo_set_source_rgb(p->pdf_cr, 0.0, 0.0, 0.0);
+    return true;
+}
+
+static void printer_pdf_show_page(Printer *p) {
+    if (!p->pdf_cr || !p->pdf_page_open) return;
+    cairo_show_page(p->pdf_cr);
+    p->pdf_page_open = false;
+    printer_reset_text(p);
+}
+
+void printer_shutdown(Printer *p) {
+    char done_path[PATH_MAX] = {0};
+    if (p->pdf_cr) {
+        if (p->pdf_page_open) cairo_show_page(p->pdf_cr);
+        cairo_destroy(p->pdf_cr);
+        p->pdf_cr = NULL;
+    }
+    if (p->pdf_surface) {
+        cairo_surface_finish(p->pdf_surface);
+        cairo_surface_destroy(p->pdf_surface);
+        p->pdf_surface = NULL;
+        snprintf(done_path, sizeof(done_path), "%s", p->pdf_path);
+    }
+    p->pdf_page_open = false;
+    p->pdf_path[0] = 0;
+
+    if (p->sink == PRINT_SINK_REAL && done_path[0])
+        printer_spool_to_lp(done_path, p->pdf_ephemeral);
+    p->pdf_ephemeral = false;
+}
+#else  /* !HAVE_CAIRO */
+static bool printer_pdf_ensure_page(Printer *p) { (void)p; return false; }
+static void printer_pdf_show_page(Printer *p)   { (void)p; }
+void printer_shutdown(Printer *p) {
+    p->pdf_page_open = false;
+    p->pdf_path[0] = 0;
+}
+#endif
+
+void printer_set_sink(Printer *p, PrintSink sink) {
+    p->sink = sink;
+}
+
+void printer_set_pdf_output_dir(Printer *p, const char *dir) {
+    char next[PATH_MAX];
+    snprintf(next, sizeof(next), "%s", (dir && dir[0]) ? dir : ".");
+    if (strcmp(p->pdf_output_dir, next) == 0) return;
+    printer_shutdown(p);
+    snprintf(p->pdf_output_dir, sizeof(p->pdf_output_dir), "%s", next);
+}
+
+void printer_set_pdf_enabled(Printer *p, bool enabled) {
+    if (p->pdf_enabled == enabled) return;
+    if (!enabled) printer_shutdown(p);
+    p->pdf_enabled = enabled;
+}
+
+static void printer_mark_active(Printer *p) {
+    p->idle_countdown = IDLE_FRAMES_TO_FINALISE;
+    leds_ping(LED_PRINTER);
+}
+
+void printer_tick(Printer *p) {
+    if (!p->idle_countdown) return;
+    if (--p->idle_countdown > 0) return;
+#if HAVE_CAIRO
+    if (p->pdf_cr || p->pdf_surface)
+        printer_shutdown(p);
+#endif
+}
+
+static void printer_text_linefeed(Printer *p) {
+    p->text_x = TEXT_MARGIN_PT;
+    p->text_y += TEXT_LINE_PT;
+    if (p->text_y > PAGE_H_PT - TEXT_MARGIN_PT) {
+        printer_pdf_show_page(p);
+        printer_reset_text(p);
+    }
+}
+
+/* Emit one Centronics data byte (already with strobe bit stripped). */
+static void printer_emit(Printer *p, u8 val) {
+    leds_ping(LED_PRINTER);
+    if (!printer_capture_active(p)) return;
+
+    if (p->text_esc_skip > 0) { p->text_esc_skip--; return; }
+
+    switch (val) {
+        case 0x1B: p->text_esc_skip = 1; return;
+        case '\r': p->text_x = TEXT_MARGIN_PT; return;
+        case '\n': printer_text_linefeed(p); return;
+        case '\f': printer_pdf_show_page(p); return;
+        case '\t': {
+            int col = (int)((p->text_x - TEXT_MARGIN_PT) / TEXT_CHAR_PT);
+            col = ((col / 8) + 1) * 8;
+            p->text_x = TEXT_MARGIN_PT + (float)col * TEXT_CHAR_PT;
+            return;
+        }
+        default: break;
+    }
+
+    if (val < 0x20 || val == 0x7F) return;
+    if (!printer_pdf_ensure_page(p)) return;
+
+#if HAVE_CAIRO
+    cairo_select_font_face(p->pdf_cr, "monospace",
+                           CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
+    cairo_set_font_size(p->pdf_cr, TEXT_FONT_PT);
+    cairo_move_to(p->pdf_cr, p->text_x, p->text_y);
+    char s[2] = { (char)val, 0 };
+    cairo_show_text(p->pdf_cr, s);
+    printer_mark_active(p);
+#endif
+
+    p->text_x += TEXT_CHAR_PT;
+    if (p->text_x > PAGE_W_PT - TEXT_MARGIN_PT)
+        printer_text_linefeed(p);
+}
+
+void printer_out(Printer *p, u8 val) {
+    if (!p->connected) return;
+
+    /* The CPC inverts the strobe line: bit 7 LOW means asserted. We
+     * detect the high→low edge and clock the low 7 bits in. Bit 7 of
+     * the data side isn't wired to the connector at all, so dropping
+     * it is faithful, not a workaround (Caprice32 cap32.cpp:768-773). */
+    bool strobe_high_now = (val & 0x80) != 0;
+    if (p->strobe_high && !strobe_high_now)
+        printer_emit(p, val & 0x7F);
+    p->strobe_high = strobe_high_now;
+}

--- a/src/printer.c
+++ b/src/printer.c
@@ -22,35 +22,55 @@ static bool printer_capture_active(const Printer *p) {
     return p->pdf_enabled || p->sink == PRINT_SINK_REAL;
 }
 
-/* Hand the finalised PDF to CUPS via `lp`. Detaches the child so the
- * emulator doesn't stutter while CUPS queues; when the PDF is ephemeral
- * (no user-visible file), we wait for lp and unlink afterwards. */
-static void printer_spool_to_lp(const char *pdf_path, bool wait_then_unlink) {
+/* Hand the finalised PDF to CUPS via `lp`. The emulator often runs
+ * inside a sandbox (distrobox / flatpak) where lp + CUPS live on the
+ * host, not in the container. We try the host-escape helpers first
+ * and fall back to plain lp so a host-side install also Just Works.
+ * We always WAIT for the spool to finish — lp typically returns in
+ * <100 ms once CUPS has the file, and we need the exit status so the
+ * user finds out when there's no default printer / lp is missing /
+ * CUPS isn't running, instead of silent failure. */
+static void printer_spool_to_lp(const char *pdf_path, bool unlink_after) {
 #ifdef _WIN32
-    (void)pdf_path; (void)wait_then_unlink;
+    (void)pdf_path; (void)unlink_after;
     fprintf(stderr, "printer: real-printer sink not implemented on Windows yet\n");
 #else
     if (!pdf_path || !pdf_path[0]) return;
+
+    /* Helpers in preferred order: distrobox-host-exec when in distrobox,
+     * flatpak-spawn --host when in a flatpak sandbox, else plain lp. */
+    static const struct { const char *prog; const char *arg1; } cands[] = {
+        { "distrobox-host-exec", NULL    },
+        { "flatpak-spawn",       "--host"},
+        { "lp",                  NULL    },
+    };
+
     pid_t pid = fork();
     if (pid < 0) { perror("printer: fork"); return; }
     if (pid == 0) {
-        int devnull = open("/dev/null", O_WRONLY);
-        if (devnull >= 0) {
-            dup2(devnull, STDOUT_FILENO);
-            dup2(devnull, STDERR_FILENO);
-            if (devnull > 2) close(devnull);
+        for (size_t i = 0; i < sizeof(cands)/sizeof(cands[0]); i++) {
+            if (cands[i].arg1)
+                execlp(cands[i].prog, cands[i].prog, cands[i].arg1,
+                       "lp", pdf_path, (char *)NULL);
+            else if (!strcmp(cands[i].prog, "lp"))
+                execlp("lp", "lp", pdf_path, (char *)NULL);
+            else
+                execlp(cands[i].prog, cands[i].prog,
+                       "lp", pdf_path, (char *)NULL);
+            /* execlp only returns on failure — try the next candidate. */
         }
-        execlp("lp", "lp", pdf_path, (char *)NULL);
+        fprintf(stderr, "printer: no `lp` available (tried distrobox-host-exec, "
+                        "flatpak-spawn --host, lp) — install cups-client or "
+                        "expose the host's lp\n");
         _exit(127);
     }
-    if (wait_then_unlink) {
-        int status;
-        waitpid(pid, &status, 0);
-        unlink(pdf_path);
-    } else {
-        static bool signal_set = false;
-        if (!signal_set) { signal(SIGCHLD, SIG_IGN); signal_set = true; }
-    }
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (WIFEXITED(status) && WEXITSTATUS(status) != 0)
+        fprintf(stderr, "printer: lp exited with status %d (check the host "
+                        "default printer with `lpstat -d`)\n",
+                WEXITSTATUS(status));
+    if (unlink_after) unlink(pdf_path);
 #endif
 }
 
@@ -187,6 +207,15 @@ void printer_shutdown(Printer *p) {
 #endif
 
 void printer_set_sink(Printer *p, PrintSink sink) {
+    if (p->sink == sink) return;
+    /* Finalise any in-progress job under the OLD sink rules first so
+     * the user sees the change take effect on the next char they print,
+     * not on whatever was already buffered. Without this, an open
+     * surface created while sink=PDF would stay around after switching
+     * to REAL and only get spooled on the next idle-finalise (and an
+     * ephemeral /tmp file from sink=REAL would get unlinked if the
+     * user flipped back to PDF before the idle tick). */
+    printer_shutdown(p);
     p->sink = sink;
 }
 

--- a/src/printer.c
+++ b/src/printer.c
@@ -79,6 +79,12 @@ void printer_init(Printer *p) {
     printer_reset_text(p);
 }
 
+void printer_set_connected(Printer *p, bool connected) {
+    if (p->connected == connected) return;
+    if (!connected) printer_shutdown(p);
+    p->connected = connected;
+}
+
 static void printer_make_pdf_path(Printer *p) {
     time_t now = time(NULL);
     struct tm *lt = localtime(&now);

--- a/src/printer.h
+++ b/src/printer.h
@@ -1,0 +1,74 @@
+#pragma once
+#include "types.h"
+#include <limits.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+/* Opaque-pointer forward decls so consumers don't need <cairo.h>. When
+ * built without Cairo, these stay NULL. */
+typedef struct _cairo cairo_t;
+typedef struct _cairo_surface cairo_surface_t;
+
+/*
+ * CPC parallel printer port.
+ *
+ * The CPC presents a 7-bit Centronics-style data port on writes to any
+ * I/O address with A12 low (0xEFxx). Bit 7 of the latched byte is the
+ * STROBE line, inverted by the hardware: only on strobe-LOW does the
+ * byte actually clock into the printer. The PPI's port B bit 6
+ * (BUSY input) is hardcoded to "not busy" so guests never throttle.
+ *
+ * The host-side sink is Cairo → PDF, optionally spooled to the default
+ * CUPS printer via `lp` so users can print from a CPC program to a
+ * real laser printer. The decoder is intentionally light: ESC eats
+ * one operand, printable bytes drop onto a monospace canvas at 10pt,
+ * CR/LF/FF/TAB handled, control bytes ignored. Anything more elaborate
+ * (graphics, ESC/P sequences) lands as text — the PDF is the captured
+ * stream, not a glyph-perfect simulation.
+ */
+
+typedef enum {
+    PRINT_SINK_PDF = 0,
+    PRINT_SINK_REAL,
+} PrintSink;
+
+typedef struct Printer {
+    bool connected;
+    bool pdf_enabled;
+    PrintSink sink;
+
+    /* Centronics latch. The CPC writes a full 8-bit byte where bit 7
+     * is the strobe; we commit the low 7 bits to print when strobe
+     * goes low (Caprice32 cap32.cpp:771-773). */
+    bool strobe_high;
+
+    bool pdf_ephemeral;
+    char pdf_output_dir[PATH_MAX];
+    char pdf_path[PATH_MAX];
+    cairo_surface_t *pdf_surface;
+    cairo_t *pdf_cr;
+    bool pdf_page_open;
+
+    float text_x;
+    float text_y;
+    int   text_esc_skip;
+
+    /* Idle-flush counter (frames at ~50 Hz). Every print byte resets it
+     * to IDLE_FRAMES_TO_FINALISE; printer_tick decrements and closes
+     * the PDF when it hits zero so viewers can open the file mid-job. */
+    int   idle_countdown;
+} Printer;
+
+void printer_init(Printer *p);
+void printer_shutdown(Printer *p);
+void printer_set_pdf_output_dir(Printer *p, const char *dir);
+void printer_set_pdf_enabled(Printer *p, bool enabled);
+void printer_set_sink(Printer *p, PrintSink sink);
+
+/* CPC Z80 OUT (0xEFxx),A — passes the full latched byte. The module
+ * does the strobe-edge detect and bit-7 invert internally. */
+void printer_out(Printer *p, u8 val);
+
+void printer_tick(Printer *p);

--- a/src/printer.h
+++ b/src/printer.h
@@ -39,10 +39,14 @@ typedef struct Printer {
     bool pdf_enabled;
     PrintSink sink;
 
-    /* Centronics latch. The CPC writes a full 8-bit byte where bit 7
-     * is the strobe; we commit the low 7 bits to print when strobe
-     * goes low (Caprice32 cap32.cpp:771-773). */
-    bool strobe_high;
+    /* The CPC inverts bit 7 between the data byte and the cable, so a
+     * raw Z80 OUT byte with bit 7 SET asserts the strobe (cable LOW).
+     * We emit on every write where bit 7 is set — Caprice32's model
+     * (cap32.cpp:771-773). No edge detection: real firmware pulses the
+     * strobe per byte (assert + deassert) so each char is one emit;
+     * homebrew that writes only the asserted byte per char (e.g.
+     * direct BASIC `OUT &EFFF, &80+ASC("X")`) also works because each
+     * write with bit 7 set prints its data byte. */
 
     bool pdf_ephemeral;
     char pdf_output_dir[PATH_MAX];

--- a/src/printer.h
+++ b/src/printer.h
@@ -71,6 +71,14 @@ void printer_set_pdf_output_dir(Printer *p, const char *dir);
 void printer_set_pdf_enabled(Printer *p, bool enabled);
 void printer_set_sink(Printer *p, PrintSink sink);
 
+/* Gate the whole printer at the bus level. When disconnected, every
+ * OUT (&EFxx),A becomes a no-op host-side: no LED ping, no PDF byte,
+ * no CUPS spool. The CPC firmware still sees PPI BUSY = not busy
+ * (handled in src/ppi.c), so guest software won't hang. Wired to
+ * cfg->mx4 in main.c / the overlay so the printer appears only when
+ * the MX4 expansion bus is connected. */
+void printer_set_connected(Printer *p, bool connected);
+
 /* CPC Z80 OUT (0xEFxx),A — passes the full latched byte. The module
  * does the strobe-edge detect and bit-7 invert internally. */
 void printer_out(Printer *p, u8 val);


### PR DESCRIPTION
Implements the parallel printer port (0xEFxx) end-to-end with a Cairo PDF host sink and optional CUPS spool.

## Summary
- Bus decode: every `OUT (port),A` with A12 LOW is handed to `printer_out` (Caprice32 cap32.cpp:768 model). Bit-7 set asserts the strobe — emit on every such write, low 7 bits = data byte.
- Host sink: Cairo PDF surface with monospace 10pt text capture, ESC/CR/LF/FF/TAB handling, idle-finalise (~2 s) so the file is openable mid-job.
- Real-printer mode: spools the finalised PDF via `lp`, escaping sandboxes via `distrobox-host-exec` / `flatpak-spawn --host` first, then plain `lp`. Errors surfaced to stderr.
- Config: `[printer]` section with `pdf_printer` / `pdf_printer_dir` / `print_sink`.
- CLI: `--printer-pdf=DIR` / `--printer-real`.
- Overlay: two rows on the Extensions tab after Cyboard (PDF printer + Printer mode). Gated on `mx4`; \"PDF printer\" Enter pops a folder picker.
- LED bar: warm-amber `LED_PRINTER` slot, gated on MX4.
- PPI port B bit 6 (BUSY) polarity corrected — was held HIGH (\"always busy\"), firmware never wrote.

## Test plan
- [x] `OUT &EFFF,&C1:OUT &EFFF,&41` → PDF with \"A\"
- [x] `PRINT #8,\"HELLO\":PRINT #8` → PDF with HELLO via the firmware printer path
- [x] Toggle Printer mode PDF → Real, spools to host CUPS default printer (HL-L2400DWE, user-confirmed working)
- [x] Folder picker pops on PDF printer enable; output dir persists across runs
- [x] Disabling MX4 hides the printer entries and silences the port

Closes #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)