### PR TITLE
usifac: align control-byte handling with the real PIC firmware

### DIFF
--- a/src/usifac.c
+++ b/src/usifac.c
@@ -161,6 +161,7 @@ void usifac_init(USIfAC *u, bool enable, const char *backend, int tcp_port,
     u->pty_master = -1;
     u->tcp_listen = -1;
     u->tcp_client = -1;
+    u->empty_sentinel = 0x01;
     u->present = enable;
     if (!u->present) return;
 
@@ -318,8 +319,8 @@ u8 usifac_read(USIfAC *u, u8 lo) {
         }
         case 0x1:  /* &FBD1 — status */
             if (via_perryfi)
-                return perryfi_rx_has(u->perryfi) ? 0xFF : 0x01;
-            return rb_empty(u->rx_head, u->rx_tail) ? 0x01 : 0xFF;
+                return perryfi_rx_has(u->perryfi) ? 0xFF : u->empty_sentinel;
+            return rb_empty(u->rx_head, u->rx_tail) ? u->empty_sentinel : 0xFF;
         case 0x8:  /* &FBD8 — presence (anything ≠ 0xFF is "present") */
             return 0x00;
         case 0xD:  /* &FBDD — current baud code */
@@ -343,31 +344,51 @@ void usifac_write(USIfAC *u, u8 lo, u8 val) {
             return;
         case 0x1:  /* &FBD1 — control */
             switch (val) {
-                case 0:  /* reset interface (no CPC reset) */
+                case 0:  /* full PIC reset (real hardware reboots) */
                     u->rx_head = u->rx_tail = 0;
                     u->tx_head = u->tx_tail = 0;
-                    u->burst_mode = false;
-                    u->baud_code  = 0;
+                    u->burst_mode    = false;
+                    u->baud_code     = 0;
+                    u->empty_sentinel = 0x01;
                     return;
-                case 1:  /* clear RX */
+                case 1:  /* clear RX pointers (firmware: next_in=next_out=1) */
                     u->rx_head = u->rx_tail = 0;
                     return;
-                case 2:  /* burst mode on */
+                case 2:   /* chunked file-transfer / burst mode on */
+                case 29:  /* blocking file-transfer mode (no chunking) */
                     u->burst_mode = true;
                     return;
-                case 3:  /* burst mode off */
+                case 3:  /* burst / file-transfer mode off */
                     u->burst_mode = false;
                     return;
                 case 4:        /* disable Direct/FDC mode — host-ROM concern */
                 case 65: case 66:  /* post-reset USB dir behaviour */
                     return;
-                case 30:       /* |STAT request — stub a zeroed reply */
+                case 30:       /* |STAT report — stub a zeroed reply */
                     for (int i = 0; i < 8; i++) rx_push(u, 0);
+                    return;
+                case 31:       /* image-slot report — firmware emits a
+                                * status string; nothing we run consumes
+                                * it, so swallow silently. */
+                    return;
+                case 40:       /* set RX-empty sentinel = 0 */
+                    u->empty_sentinel = 0x00;
+                    return;
+                case 41:       /* set RX-empty sentinel = 1 */
+                    u->empty_sentinel = 0x01;
+                    return;
+                case 100: case 101:  /* disable_board (CLC2 gate) — we
+                                      * have no chip-level decode to
+                                      * toggle; swallow. */
                     return;
                 default:
                     if (val >= 10 && val <= 23) {
                         u->baud_code = val;     /* readable at &FBDD */
                     }
+                    /* Anything else (24..28, 32..39, 42..64, 67..99,
+                     * 102..255 except the cases above) is a firmware
+                     * cmd we don't model; swallow it instead of
+                     * stashing it as a bogus baud code. */
                     return;
             }
         case 0x2:  /* &FBD2 — ROM-slot select (host-ROM concern; ignore) */

--- a/src/usifac.h
+++ b/src/usifac.h
@@ -7,9 +7,21 @@
  *
  * Ports (CPC I/O, all gated on the MX4 expansion bus):
  *   &FBD0  r/w  DATA      — pop/push one byte from the RX/TX queue
- *   &FBD1  r    STATUS    — 0xFF when RX non-empty, 0x01 when empty
+ *   &FBD1  r    STATUS    — 0xFF when RX non-empty; when empty returns
+ *                            the "empty sentinel" (default 0x01; flipped
+ *                            to 0x00 by control cmd 40, back by cmd 41)
  *   &FBD1  w    CONTROL   — see usifac_write() comments for the command map
- *   &FBD8  r    EXISTS    — 0x00 when board enabled (0xFF means absent)
+ *   &FBD8  r    EXISTS    — real firmware returns the board's rom_number
+ *                            (0..6) so the companion host-ROM can call
+ *                            back into itself after a bank switch; 0xFF
+ *                            means absent. We don't ship the host-ROM
+ *                            and only emulate the serial pipe, so we
+ *                            return 0x00 — passes the "not 0xFF"
+ *                            presence check used by every pure-serial
+ *                            consumer (FUZIX, Hayes/PerryFi, raw I/O),
+ *                            and steers any hypothetical ROM-aware code
+ *                            away from a bogus bank switch (slot 0 is
+ *                            the lower OS ROM, never an expansion).
  *   &FBDD  r    BAUDCODE  — last x written to &FBD1 in range 10..23
  *
  * Backend: a host-side PTY or a TCP listener, selected via cfg.
@@ -24,7 +36,7 @@
 
 struct Perryfi;
 
-#define USIFAC_RING (4096)  /* power of two; >= 3100 (firmware RX buffer) */
+#define USIFAC_RING (4096)  /* power of two; >= 2900 (firmware RX buffer) */
 
 typedef enum {
     USIFAC_BACKEND_PTY = 0,
@@ -53,6 +65,8 @@ typedef struct {
 
     bool burst_mode;
     u8   baud_code;           /* last 10..23 command via OUT &FBD1,x */
+    u8   empty_sentinel;      /* value returned from &FBD1 read when RX
+                               * empty; default 0x01, cmds 40/41 flip it */
 
     /* When non-NULL AND p->present, the data port (&FBD0) routes
      * through the AT-modem instead of touching the PTY/TCP rings.


### PR DESCRIPTION
Closes #171.

## Summary
Brought the wire-level USIfAC emulation into agreement with the real PIC18F47Q10 firmware on a few small details I'd previously been guessing at:

- **`empty_sentinel`** (default `0x01`) — `&FBD1` reads now return whatever the firmware would return. Control cmds `40` / `41` flip the sentinel between `0x00` and `0x01`. Default matches existing behaviour.
- **Control bytes** — accept cmd `29` (blocking burst-mode entry) as an alias of cmd `2`. Cmd `0` also resets the sentinel. Cmds `31` / `100` / `101` are explicitly swallowed with a comment so they read as intentional no-ops in traces, not "huh, what's that".
- **Header docs** — fix buffer-size note (`3100` → `2900`), document the empty-sentinel mechanism, and explain why we return `0x00` at `&FBD8` (the real firmware returns `rom_number`; we don't ship the host-ROM so `0x00` is the safe value that still passes the "not `0xFF`" presence check used by every pure-serial consumer).

## What this PR is *not*

No observable behaviour change for any current consumer (FUZIX, Hayes/PerryFi, HDCPM, SymbOS, BASIC `OUT &FBD0`). This is correctness + docs polish from reading the real firmware source — preparatory rather than load-bearing.

**Deliberately out of scope:** chunked file-transfer back-channel (cmd 2/29 + PIC-side chunk pull, used by XMODEM-style bulk transfers — no current user hits this path) and actual baud-rate enforcement.

## Test plan
- [x] Builds clean
- [ ] FUZIX still boots + telnets out over USIfAC
- [ ] Wi-Fi Modem (PerryFi) still dials / hangs up
