### PR TITLE
usifac: don't open PTY/listener when MX4 expansion bus is off

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -580,7 +580,7 @@ int main(int argc, char *argv[]) {
         cpc.m4 = false;
         cfg.m4 = false;
     }
-    usifac_init(&cpc.usifac, cfg.usifac, cfg.usifac_backend, cfg.usifac_tcp_port,
+    usifac_init(&cpc.usifac, cfg.mx4 && cfg.usifac, cfg.usifac_backend, cfg.usifac_tcp_port,
                 cfg.usifac_pty_link);
     perryfi_init(&cpc.perryfi, cfg.mx4 && cfg.usifac && cfg.perryfi);
     usifac_attach_perryfi(&cpc.usifac, &cpc.perryfi);
@@ -1102,7 +1102,7 @@ int main(int argc, char *argv[]) {
             }
             ch376_disable_disk_read = cfg.albireo_disable_disk_read ? 1 : 0;
             usifac_shutdown(&cpc.usifac);
-            usifac_init(&cpc.usifac, cfg.usifac,
+            usifac_init(&cpc.usifac, cfg.mx4 && cfg.usifac,
                         cfg.usifac_backend, cfg.usifac_tcp_port,
                         cfg.usifac_pty_link);
             perryfi_shutdown(&cpc.perryfi);

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -700,7 +700,7 @@ static void activate_item(Overlay *ov) {
             if (!ov->cfg->usifac) ov->cfg->perryfi = false;
             if (ov->cpc) {
                 usifac_shutdown(&ov->cpc->usifac);
-                usifac_init(&ov->cpc->usifac, ov->cfg->usifac,
+                usifac_init(&ov->cpc->usifac, ov->cfg->mx4 && ov->cfg->usifac,
                             ov->cfg->usifac_backend, ov->cfg->usifac_tcp_port,
                             ov->cfg->usifac_pty_link);
                 perryfi_shutdown(&ov->cpc->perryfi);
@@ -1049,7 +1049,7 @@ static void activate_item(Overlay *ov) {
                          sizeof(ov->cfg->usifac_backend), "tcp");
             if (ov->cpc) {
                 usifac_shutdown(&ov->cpc->usifac);
-                usifac_init(&ov->cpc->usifac, ov->cfg->usifac,
+                usifac_init(&ov->cpc->usifac, ov->cfg->mx4 && ov->cfg->usifac,
                             ov->cfg->usifac_backend, ov->cfg->usifac_tcp_port,
                             ov->cfg->usifac_pty_link);
             }
@@ -1367,7 +1367,7 @@ bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
                      ov->pty_link_edit_buf);
             if (ov->cpc) {
                 usifac_shutdown(&ov->cpc->usifac);
-                usifac_init(&ov->cpc->usifac, ov->cfg->usifac,
+                usifac_init(&ov->cpc->usifac, ov->cfg->mx4 && ov->cfg->usifac,
                             ov->cfg->usifac_backend, ov->cfg->usifac_tcp_port,
                             ov->cfg->usifac_pty_link);
             }


### PR DESCRIPTION
## Summary
- `usifac_init` was called with just `cfg.usifac` at all four call sites, so the PTY allocation + `usifac: PTY ready at /dev/pts/N` log line fired even with `mx4=false` in 1984.conf.
- The I/O dispatcher in `cpc.c` already correctly gates port accesses on `mx4 && usifac.present` — only the startup wiring missed it.
- Now ANDs `cfg.mx4 && cfg.usifac` at all four sites, matching the `perryfi_init` line immediately adjacent to each call.

## Test plan
- [x] Build clean inside distrobox
- [x] With `mx4=false, usifac=true` in 1984.conf, no PTY is opened and no \"PTY ready\" log line
- [ ] User verifies overlay-driven mx4/usifac toggle still creates/destroys PTY correctly