### PR TITLE
overlay: remember last picker dir; show drive paths in full; N=new blank dsk

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -488,6 +488,8 @@ int config_load_from(Config *cfg, const char *path_override) {
                 bool b;
                 if (parse_bool(val, &b)) cfg->debug = b;
                 else { fprintf(stderr, "1984.conf:%d: debug must be true/false\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "last_dir")) {
+                if (val[0]) expand_path(val, cfg->last_dir, sizeof(cfg->last_dir));
             }
         }
     }
@@ -625,7 +627,8 @@ int config_save(const Config *cfg) {
         "monochrome=%s\n\n"
         "[advanced]\n"
         "tinker=%s\n"
-        "debug=%s\n",
+        "debug=%s\n"
+        "last_dir=%s\n",
         cfg->disk_a,
         cfg->disk_b,
         cfg->tape,
@@ -664,7 +667,8 @@ int config_save(const Config *cfg) {
         cfg->fullscreen_smoothing ? "true" : "false",
         mono_to_str(cfg->monochrome),
         cfg->tinker     ? "true" : "false",
-        cfg->debug      ? "true" : "false"
+        cfg->debug      ? "true" : "false",
+        cfg->last_dir
     );
 
     fclose(f);

--- a/src/config.h
+++ b/src/config.h
@@ -120,6 +120,12 @@ typedef struct {
     char            pdf_printer_dir[CONFIG_PATH_MAX];
     ConfigPrintSink print_sink;
 
+    /* Last directory used by the F9 file pickers. Updated whenever the
+     * user picks a file or folder; passed back as the default location
+     * on the next dialog so each launch starts where the previous one
+     * left off (issue #107). */
+    char last_dir[CONFIG_PATH_MAX];
+
     /* [advanced] */
     bool tinker;             /* enable Advanced overlay tab with low-level toggles */
     bool debug;              /* enable debug machinery (env-var traces, panic

--- a/src/disk.c
+++ b/src/disk.c
@@ -112,6 +112,69 @@ int disk_load(Disk *d, const char *path) {
     return 0;
 }
 
+/* Standard CPC DATA-format DSK: 40 tracks, 1 side, 9 sectors × 512 bytes.
+ * Sector IDs are 0xC1..0xC9 (DATA, not SYSTEM/0x41..). Fill byte 0xE5
+ * leaves an empty AMSDOS directory in track-0 sector-0. */
+#define BLANK_TRACKS    40
+#define BLANK_SPT        9       /* sectors per track */
+#define BLANK_SECTOR_SZ  512
+#define BLANK_TRACK_SZ  (256 + BLANK_SPT * BLANK_SECTOR_SZ)   /* 4864 */
+
+int disk_create_blank(const char *path) {
+    const int TRACKS     = BLANK_TRACKS;
+    const int SPT        = BLANK_SPT;
+    const int SECTOR_SZ  = BLANK_SECTOR_SZ;
+    const int TRACK_SZ   = BLANK_TRACK_SZ;
+    const uint8_t FILL   = 0xE5;
+
+    FILE *f = fopen(path, "wb");
+    if (!f) { fprintf(stderr, "disk: cannot create %s\n", path); return -1; }
+
+    uint8_t hdr[256];
+    uint8_t track[BLANK_TRACK_SZ];
+    memset(hdr, 0, sizeof(hdr));
+    memcpy(hdr,
+           "MV - CPCEMU Disk-File\r\nDisk-Info\r\n",
+           34);
+    memcpy(hdr + 0x22, "1984        ", 12);   /* creator tag */
+    hdr[0x30] = (uint8_t)TRACKS;
+    hdr[0x31] = 1;                            /* sides */
+    hdr[0x32] = (uint8_t)(TRACK_SZ & 0xFF);
+    hdr[0x33] = (uint8_t)(TRACK_SZ >> 8);
+    if (fwrite(hdr, 1, 256, f) != 256) goto fail;
+
+    for (int t = 0; t < TRACKS; t++) {
+        memset(track, 0, 256);
+        memset(track + 256, FILL, SPT * SECTOR_SZ);
+        memcpy(track, "Track-Info\r\n", 12);
+        track[0x10] = (uint8_t)t;     /* track number */
+        track[0x11] = 0;              /* side */
+        track[0x14] = 2;              /* sector size code (N=2 → 512) */
+        track[0x15] = (uint8_t)SPT;   /* sectors */
+        track[0x16] = 0x4E;           /* GAP3 */
+        track[0x17] = FILL;           /* filler */
+        for (int s = 0; s < SPT; s++) {
+            uint8_t *si = track + 0x18 + s * 8;
+            si[0] = (uint8_t)t;       /* C */
+            si[1] = 0;                /* H */
+            si[2] = (uint8_t)(0xC1 + s);  /* R — DATA format */
+            si[3] = 2;                /* N */
+            si[4] = 0;                /* st1 */
+            si[5] = 0;                /* st2 */
+            si[6] = (uint8_t)(SECTOR_SZ & 0xFF);
+            si[7] = (uint8_t)(SECTOR_SZ >> 8);
+        }
+        if (fwrite(track, 1, TRACK_SZ, f) != (size_t)TRACK_SZ) goto fail;
+    }
+
+    fclose(f);
+    return 0;
+fail:
+    fprintf(stderr, "disk: short write to %s\n", path);
+    fclose(f);
+    return -1;
+}
+
 DiskSector *disk_find_sector(Disk *d, int side, uint8_t C, uint8_t H,
                              uint8_t R, uint8_t N) {
     if (!d->inserted || side >= d->sides) return NULL;

--- a/src/disk.h
+++ b/src/disk.h
@@ -36,6 +36,11 @@ void disk_eject(Disk *d);
 /* Returns 0 on success, -1 on error. */
 int  disk_load(Disk *d, const char *path);
 
+/* Write a standard CPC DATA-format blank .dsk to `path` (40 tracks,
+ * single-sided, 9 × 512-byte sectors, sector IDs 0xC1..0xC9, 0xE5 fill
+ * — empty AMSDOS directory). Returns 0 on success, -1 on I/O error. */
+int  disk_create_blank(const char *path);
+
 /* Find a sector by CHRN on the current track. Returns NULL if not found. */
 DiskSector *disk_find_sector(Disk *d, int side, uint8_t C, uint8_t H,
                              uint8_t R, uint8_t N);

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -156,12 +156,10 @@ static void item_text(const Overlay *ov, int row,
                 snprintf(val, vsz, "[enable DD1 in Advanced]");
                 *readonly = true;
             } else if (da && da->inserted && ov->cfg->disk_a[0]) {
-                char tmp[CONFIG_PATH_MAX];
-                snprintf(tmp, sizeof(tmp), "%s", ov->cfg->disk_a);
-                trunc_path(basename(tmp), val, vsz);
+                trunc_path(ov->cfg->disk_a, val, vsz);
             }
             else
-                snprintf(val, vsz, "[empty]  Enter=load");
+                snprintf(val, vsz, "[empty]  Enter=load, N=new, Del=clear");
             break;
         case 1:
             snprintf(lbl, lsz, "Drive B");
@@ -169,12 +167,10 @@ static void item_text(const Overlay *ov, int row,
                 snprintf(val, vsz, "[enable DD1 in Advanced]");
                 *readonly = true;
             } else if (db && db->inserted && ov->cfg->disk_b[0]) {
-                char tmp[CONFIG_PATH_MAX];
-                snprintf(tmp, sizeof(tmp), "%s", ov->cfg->disk_b);
-                trunc_path(basename(tmp), val, vsz);
+                trunc_path(ov->cfg->disk_b, val, vsz);
             }
             else
-                snprintf(val, vsz, "[empty]  Enter=load");
+                snprintf(val, vsz, "[empty]  Enter=load, N=new, Del=clear");
             break;
         case 2:
             snprintf(lbl, lsz, "Tape");
@@ -548,7 +544,7 @@ static void activate_item(Overlay *ov) {
             };
             SDL_ShowOpenFileDialog(overlay_file_callback, ov,
                 ov->cpc ? ov->cpc->display.window : NULL,
-                rom_filters, 2, NULL, false);
+                rom_filters, 2, ov->cfg->last_dir[0] ? ov->cfg->last_dir : NULL, false);
             break;
         }
         case 6: {
@@ -560,7 +556,7 @@ static void activate_item(Overlay *ov) {
             };
             SDL_ShowOpenFileDialog(overlay_file_callback, ov,
                 ov->cpc ? ov->cpc->display.window : NULL,
-                rom_filters, 2, NULL, false);
+                rom_filters, 2, ov->cfg->last_dir[0] ? ov->cfg->last_dir : NULL, false);
             break;
         }
         case 7:
@@ -587,7 +583,7 @@ static void activate_item(Overlay *ov) {
             };
             SDL_ShowOpenFileDialog(overlay_file_callback, ov,
                 ov->cpc ? ov->cpc->display.window : NULL,
-                filters, 2, NULL, false);
+                filters, 2, ov->cfg->last_dir[0] ? ov->cfg->last_dir : NULL, false);
         } else if (ov->row == 2) {
             /* Tape — stub: file picker captures the .cdt path into
              * cfg.tape, but nothing reads it yet. */
@@ -599,7 +595,7 @@ static void activate_item(Overlay *ov) {
             };
             SDL_ShowOpenFileDialog(overlay_file_callback, ov,
                 ov->cpc ? ov->cpc->display.window : NULL,
-                tape_filters, 2, NULL, false);
+                tape_filters, 2, ov->cfg->last_dir[0] ? ov->cfg->last_dir : NULL, false);
         }
         break;
 
@@ -676,7 +672,7 @@ static void activate_item(Overlay *ov) {
                     };
                     SDL_ShowOpenFileDialog(overlay_file_callback, ov,
                         ov->cpc ? ov->cpc->display.window : NULL,
-                        m4_filters, 2, NULL, false);
+                        m4_filters, 2, ov->cfg->last_dir[0] ? ov->cfg->last_dir : NULL, false);
                 }
             } else {
                 /* Disable: clear flag and unload M4ROM from its slot.
@@ -785,7 +781,7 @@ static void activate_item(Overlay *ov) {
                     };
                     SDL_ShowOpenFileDialog(overlay_file_callback, ov,
                         ov->cpc ? ov->cpc->display.window : NULL,
-                        ide_filters, 2, NULL, false);
+                        ide_filters, 2, ov->cfg->last_dir[0] ? ov->cfg->last_dir : NULL, false);
                 }
             } else {
                 /* Disabling: clear the LIVE image but keep the cached
@@ -868,7 +864,7 @@ static void activate_item(Overlay *ov) {
                     };
                     SDL_ShowOpenFileDialog(overlay_file_callback, ov,
                         ov->cpc ? ov->cpc->display.window : NULL,
-                        alb_filters, 2, NULL, false);
+                        alb_filters, 2, ov->cfg->last_dir[0] ? ov->cfg->last_dir : NULL, false);
                 }
             } else {
                 /* Disabling the card also drops the Albireo Mouse — it
@@ -931,7 +927,7 @@ static void activate_item(Overlay *ov) {
                     };
                     SDL_ShowOpenFileDialog(overlay_file_callback, ov,
                         ov->cpc ? ov->cpc->display.window : NULL,
-                        ide_filters, 2, NULL, false);
+                        ide_filters, 2, ov->cfg->last_dir[0] ? ov->cfg->last_dir : NULL, false);
                     /* dirty set by file callback once image is chosen */
                 }
             } else {
@@ -956,7 +952,8 @@ static void activate_item(Overlay *ov) {
                 ov->dialog_ready = false;
                 SDL_ShowOpenFolderDialog(overlay_file_callback, ov,
                     ov->cpc ? ov->cpc->display.window : NULL,
-                    ov->cfg->pdf_printer_dir[0] ? ov->cfg->pdf_printer_dir : NULL,
+                    ov->cfg->pdf_printer_dir[0] ? ov->cfg->pdf_printer_dir
+                        : (ov->cfg->last_dir[0] ? ov->cfg->last_dir : NULL),
                     false);
             }
             break;
@@ -995,7 +992,7 @@ static void activate_item(Overlay *ov) {
             };
             SDL_ShowOpenFileDialog(overlay_file_callback, ov,
                 ov->cpc ? ov->cpc->display.window : NULL,
-                sna_filters, 2, NULL, false);
+                sna_filters, 2, ov->cfg->last_dir[0] ? ov->cfg->last_dir : NULL, false);
             break;
         }
         case 3: {
@@ -1008,7 +1005,7 @@ static void activate_item(Overlay *ov) {
             };
             SDL_ShowSaveFileDialog(overlay_file_callback, ov,
                 ov->cpc ? ov->cpc->display.window : NULL,
-                sna_filters, 2, NULL);
+                sna_filters, 2, ov->cfg->last_dir[0] ? ov->cfg->last_dir : NULL);
             break;
         }
         case 4:
@@ -1038,7 +1035,7 @@ static void activate_item(Overlay *ov) {
                 };
                 SDL_ShowSaveFileDialog(overlay_file_callback, ov,
                     ov->cpc ? ov->cpc->display.window : NULL,
-                    webm_filters, 2, NULL);
+                    webm_filters, 2, ov->cfg->last_dir[0] ? ov->cfg->last_dir : NULL);
             }
             break;
         case 8:
@@ -1164,10 +1161,30 @@ static void overlay_check_board_changes(Overlay *ov) {
     ov->last_symbiface_ide = ov->cfg->symbiface_ide;
 }
 
+/* Stash the parent directory of the freshly picked path in cfg->last_dir
+ * so the next file/folder dialog starts where this one left off (#107).
+ * Folder pickers land on the *parent* of the chosen folder which is the
+ * SDL default for "where the dialog opens" — slightly suboptimal but
+ * uniform with file pickers and avoids special-casing per dialog kind. */
+static void remember_last_dir(Config *cfg, const char *picked) {
+    if (!picked || !picked[0]) return;
+    const char *sep = strrchr(picked, '/');
+#ifdef _WIN32
+    const char *bs = strrchr(picked, '\\');
+    if (bs && (!sep || bs > sep)) sep = bs;
+#endif
+    if (!sep || sep == picked) return;
+    size_t n = (size_t)(sep - picked);
+    if (n >= sizeof(cfg->last_dir)) n = sizeof(cfg->last_dir) - 1;
+    memcpy(cfg->last_dir, picked, n);
+    cfg->last_dir[n] = '\0';
+}
+
 void overlay_tick(Overlay *ov) {
     if (!ov->dialog_ready) return;
     SDL_MemoryBarrierAcquire();
     ov->dialog_ready = false;
+    remember_last_dir(ov->cfg, ov->dialog_path);
 
     if (ov->dialog_kind == DIALOG_DISK && ov->dialog_drive >= 0 && ov->dialog_drive < 2) {
         int drv = ov->dialog_drive;
@@ -1183,6 +1200,23 @@ void overlay_tick(Overlay *ov) {
             }
         }
         ov->dirty = true;
+    } else if (ov->dialog_kind == DIALOG_DISK_NEW &&
+               ov->dialog_drive >= 0 && ov->dialog_drive < 2) {
+        int drv = ov->dialog_drive;
+        ov->dialog_drive = -1;
+        char *dest = (drv == 0) ? ov->cfg->disk_a : ov->cfg->disk_b;
+        if (disk_create_blank(ov->dialog_path) == 0) {
+            snprintf(dest, CONFIG_PATH_MAX, "%s", ov->dialog_path);
+            if (ov->cpc) {
+                Disk *d = &ov->cpc->drive[drv];
+                disk_eject(d);
+                if (disk_load(d, dest) < 0) {
+                    fprintf(stderr, "1984: created %s but failed to mount\n", dest);
+                    dest[0] = '\0';
+                }
+            }
+            ov->dirty = true;
+        }
     } else if (ov->dialog_kind == DIALOG_TAPE) {
         /* Stub — just record the path. PSG cassette input not wired yet. */
         snprintf(ov->cfg->tape, CONFIG_PATH_MAX, "%s", ov->dialog_path);
@@ -1540,7 +1574,7 @@ bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
             ov->dialog_ready = false;
             SDL_ShowOpenFileDialog(overlay_file_callback, ov,
                 ov->cpc ? ov->cpc->display.window : NULL,
-                filters, 2, NULL, false);
+                filters, 2, ov->cfg->last_dir[0] ? ov->cfg->last_dir : NULL, false);
             break;
         }
         case SDL_SCANCODE_DELETE:
@@ -1622,8 +1656,43 @@ bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
         activate_item(ov);
         overlay_check_board_changes(ov);
         break;
+    case SDL_SCANCODE_N:
+        /* N on Drive A / Drive B pops a save-as dialog and creates a
+         * fresh blank CPC DATA-format .dsk at the chosen path, then
+         * inserts it into the drive. */
+        if (ov->section == OV_STORAGE &&
+            (ov->row == 0 || ov->row == 1) && floppy_accessible(ov)) {
+            ov->dialog_kind  = DIALOG_DISK_NEW;
+            ov->dialog_drive = ov->row;
+            ov->dialog_ready = false;
+            static const SDL_DialogFileFilter dsk_filters[] = {
+                { "DSK images", "dsk;DSK" },
+                { "All files",  "*"       },
+            };
+            SDL_ShowSaveFileDialog(overlay_file_callback, ov,
+                ov->cpc ? ov->cpc->display.window : NULL,
+                dsk_filters, 2, ov->cfg->last_dir[0] ? ov->cfg->last_dir : NULL);
+        }
+        break;
     case SDL_SCANCODE_DELETE:
     case SDL_SCANCODE_BACKSPACE:
+        /* Del on Drive A / Drive B / Tape ejects the image and clears
+         * the cached path (#107 follow-up). */
+        if (ov->section == OV_STORAGE) {
+            if ((ov->row == 0 || ov->row == 1) && floppy_accessible(ov)) {
+                int drv = ov->row;
+                char *dest = (drv == 0) ? ov->cfg->disk_a : ov->cfg->disk_b;
+                if (dest[0]) {
+                    dest[0] = '\0';
+                    if (ov->cpc) disk_eject(&ov->cpc->drive[drv]);
+                    ov->dirty = true;
+                }
+            } else if (ov->row == 2 && ov->cfg->tape[0]) {
+                ov->cfg->tape[0] = '\0';
+                ov->dirty = true;
+            }
+            break;
+        }
         /* Del on the Extensions tab row for M4 / Symbiface IDE /
          * Albireo also clears the cached board image — so the next
          * enable re-prompts for a fresh path. Toggles the extension

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -30,7 +30,8 @@ typedef enum {
     DIALOG_SNAPSHOT_LOAD = 9,
     DIALOG_SNAPSHOT_SAVE = 10,
     DIALOG_VIDEO_CAPTURE = 11,
-    DIALOG_PRINTER_DIR   = 12
+    DIALOG_PRINTER_DIR   = 12,
+    DIALOG_DISK_NEW      = 13   /* save-as: create a blank .dsk */
 } DialogKind;
 
 typedef struct {


### PR DESCRIPTION
Closes #107.

Three related quality-of-life fixes for the F9 **Media** tab.

## 1. Last-used directory persisted across launches (#107)
- New `Config.last_dir` field, stored under `[advanced]` in `1984.conf`.
- `overlay_tick` extracts the parent dir of every picked path and stashes it.
- All 12 file / save / folder dialog call sites now pass `cfg->last_dir` (or `NULL` on first launch) as the `default_location`, so the next picker opens where the previous one left off.

## 2. Drive A / B / Tape show the full path
Was: just the basename. Now: the full path, only truncated with a leading `...` when it overflows the value column. Saves a detour through the OS file manager just to remember which DSK is currently mounted.

## 3. Empty-row hint now reads `Enter=load, N=new, Del=clear`
- **Del / Backspace** ejects the disk and clears `cfg.disk_{a,b}` (or `cfg.tape`) so the next session boots empty.
- **N** pops a save-as dialog and writes a fresh CPC DATA-format blank `.dsk` (40 tracks × 1 side × 9 × 512-byte sectors, IDs `0xC1..0xC9`, `0xE5` fill — AMSDOS sees an empty directory) at the chosen path, then mounts it. New helper `disk_create_blank()` in `src/disk.c`; verified by a tiny round-trip test (create → load → 194 816 bytes, 40 tracks, first sector ID `0xC1`).

## Test plan
- [x] Builds clean
- [ ] F9 → Media → open a DSK; close and reopen 1984; F9 → Media → open a DSK again, expect to land in the same folder
- [ ] F9 → Media → eject drive A with `Del`; row reads `[empty]  Enter=load, N=new, Del=clear`
- [ ] F9 → Media → drive A → `N` → name the file → mounts a blank disk that `|CAT` shows as empty in BASIC
