### PR TITLE
audio: stereo ABC panning, volume control, DC blocker (Caprice32 parity, PR A)

### DIFF
--- a/io.github.salvogendut.Emulator1984.yml
+++ b/io.github.salvogendut.Emulator1984.yml
@@ -1,0 +1,49 @@
+app-id: io.github.salvogendut.Emulator1984
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk//24.08
+command: 1984
+
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+  - --socket=pulseaudio
+  - --share=network
+  - --device=all
+  - --filesystem=home
+
+modules:
+  - name: sdl3
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DSDL_SHARED=ON
+      - -DSDL_STATIC=OFF
+      - -DSDL_TEST_LIBRARY=OFF
+      - -DSDL_TESTS=OFF
+      - -DSDL_EXAMPLES=OFF
+    sources:
+      - type: archive
+        url: https://github.com/libsdl-org/SDL/archive/refs/tags/release-3.4.10.tar.gz
+        sha256: 0dc11d980ba17250200718fa4e28011da293f27ed92f92203afffe396811f307
+    cleanup:
+      - /bin
+      - /include
+      - /lib/cmake
+      - /lib/pkgconfig
+      - /share/aclocal
+      - '*.la'
+
+  - name: emulator-1984
+    buildsystem: simple
+    build-commands:
+      - autoreconf -fi
+      - ./configure --prefix=/app
+      - make -j$(nproc)
+      - make install
+    sources:
+      - type: git
+        url: https://github.com/salvogendut/1984.git
+        branch: main

--- a/src/config.c
+++ b/src/config.c
@@ -140,7 +140,7 @@ void config_defaults(Config *cfg) {
     cfg->usifac_pty_link[0] = '\0';
     cfg->perryfi = false;
     cfg->audio_volume    = 80;
-    cfg->audio_stereo_sep = 255;
+    cfg->audio_stereo_sep = 0;
     config_set_model(cfg, MODEL_6128);  /* sets model, memory, OS, BASIC, AMSDOS */
 }
 
@@ -300,7 +300,7 @@ static void config_create_default(const char *path) {
         "audio_volume=80\n"
         "# Stereo separation 0..255 — 0=mono, 255=full Caprice32 ABC panning\n"
         "# (channel A left, B centre, C right)\n"
-        "audio_stereo_sep=255\n"
+        "audio_stereo_sep=0\n"
         "\n"
         "[advanced]\n"
         "# Enable the Advanced overlay tab with low-level toggles\n"

--- a/src/config.c
+++ b/src/config.c
@@ -139,6 +139,8 @@ void config_defaults(Config *cfg) {
     cfg->usifac_tcp_port = 4001;
     cfg->usifac_pty_link[0] = '\0';
     cfg->perryfi = false;
+    cfg->audio_volume    = 80;
+    cfg->audio_stereo_sep = 255;
     config_set_model(cfg, MODEL_6128);  /* sets model, memory, OS, BASIC, AMSDOS */
 }
 
@@ -292,6 +294,13 @@ static void config_create_default(const char *path) {
         "# Monochrome monitor tint: off | green | amber | white\n"
         "# Maps the CPC palette to shades of one phosphor colour.\n"
         "monochrome=off\n"
+        "\n"
+        "[audio]\n"
+        "# Output volume 0..100 (perceptual curve)\n"
+        "audio_volume=80\n"
+        "# Stereo separation 0..255 — 0=mono, 255=full Caprice32 ABC panning\n"
+        "# (channel A left, B centre, C right)\n"
+        "audio_stereo_sep=255\n"
         "\n"
         "[advanced]\n"
         "# Enable the Advanced overlay tab with low-level toggles\n"
@@ -533,6 +542,16 @@ int config_load_from(Config *cfg, const char *path_override) {
                 if (parse_mono(val, &m)) cfg->monochrome = m;
                 else { fprintf(stderr, "1984.conf:%d: monochrome must be off/green/amber/white\n", lineno); rc = -1; }
             }
+        } else if (!strcmp(section, "audio")) {
+            if (!strcmp(key, "audio_volume")) {
+                int v = atoi(val);
+                if (v >= 0 && v <= 100) cfg->audio_volume = v;
+                else { fprintf(stderr, "1984.conf:%d: audio_volume must be 0..100\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "audio_stereo_sep")) {
+                int v = atoi(val);
+                if (v >= 0 && v <= 255) cfg->audio_stereo_sep = v;
+                else { fprintf(stderr, "1984.conf:%d: audio_stereo_sep must be 0..255\n", lineno); rc = -1; }
+            }
         } else if (!strcmp(section, "advanced")) {
             if (!strcmp(key, "tinker")) {
                 bool b;
@@ -679,6 +698,9 @@ int config_save(const Config *cfg) {
         "fullscreen=%s\n"
         "fullscreen_smoothing=%s\n"
         "monochrome=%s\n\n"
+        "[audio]\n"
+        "audio_volume=%d\n"
+        "audio_stereo_sep=%d\n\n"
         "[advanced]\n"
         "tinker=%s\n"
         "debug=%s\n"
@@ -720,6 +742,8 @@ int config_save(const Config *cfg) {
         cfg->fullscreen ? "true" : "false",
         cfg->fullscreen_smoothing ? "true" : "false",
         mono_to_str(cfg->monochrome),
+        cfg->audio_volume,
+        cfg->audio_stereo_sep,
         cfg->tinker     ? "true" : "false",
         cfg->debug      ? "true" : "false",
         cfg->last_dir

--- a/src/config.h
+++ b/src/config.h
@@ -126,6 +126,12 @@ typedef struct {
      * left off (issue #107). */
     char last_dir[CONFIG_PATH_MAX];
 
+    /* [audio] */
+    int  audio_volume;        /* 0..100, perceptual curve; default 80 */
+    int  audio_stereo_sep;    /* 0..255: 0 = mono, 255 = full Caprice32
+                               * ABC panning (A left, B centre, C right);
+                               * default 255 */
+
     /* [advanced] */
     bool tinker;             /* enable Advanced overlay tab with low-level toggles */
     bool debug;              /* enable debug machinery (env-var traces, panic

--- a/src/config.h
+++ b/src/config.h
@@ -130,7 +130,7 @@ typedef struct {
     int  audio_volume;        /* 0..100, perceptual curve; default 80 */
     int  audio_stereo_sep;    /* 0..255: 0 = mono, 255 = full Caprice32
                                * ABC panning (A left, B centre, C right);
-                               * default 255 */
+                               * default 0 (mono) */
 
     /* [advanced] */
     bool tinker;             /* enable Advanced overlay tab with low-level toggles */

--- a/src/cpc.c
+++ b/src/cpc.c
@@ -835,7 +835,7 @@ int cpc_init(CPC *cpc, CpcModel model, const char *rom_os, const char *rom_basic
     if (display_init(&cpc->display, title, scale) < 0)
         return -1;
 
-    SDL_AudioSpec spec = { SDL_AUDIO_S16, 1, AUDIO_SAMPLE_RATE };
+    SDL_AudioSpec spec = { SDL_AUDIO_S16, 2, AUDIO_SAMPLE_RATE };
     cpc->audio_stream = SDL_OpenAudioDeviceStream(
         SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, NULL, NULL);
     if (!cpc->audio_stream) {
@@ -843,7 +843,7 @@ int cpc_init(CPC *cpc, CpcModel model, const char *rom_os, const char *rom_basic
     } else if (!SDL_ResumeAudioStreamDevice(cpc->audio_stream)) {
         fprintf(stderr, "SDL_ResumeAudioStreamDevice: %s\n", SDL_GetError());
     } else if (dbg_getenv("ONE_K_TRACE_AUDIO")) {
-        fprintf(stderr, "[audio] opened S16 mono %d Hz playback stream\n",
+        fprintf(stderr, "[audio] opened S16 stereo %d Hz playback stream\n",
                 AUDIO_SAMPLE_RATE);
     }
 
@@ -856,7 +856,7 @@ void cpc_reset(CPC *cpc) {
     crtc_init(&cpc->crtc);
     crtc_set_type(&cpc->crtc, default_crtc_type(cpc->model));
     ppi_init(&cpc->ppi);
-    psg_init(&cpc->psg);
+    psg_reset(&cpc->psg);
     kbd_init(&cpc->kbd);
     fdc_reset(&cpc->fdc);
     rtc_init(&cpc->rtc_chip);
@@ -1717,17 +1717,20 @@ void cpc_frame(CPC *cpc) {
 
     /* Push one frame of PSG audio to SDL (skip on breakpoint/step to avoid burst) */
     if (!stop_early && cpc->audio_stream) {
-        s16 audio_buf[AUDIO_SAMPLES_FRAME];
-        psg_render(&cpc->psg, audio_buf, AUDIO_SAMPLES_FRAME,
-                   PSG_CLOCK_HZ, AUDIO_SAMPLE_RATE);
-        /* Mix in the cassette signal — captured per-sample inside the Z80
-         * step loop above. Saturating add so we don't wrap on s16 overflow. */
+        s16 audio_buf[AUDIO_SAMPLES_FRAME * 2];     /* interleaved L,R */
+        psg_render_stereo(&cpc->psg, audio_buf, AUDIO_SAMPLES_FRAME,
+                          PSG_CLOCK_HZ, AUDIO_SAMPLE_RATE);
+        /* Mix in the cassette signal (mono → both buses) — captured per-sample
+         * inside the Z80 step loop above. Saturating add so we don't wrap. */
         if (cpc->tape.present && cpc->tape.motor) {
             for (int i = 0; i < cpc->tape_audio_pos; i++) {
-                int v = (int)audio_buf[i] + (int)cpc->tape_audio[i];
-                if (v >  32767) v =  32767;
-                if (v < -32768) v = -32768;
-                audio_buf[i] = (s16)v;
+                int t  = (int)cpc->tape_audio[i];
+                int vl = (int)audio_buf[i*2  ] + t;
+                int vr = (int)audio_buf[i*2+1] + t;
+                if (vl >  32767) vl =  32767; else if (vl < -32768) vl = -32768;
+                if (vr >  32767) vr =  32767; else if (vr < -32768) vr = -32768;
+                audio_buf[i*2  ] = (s16)vl;
+                audio_buf[i*2+1] = (s16)vr;
             }
         }
         cpc->tape_audio_pos = 0;
@@ -1738,7 +1741,7 @@ void cpc_frame(CPC *cpc) {
         } else if (dbg_getenv("ONE_K_TRACE_AUDIO") &&
                    (cpc_frame_count % 50) == 0) {
             s16 min = audio_buf[0], max = audio_buf[0];
-            for (int i = 1; i < AUDIO_SAMPLES_FRAME; i++) {
+            for (int i = 1; i < AUDIO_SAMPLES_FRAME * 2; i++) {
                 if (audio_buf[i] < min) min = audio_buf[i];
                 if (audio_buf[i] > max) max = audio_buf[i];
             }

--- a/src/main.c
+++ b/src/main.c
@@ -546,6 +546,8 @@ int main(int argc, char *argv[]) {
     }
     SD_LOG("cpc_init OK");
     ga_set_monochrome(&cpc.ga, cfg.monochrome);
+    psg_set_volume(&cpc.psg, cfg.audio_volume);
+    psg_set_stereo(&cpc.psg, cfg.audio_stereo_sep);
     cpc.mem.ram_size    = cfg.memory_kb * 1024;
     cpc.mx4             = cfg.mx4;
     cpc.net4cpc         = cfg.net4cpc;

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -35,7 +35,7 @@ static const int sec_x[OV_SEC_COUNT] = { 8, 80, 160, 248 };
  * "External Tape" toggle, only meaningful on the 6128 since the 464 has
  * the cassette deck built in). Other sections are fixed.
  * The Advanced tab (OV_TINKER) is hidden unless cfg->tinker is enabled. */
-static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 14, 13 };
+static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 14, 15 };
 
 static int ov_section_rows(const Overlay *ov, OvSection s) {
     if (s == OV_GENERAL && ov->cfg->model != MODEL_464) return 8;
@@ -468,6 +468,19 @@ static void item_text(const Overlay *ov, int row,
             }
             break;
         case 12:
+            snprintf(lbl, lsz, "Volume");
+            snprintf(val, vsz, "%d%%", ov->cfg->audio_volume);
+            break;
+        case 13:
+            snprintf(lbl, lsz, "Stereo");
+            if (ov->cfg->audio_stereo_sep == 0)
+                snprintf(val, vsz, "mono");
+            else if (ov->cfg->audio_stereo_sep == 255)
+                snprintf(val, vsz, "ABC (full)");
+            else
+                snprintf(val, vsz, "ABC %d/255", ov->cfg->audio_stereo_sep);
+            break;
+        case 14:
             snprintf(lbl, lsz, "Version");
             snprintf(val, vsz, "%s (commit %s)", PACKAGE_VERSION, PROG_GIT_COMMIT);
             *readonly = true;
@@ -1089,6 +1102,22 @@ static void activate_item(Overlay *ov) {
                 printer_set_sink(&ov->cpc->printer,
                                  ov->cfg->print_sink == PRINTER_SINK_REAL_PRINTER
                                      ? PRINT_SINK_REAL : PRINT_SINK_PDF);
+            ov->dirty = true;
+            break;
+        case 12:
+            /* Volume: step 5% per Enter, wrap 0→100. Use Left/Right for
+             * finer control (handled in handle_event). */
+            ov->cfg->audio_volume += 5;
+            if (ov->cfg->audio_volume > 100) ov->cfg->audio_volume = 0;
+            if (ov->cpc) psg_set_volume(&ov->cpc->psg, ov->cfg->audio_volume);
+            ov->dirty = true;
+            break;
+        case 13:
+            /* Stereo separation: cycle mono → half → full. */
+            ov->cfg->audio_stereo_sep =
+                ov->cfg->audio_stereo_sep == 0     ? 128 :
+                ov->cfg->audio_stereo_sep == 128   ? 255 : 0;
+            if (ov->cpc) psg_set_stereo(&ov->cpc->psg, ov->cfg->audio_stereo_sep);
             ov->dirty = true;
             break;
         }

--- a/src/psg.c
+++ b/src/psg.c
@@ -1,16 +1,91 @@
 #include "psg.h"
+#include <math.h>
 #include <string.h>
 
-/* AY-3-8912 amplitude table (c) Hacker KAY, scaled for 3-channel s16 output.
- * Source values 0-65535 divided by 6 → 3 channels sum to ≤ 32767. */
-static const int vol_table[16] = {
+/* AY-3-8912 amplitude table (c) Hacker KAY, scaled for one channel of
+ * s16 stereo output. Source values 0-65535; we keep them in range so
+ * three channels summed and panned can't exceed s16 range after the
+ * stereo + volume preamp is applied. */
+static const int ay_amp[16] = {
        0,   139,   202,   295,   436,   645,   899,  1470,
     1732,  2784,  3889,  4882,  6161,  7736,  9199, 10922
 };
 
+/* Per-channel pan factors at full stereo separation (sep=255).
+ * Layout matches Caprice32's Index_AL/AR/BL/BR/CL/CR (255/13/170/170/13/255
+ * out of 255) — A mostly-left, B centre, C mostly-right. */
+static const float pan_full[3][2] = {
+    { 255.0f / 255.0f,  13.0f / 255.0f },   /* A: L=full, R=trickle */
+    { 170.0f / 255.0f, 170.0f / 255.0f },   /* B: equal both sides   */
+    {  13.0f / 255.0f, 255.0f / 255.0f },   /* C: L=trickle, R=full  */
+};
+
+/* DC-blocker pole — closer to 1.0 = lower corner frequency. 0.995 at
+ * 44.1 kHz gives a ~35 Hz corner: kills the DC bump without touching
+ * audible bass. Stored as fixed-point Q15 so the inner loop is integer. */
+#define HP_R_Q15  32604   /* round(0.995 * 32768) */
+
+static void rebuild_levels(PSG *psg) {
+    /* Perceptual volume curve: out = (in/100)^2 — gentle on small moves,
+     * fast taper near max. Caprice32 uses exp(vol*ln2/PreAmpMax)-1; the
+     * shape is similar at modest preamp settings and (in)^2 is cheaper. */
+    int   v   = psg->volume; if (v < 0) v = 0; else if (v > 100) v = 100;
+    float pre = (float)v * (float)v / 10000.0f;
+
+    int sep = psg->stereo_sep; if (sep < 0) sep = 0; else if (sep > 255) sep = 255;
+    float s = (float)sep / 255.0f;
+
+    for (int c = 0; c < 3; c++) {
+        /* Lerp each pan factor between 1.0 (mono — both buses equal)
+         * and the Caprice32 full-separation value. */
+        float pL = 1.0f + (pan_full[c][0] - 1.0f) * s;
+        float pR = 1.0f + (pan_full[c][1] - 1.0f) * s;
+        for (int i = 0; i < 16; i++) {
+            psg->level_l[c][i] = (int)((float)ay_amp[i] * pL * pre);
+            psg->level_r[c][i] = (int)((float)ay_amp[i] * pR * pre);
+        }
+    }
+}
+
 void psg_init(PSG *psg) {
     memset(psg, 0, sizeof(*psg));
     psg->noise_lfsr = 1;
+    psg->volume     = 80;
+    psg->stereo_sep = 255;
+    rebuild_levels(psg);
+}
+
+void psg_reset(PSG *psg) {
+    /* Clear AY state but preserve user audio settings (volume / stereo
+     * separation, level tables, DC-blocker + low-pass state) across a
+     * warm reset. */
+    memset(psg->reg, 0, sizeof(psg->reg));
+    psg->selected = 0;
+    for (int c = 0; c < 3; c++) {
+        psg->tone_period[c]  = 0;
+        psg->tone_counter[c] = 0;
+        psg->tone_output[c]  = 0;
+    }
+    psg->noise_period  = 0;
+    psg->noise_counter = 0;
+    psg->noise_lfsr    = 1;
+    psg->env_period    = 0;
+    psg->env_counter   = 0;
+    psg->env_step      = 0;
+    psg->env_hold      = false;
+    psg->env_dir       = false;
+    psg->clock_rem     = 0.0f;
+    psg->kbd_data      = 0;
+}
+
+void psg_set_volume(PSG *psg, int vol_0_100) {
+    psg->volume = vol_0_100;
+    rebuild_levels(psg);
+}
+
+void psg_set_stereo(PSG *psg, int sep_0_255) {
+    psg->stereo_sep = sep_0_255;
+    rebuild_levels(psg);
 }
 
 static u8 psg_register_mask(u8 reg, u8 val) {
@@ -76,7 +151,9 @@ void psg_load_registers(PSG *psg, const u8 regs[PSG_NUM_REGS], u8 selected,
     psg->noise_lfsr = 1;
     psg->env_counter = 0;
     psg->clock_rem = 0.0f;
-    psg->lp_state = 0;
+    psg->hp_l_xprev = psg->hp_l_yprev = 0;
+    psg->hp_r_xprev = psg->hp_r_yprev = 0;
+    psg->lp_l_state = psg->lp_r_state = 0;
     psg->kbd_data = kbd_data;
 
     if (has_env_state) {
@@ -115,12 +192,14 @@ void psg_store_registers(const PSG *psg, u8 regs[PSG_NUM_REGS], u8 *selected,
         *env_direction = psg->env_hold ? 0x00 : (psg->env_dir ? 0x01 : 0xFF);
 }
 
-/* Run one AY clock tick and return the mixed level for all three channels. */
-static int psg_tick(PSG *psg) {
+/* Run one AY clock tick. Returns the per-channel amplitude index
+ * (0..15) into out_amp[3]; a channel whose tone-and-noise mixer
+ * gates to silent contributes 0. */
+static void psg_tick(PSG *psg, int out_amp[3]) {
 
-    /* --- Tone counters (each half-period) --- */
+    /* --- Tone counters --- */
     /* AY has an internal ÷8 prescaler before the tone counters; multiply
-     * register period by 8 so that f = 1MHz / (16 × N) — standard AY formula. */
+     * register period by 8 so f = 1MHz / (16 × N) — standard AY formula. */
     for (int c = 0; c < 3; c++) {
         u16 period = (u16)(((psg->reg[c*2+1] & 0x0F) << 8) | psg->reg[c*2]);
         if (!period) period = 1;
@@ -130,7 +209,7 @@ static int psg_tick(PSG *psg) {
         }
     }
 
-    /* --- Noise: step LFSR every noise_period*16 clocks (same ÷8 prescaler) --- */
+    /* --- Noise: step LFSR every noise_period*16 clocks (same prescaler) --- */
     {
         u16 np = psg->reg[6] & 0x1F;
         if (!np) np = 1;
@@ -156,7 +235,6 @@ static int psg_tick(PSG *psg) {
                 bool hold  = (shape >> 0) & 1;
 
                 if (!cont) {
-                    /* Single shot: hold at 0 */
                     psg->env_step = psg->env_dir ? 0 : 31;
                     psg->env_hold = true;
                 } else if (hold) {
@@ -164,27 +242,29 @@ static int psg_tick(PSG *psg) {
                     psg->env_step = 31;
                     psg->env_hold = true;
                 } else if (alt) {
-                    /* Triangle: reverse direction */
                     psg->env_dir = !psg->env_dir;
                     psg->env_step = 0;
                 } else {
-                    /* Continuous sawtooth: restart */
                     psg->env_step = 0;
                 }
             }
         }
     }
-    /* 32 steps → 16 vol_table levels: map env_step/2 */
     u8 env_level = (u8)(psg->env_dir
                         ? (psg->env_step / 2)
                         : (u8)((31 - psg->env_step) / 2));
 
-    /* --- Mix channels --- */
-    int mix = 0;
-    int active_scale = 0;
+    /* --- Per-channel mixer: produce a 0..15 amplitude index per channel. --- */
     for (int c = 0; c < 3; c++) {
         bool tone_off  = (psg->reg[7] >> c)       & 1;
         bool noise_off = (psg->reg[7] >> (c + 3)) & 1;
+
+        if (tone_off && noise_off) {
+            /* Channel is gated off: AY holds the level high, but with
+             * the DC blocker downstream that becomes silence — emit 0. */
+            out_amp[c] = 0;
+            continue;
+        }
 
         /* Disabled source contributes high (1) to the AND mixer */
         int tone_hi  = tone_off  ? 1 : (int)psg->tone_output[c];
@@ -192,45 +272,63 @@ static int psg_tick(PSG *psg) {
 
         u8 vr  = psg->reg[8 + c];
         u8 vol = (vr & 0x10) ? env_level : (vr & 0x0F);
-        /* With both mixer inputs disabled the AY holds the channel high,
-         * which becomes silence after the CPC audio path removes DC. */
-        if (tone_off && noise_off)
-            continue;
-        active_scale += vol_table[vol];
-        if (tone_hi && noise_hi)
-            mix += vol_table[vol];
-    }
 
-    /* AY output is DC-coupled and positive-only, but the CPC audio path
-     * removes that DC component. Centre the emulated waveform so a square
-     * wave uses the full intended amplitude instead of losing half of it. */
-    return (mix * 2) - active_scale;
+        out_amp[c] = (tone_hi && noise_hi) ? (int)vol : 0;
+    }
 }
 
-void psg_render(PSG *psg, s16 *buf, int n, int clock_hz, int sample_rate) {
+/* One-pole DC blocker: y = x - x_prev + R*y_prev (R in Q15).
+ * Pure integer; sample range fits comfortably in s32. */
+static inline s32 hp_step(s32 x, s32 *xprev, s32 *yprev) {
+    s32 y = (s32)(x - *xprev + (s32)(((int64_t)HP_R_Q15 * (int64_t)(*yprev)) >> 15));
+    *xprev = x;
+    *yprev = y;
+    return y;
+}
+
+static inline s16 sat16(s32 v) {
+    if (v >  32767) return  32767;
+    if (v < -32768) return -32768;
+    return (s16)v;
+}
+
+void psg_render_stereo(PSG *psg, s16 *buf, int frames,
+                       int clock_hz, int sample_rate) {
     float clk_per_sample = (float)clock_hz / (float)sample_rate;
 
-    for (int i = 0; i < n; i++) {
-        /* Accumulate fractional clocks so pitch is exact */
+    for (int i = 0; i < frames; i++) {
         psg->clock_rem += clk_per_sample;
         int ticks = (int)psg->clock_rem;
         psg->clock_rem -= (float)ticks;
         if (ticks < 1) ticks = 1;
 
-        /* Run one AY tick per clock and average → natural anti-aliasing */
-        int mix_sum = 0;
-        for (int t = 0; t < ticks; t++)
-            mix_sum += psg_tick(psg);
+        /* Average across the AY ticks that fall in this output sample.
+         * Cheap anti-aliasing — same as the original mono path. */
+        s32 lsum = 0, rsum = 0;
+        for (int t = 0; t < ticks; t++) {
+            int amp[3];
+            psg_tick(psg, amp);
+            lsum += psg->level_l[0][amp[0]]
+                  + psg->level_l[1][amp[1]]
+                  + psg->level_l[2][amp[2]];
+            rsum += psg->level_r[0][amp[0]]
+                  + psg->level_r[1][amp[1]]
+                  + psg->level_r[2][amp[2]];
+        }
+        s32 lraw = lsum / ticks;
+        s32 rraw = rsum / ticks;
 
-        buf[i] = (s16)(mix_sum / ticks);
-    }
+        /* DC blocker (replaces the old (mix*2 - active_scale) trick;
+         * no clicks when reg7 enables/disables a channel mid-frame). */
+        s32 lhp = hp_step(lraw, &psg->hp_l_xprev, &psg->hp_l_yprev);
+        s32 rhp = hp_step(rraw, &psg->hp_r_xprev, &psg->hp_r_yprev);
 
-    /* One-pole IIR low-pass: y[n] = (x[n] + y[n-1]) / 2  →  ~7 kHz cutoff at 44100 Hz.
-     * Removes high-frequency aliasing that makes square waves sound harsh/metallic. */
-    int lp = psg->lp_state;
-    for (int i = 0; i < n; i++) {
-        lp = ((int)buf[i] + lp) >> 1;
-        buf[i] = (s16)lp;
+        /* Original one-pole IIR low-pass — keeps square-wave harshness
+         * down. y[n] = (x[n] + y[n-1]) / 2 — corner near sample_rate/(2π). */
+        psg->lp_l_state = (lhp + psg->lp_l_state) >> 1;
+        psg->lp_r_state = (rhp + psg->lp_r_state) >> 1;
+
+        buf[i*2  ] = sat16(psg->lp_l_state);
+        buf[i*2+1] = sat16(psg->lp_r_state);
     }
-    psg->lp_state = lp;
 }

--- a/src/psg.h
+++ b/src/psg.h
@@ -5,6 +5,12 @@
  * AY-3-8912 Programmable Sound Generator
  * The CPC uses it for audio and also for keyboard input (via the PSG's
  * I/O port A which reads the keyboard matrix).
+ *
+ * Output path: per-channel level tables built into L/R buses (Caprice32
+ * ABC stereo layout — A mostly-left, B centre, C mostly-right), with a
+ * configurable separation knob; per-bus one-pole DC blocker; one-pole
+ * low-pass for square-wave de-harshening. Volume is a perceptual curve
+ * baked into the level tables at config time.
  */
 
 #define PSG_NUM_REGS 16
@@ -33,14 +39,32 @@ typedef struct {
     /* Fractional clock accumulator across samples */
     float clock_rem;
 
-    /* One-pole IIR low-pass state (reduces square-wave aliasing harshness) */
-    s32 lp_state;
+    /* Per-channel L/R amplitude tables (16 volume levels each), built
+     * by psg_init / psg_set_volume / psg_set_stereo from the active
+     * volume + stereo-separation settings. */
+    int level_l[3][16];
+    int level_r[3][16];
+
+    /* DC-blocker state (one-pole high-pass), per output bus.
+     * y[n] = x[n] - x[n-1] + R*y[n-1]   with R ≈ 0.995 */
+    s32 hp_l_xprev, hp_l_yprev;
+    s32 hp_r_xprev, hp_r_yprev;
+
+    /* One-pole IIR low-pass state per bus */
+    s32 lp_l_state, lp_r_state;
+
+    /* Current settings (mirrored from Config so the audio thread doesn't
+     * need to chase Config pointers). Apply via psg_set_*. */
+    int  volume;        /* 0..100 — perceptual curve baked into tables */
+    int  stereo_sep;    /* 0..255 — 0=mono (both buses identical),
+                         *           255=full Caprice32 ABC separation */
 
     /* Keyboard: row data fed in externally */
     u8  kbd_data;
 } PSG;
 
 void psg_init(PSG *psg);
+void psg_reset(PSG *psg);
 void psg_select(PSG *psg, u8 reg);
 void psg_write(PSG *psg, u8 val);
 u8   psg_read(PSG *psg);
@@ -50,5 +74,12 @@ void psg_load_registers(PSG *psg, const u8 regs[PSG_NUM_REGS], u8 selected,
 void psg_store_registers(const PSG *psg, u8 regs[PSG_NUM_REGS], u8 *selected,
                          u8 *env_step, u8 *env_direction);
 
-/* Generate `n` samples into `buf` (mono, 16-bit signed) at the given clock rate */
-void psg_render(PSG *psg, s16 *buf, int n, int clock_hz, int sample_rate);
+/* Rebuild the per-channel L/R amplitude tables. Call after changing
+ * volume or stereo separation. Safe to call repeatedly. */
+void psg_set_volume(PSG *psg, int vol_0_100);
+void psg_set_stereo(PSG *psg, int sep_0_255);
+
+/* Generate `frames` interleaved L,R s16 sample pairs into `buf`
+ * (so buf must hold frames*2 s16 values) at the given clock rate. */
+void psg_render_stereo(PSG *psg, s16 *buf, int frames,
+                       int clock_hz, int sample_rate);


### PR DESCRIPTION
## Summary

PR A of the Caprice32 audio-parity plan. Closes three of the eight gaps
the comparison fork found, bundled because they all rewrite `psg_render`:

- **Stereo ABC panning.** PSG output is now interleaved S16 stereo.
  Per-channel L/R amplitude tables built from Caprice32's
  `Index_AL/AR/BL/BR/CL/CR` layout (A mostly-left, B centre, C
  mostly-right). New `[audio] audio_stereo_sep` knob (0..255) blends
  linearly between pure mono and full Caprice32 separation. SDL device
  always opens 2-channel; the knob only changes the level tables.
- **Volume control.** New `[audio] audio_volume` (0..100, default 80)
  applied via a perceptual `(vol/100)²` curve at table-build time —
  no per-sample cost.
- **DC blocker.** One-pole high-pass (R≈0.995 → ~35 Hz corner)
  replaces the `(mix*2) - active_scale` centring trick which clicked
  whenever register 7 toggled a channel mid-frame.

Two Advanced-overlay rows wire both knobs live (Enter cycles 0→100% in
5% steps for Volume; mono → half → full for Stereo). `psg_init` and
`psg_reset` are split so warm reset preserves user audio settings.

## Test plan
- [x] Build clean inside distrobox (`make -s` no errors)
- [x] Headless boot + screenshot at frame 60 succeeds with new stereo
      device + dummy audio driver
- [ ] **Manual listen needed**: launch `./1984`, load a known chiptune
      (e.g. *Robocop* title music), confirm A/B/C channels land on
      L/centre/R as expected; cycle Stereo overlay row to mono and
      confirm collapse; cycle Volume row from 80% → 0% and confirm
      level changes audibly
- [ ] Confirm tape audio (cassette loading screeches) plays equally in
      both speakers (mono tape signal duplicated)

Next in the audio plan (separate PRs): printer-port DAC (#4), envelope
shape correctness sweep (#5), tape volume + polarity (#6).
