### PR TITLE
Fix Bomb Jack CRTC raster timing

### DIFF
--- a/src/cpc.c
+++ b/src/cpc.c
@@ -956,9 +956,7 @@ static void cpc_monitor_end_hsync(CPC *cpc) {
     cpc->monitor_hs_end_pos = 0;
 }
 
-static bool cpc_monitor_advance(CPC *cpc) {
-    bool new_line = false;
-
+static void cpc_monitor_advance(CPC *cpc) {
     cpc->monitor_hs_start_pos += 0x100;
     cpc->monitor_hs_end_pos += 0x100;
     cpc->monitor_hs_peak_pos += 0x100;
@@ -975,10 +973,7 @@ static bool cpc_monitor_advance(CPC *cpc) {
             cpc->monitor_hs_peak_pos - cpc->monitor_hsync_duration;
         cpc->raster_y++;
         cpc->monitor_vline++;
-        new_line = true;
     }
-
-    return new_line;
 }
 
 static bool cpc_monitor_finish_frame(CPC *cpc, bool crtc_vsync) {
@@ -1028,6 +1023,7 @@ static void cpc_advance_bus(CPC *cpc, int cycles) {
 
         bool new_hsync = crtc_hsync(&cpc->crtc);
         bool new_vsync = crtc_vsync(&cpc->crtc);
+        bool new_crtc_line = crtc_new_scanline(&cpc->crtc);
         bool latch_mode = crtc_mode_latch(&cpc->crtc);
 
         /* GA interrupt counter on hsync falling edge (matches Caprice32) */
@@ -1072,10 +1068,13 @@ static void cpc_advance_bus(CPC *cpc, int cycles) {
         if (latch_mode)
             ga_latch_mode(&cpc->ga);
 
-        bool new_monitor_line = cpc_monitor_advance(cpc);
+        cpc_monitor_advance(cpc);
         cpc->raster_x = cpc->monitor_hpos / 256;
 
-        if (new_monitor_line && cpc_monitor_finish_frame(cpc, new_vsync))
+        /* The physical monitor free-runs through long/short CRTC lines, but
+         * vertical hold is sampled when the CRTC starts a real scanline.
+         * An 8-bit HCC wrap after a missed R0 comparator is not a newscan. */
+        if (new_crtc_line && cpc_monitor_finish_frame(cpc, new_vsync))
             display_upload(&cpc->display);
 
         /* On a CPC the Gate Array only observes the first seven CRTC HSYNC

--- a/src/crtc.c
+++ b/src/crtc.c
@@ -41,6 +41,11 @@ static u16 crtc_start_addr(const CRTC *c) {
     return ((u16)(c->reg[12] << 8) | c->reg[13]) & 0x3FFF;
 }
 
+static void crtc_latch_line_state(CRTC *c) {
+    c->line_last_raster = c->vlc == c->reg[9];
+    c->line_last_frame = c->line_last_raster && c->vcc == c->reg[4];
+}
+
 void crtc_init(CRTC *c) {
     memset(c, 0, sizeof(*c));
     c->type = CRTC_TYPE_1;
@@ -62,6 +67,7 @@ void crtc_init(CRTC *c) {
     c->h_display = true;
     c->v_display = true;
     c->display_enable = true;
+    crtc_latch_line_state(c);
 }
 
 void crtc_set_type(CRTC *c, CrtcType type) {
@@ -69,6 +75,15 @@ void crtc_set_type(CRTC *c, CrtcType type) {
         type = CRTC_TYPE_0;
     c->type = type;
     c->reg[8] = crtc_masked_reg_value(c, 8, c->reg[8]);
+}
+
+void crtc_recompute_state(CRTC *c) {
+    crtc_latch_line_state(c);
+    c->h_display = c->reg[1] != 0 && c->hcc < c->reg[1];
+    c->v_display = c->reg[6] != 0 && c->vcc < c->reg[6];
+    c->display_enable = c->h_display && c->v_display;
+    c->new_scanline = false;
+    c->mode_latch = false;
 }
 
 void crtc_select(CRTC *c, u8 reg) { c->selected = reg & 0x1F; }
@@ -81,6 +96,11 @@ void crtc_write(CRTC *c, u8 val) {
          * but moving R6 beyond the beam does not re-enable it this frame. */
         if (c->selected == 6 && c->vcc == c->reg[6])
             c->v_display = false;
+        /* C9/R9 and C4/R4 are sampled for the current scanline while C0 is
+         * still in its first two character positions. Later writes affect
+         * following lines, not this line's row/frame reset decision. */
+        if ((c->selected == 4 || c->selected == 9) && c->hcc <= 1)
+            crtc_latch_line_state(c);
         c->display_enable = c->h_display && c->v_display;
     }
 }
@@ -110,6 +130,7 @@ u8 crtc_read_status(CRTC *c) {
 }
 
 void crtc_tick(CRTC *c) {
+    c->new_scanline = false;
     c->mode_latch = false;
 
     u8 old_hcc = (u8)c->hcc;
@@ -150,14 +171,19 @@ void crtc_tick(CRTC *c) {
     /* On the final raster of a character row, R1 captures the address for
      * the next row. If software moves R1 behind the beam, the comparator is
      * missed and the current row address is repeated, as on the real CRTC. */
-    if (c->vlc == c->reg[9] &&
-        (c->hcc == c->reg[1] || (end_of_line && c->reg[1] == 0)))
-        c->ma_next_row = (u16)((c->ma_row_start + c->reg[1]) & 0x3FFF);
+    if (c->line_last_raster &&
+        (c->hcc == c->reg[1] || (end_of_line && c->reg[1] == 0))) {
+        c->ma_next_row = (end_of_line && c->reg[1] == 0)
+            ? c->ma_row_start
+            : (u16)(c->ma & 0x3FFF);
+    }
 
-    bool end_char_row = c->vlc == c->reg[9];
+    bool end_char_row = c->line_last_raster;
+    bool end_frame_line = c->line_last_frame;
 
     /* --- End of line --- */
     if (end_of_line) {
+        c->new_scanline = true;
         c->hcc = 0;
         c->h_display = c->reg[1] != 0;
 
@@ -191,7 +217,7 @@ void crtc_tick(CRTC *c) {
              * passed the new value, the CRTC keeps counting until the counter
              * wraps and the comparator can match again. Line-by-line rupture
              * effects depend on that overflow behaviour. */
-            if (c->vcc == c->reg[4]) {
+            if (end_frame_line) {
                 if (c->reg[5]) {
                     c->in_vadjust = true;
                     c->vac = 0;
@@ -222,6 +248,7 @@ void crtc_tick(CRTC *c) {
          * rasters ma_next_row still holds the current row start. */
         c->ma_row_start = c->ma_next_row;
         c->ma = c->ma_row_start;
+        crtc_latch_line_state(c);
     } else if (c->hcc == c->reg[1]) {
         c->h_display = false;
     }

--- a/src/crtc.h
+++ b/src/crtc.h
@@ -40,6 +40,9 @@ typedef struct {
     bool h_display;
     bool v_display;
     bool display_enable;
+    bool line_last_raster; /* C9 == R9 latched near C0=0 */
+    bool line_last_frame;  /* C4 == R4 && C9 == R9 latched near C0=0 */
+    bool new_scanline;     /* one-tick R0 comparator event */
     bool mode_latch;       /* one-tick GA mode-latch event */
     bool mode_latched_this_hsync;
 } CRTC;
@@ -51,10 +54,12 @@ void crtc_write(CRTC *c, u8 val);
 u8   crtc_read(CRTC *c);
 u8   crtc_read_status(CRTC *c);     /* &BE00 — type-dependent status/read port */
 void crtc_tick(CRTC *c);       /* one character clock (1 MHz) */
+void crtc_recompute_state(CRTC *c); /* after direct state restore */
 
 /* Derived helpers */
 static inline u16 crtc_screen_addr(CRTC *c) { return c->ma; }
 static inline bool crtc_hsync(CRTC *c)      { return c->hsync; }
 static inline bool crtc_vsync(CRTC *c)      { return c->vsync; }
 static inline bool crtc_de(CRTC *c)         { return c->display_enable; }
+static inline bool crtc_new_scanline(CRTC *c) { return c->new_scanline; }
 static inline bool crtc_mode_latch(CRTC *c) { return c->mode_latch; }

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -10,6 +10,28 @@ static u16 le16(const u8 *p) {
     return (u16)p[0] | ((u16)p[1] << 8);
 }
 
+#define SNA_CPC_MODEL           0x6D
+#define SNA_V3_CRTC_TYPE        0xA4
+#define SNA_V3_CRTC_ADDR        0xA5
+#define SNA_V3_CRTC_SCANLINE    0xA7
+#define SNA_V3_CRTC_CHAR_COUNT  0xA9
+#define SNA_V3_CRTC_LINE_COUNT  0xAB
+#define SNA_V3_CRTC_RASTER      0xAC
+#define SNA_V3_CRTC_VADJUST     0xAD
+#define SNA_V3_CRTC_HSW_COUNT   0xAE
+#define SNA_V3_CRTC_VSW_COUNT   0xAF
+#define SNA_V3_CRTC_FLAGS       0xB0
+#define SNA_V3_GA_INT_DELAY     0xB2
+#define SNA_V3_GA_SL_COUNT      0xB3
+#define SNA_V3_Z80_INT_PENDING  0xB4
+
+static u16 crtc_restore_next_row(const CRTC *crtc, u16 row_start) {
+    if (crtc->vlc == crtc->reg[9] && crtc->reg[1] != 0 &&
+        crtc->hcc >= crtc->reg[1])
+        return (u16)((row_start + crtc->reg[1]) & 0x3FFF);
+    return row_start;
+}
+
 int snapshot_load(CPC *cpc, const char *path) {
     if (!cpc || cpc->mem.ram_size <= 0) {
         fprintf(stderr, "snapshot: RAM not initialised — refusing to load '%s'\n",
@@ -118,6 +140,47 @@ int snapshot_load(CPC *cpc, const char *path) {
     u16 ram_kb = (version >= 2) ? le16(&hdr[0x6B]) : 64;
     if (ram_kb == 0) ram_kb = 64;   /* v1 default */
 
+    if (version >= 3) {
+        u8 type = hdr[SNA_V3_CRTC_TYPE];
+        if (type <= CRTC_TYPE_3)
+            crtc_set_type(&cpc->crtc, (CrtcType)type);
+
+        u16 row_start = le16(&hdr[SNA_V3_CRTC_ADDR]) & 0x3FFF;
+        cpc->crtc.hcc = hdr[SNA_V3_CRTC_CHAR_COUNT];
+        cpc->crtc.vcc = hdr[SNA_V3_CRTC_LINE_COUNT] & 0x7F;
+        cpc->crtc.vlc = hdr[SNA_V3_CRTC_RASTER] & 0x1F;
+        cpc->crtc.vac = hdr[SNA_V3_CRTC_VADJUST] & 0x1F;
+        cpc->crtc.hsc = hdr[SNA_V3_CRTC_HSW_COUNT] & 0x0F;
+        cpc->crtc.vsc = hdr[SNA_V3_CRTC_VSW_COUNT] & 0x0F;
+
+        u16 flags = le16(&hdr[SNA_V3_CRTC_FLAGS]);
+        cpc->crtc.vsync = (flags & 0x0001) != 0;
+        cpc->crtc.hsync = (flags & 0x0002) != 0;
+        cpc->crtc.in_vadjust = (flags & 0x0080) != 0;
+
+        cpc->crtc.ma_row_start = row_start;
+        cpc->crtc.ma_next_row = crtc_restore_next_row(&cpc->crtc, row_start);
+        cpc->crtc.ma = (u16)((row_start + cpc->crtc.hcc) & 0x3FFF);
+
+        cpc->monitor_vline = le16(&hdr[SNA_V3_CRTC_SCANLINE]);
+        cpc->raster_y = cpc->monitor_vline;
+        cpc->ga.vsync_delay = hdr[SNA_V3_GA_INT_DELAY] & 0x03;
+        cpc->ga.interrupt_counter = hdr[SNA_V3_GA_SL_COUNT];
+        cpc->ga.interrupt_pending = false;
+        cpc->cpu.pending_irq = hdr[SNA_V3_Z80_INT_PENDING] != 0;
+        cpc->prev_hsync = cpc->crtc.hsync;
+        cpc->prev_vsync = cpc->crtc.vsync;
+        cpc->crtc_cycle_acc = 0;
+    } else {
+        cpc->crtc.ma_row_start = ((u16)cpc->crtc.reg[12] << 8 | cpc->crtc.reg[13]) & 0x3FFF;
+        cpc->crtc.ma_next_row = cpc->crtc.ma_row_start;
+        cpc->crtc.ma = cpc->crtc.ma_row_start;
+    }
+    crtc_recompute_state(&cpc->crtc);
+    cpc->crtc_pre_ma = cpc->crtc.ma;
+    cpc->crtc_pre_ra = cpc->crtc.vlc;
+    cpc->crtc_pre_de = cpc->crtc.display_enable;
+
     size_t want = (size_t)ram_kb * 1024;
     if (want > (size_t)cpc->mem.ram_size) {
         fprintf(stderr, "snapshot: '%s' wants %u KB RAM, emulator configured for %d KB — "
@@ -195,6 +258,26 @@ int snapshot_save(CPC *cpc, const char *path) {
 
     u16 ram_kb = (u16)(cpc->mem.ram_size / 1024);
     put16(&hdr[0x6B], ram_kb);
+    hdr[SNA_CPC_MODEL] = (u8)cpc->model;
+
+    hdr[SNA_V3_CRTC_TYPE] = (u8)cpc->crtc.type;
+    put16(&hdr[SNA_V3_CRTC_ADDR], cpc->crtc.ma_row_start & 0x3FFF);
+    put16(&hdr[SNA_V3_CRTC_SCANLINE], (u16)cpc->monitor_vline);
+    hdr[SNA_V3_CRTC_CHAR_COUNT] = cpc->crtc.hcc & 0xFF;
+    hdr[SNA_V3_CRTC_CHAR_COUNT + 1] = 0;
+    hdr[SNA_V3_CRTC_LINE_COUNT] = cpc->crtc.vcc & 0x7F;
+    hdr[SNA_V3_CRTC_RASTER] = cpc->crtc.vlc & 0x1F;
+    hdr[SNA_V3_CRTC_VADJUST] = cpc->crtc.vac & 0x1F;
+    hdr[SNA_V3_CRTC_HSW_COUNT] = cpc->crtc.hsc & 0x0F;
+    hdr[SNA_V3_CRTC_VSW_COUNT] = cpc->crtc.vsc & 0x0F;
+    u16 flags = 0;
+    if (cpc->crtc.vsync) flags |= 0x0001;
+    if (cpc->crtc.hsync) flags |= 0x0002;
+    if (cpc->crtc.in_vadjust) flags |= 0x0080;
+    put16(&hdr[SNA_V3_CRTC_FLAGS], flags);
+    hdr[SNA_V3_GA_INT_DELAY] = cpc->ga.vsync_delay & 0x03;
+    hdr[SNA_V3_GA_SL_COUNT] = cpc->ga.interrupt_counter;
+    hdr[SNA_V3_Z80_INT_PENDING] = cpc->cpu.pending_irq ? 1 : 0;
 
     FILE *f = fopen(path, "wb");
     if (!f) {

--- a/src/z80.c
+++ b/src/z80.c
@@ -7,7 +7,7 @@ void (*z80_rst10_hook)(Z80 *cpu, Z80Bus *bus) = NULL;
 
 /* ---- Cycle tables (Caprice32 / konCePCja convention) ----------------
  * Cycle counts are T-states. Lookups: cc_op[op] for unprefixed,
- * cc_cb[op] for CB-prefixed, cc_ed[op] for ED-prefixed,
+ * cc_cb[op] for CB-prefixed, cc_ed[op] for the ED sub-op,
  * cc_xy[op] for DD/FD-prefixed (followed by a normal opcode),
  * cc_xycb[op] for DD/FD CB-prefixed.
  *
@@ -323,18 +323,20 @@ static int exec_ed(Z80 *cpu, Z80Bus *bus) {
         /* IN r,(C) */
         case 0x40: case 0x48: case 0x50: case 0x58:
         case 0x60: case 0x68: case 0x70: case 0x78: {
-            int ri = (op >> 3) & 7; u8 v = IN(cpu->bc);
+            int ri = (op >> 3) & 7;
+            if (bus->tick) bus->tick(bus->ctx, 16);
+            u8 v = IN(cpu->bc);
             if (ri != 6) set_r(cpu, bus, ri, cpu->hl, v);
             cpu->f = (cpu->f & Z80_FLAG_C) | sz(v) | par(v);
-            return 12;
+            return 16;
         }
         case 0x41: case 0x49: case 0x51: case 0x59:
         case 0x61: case 0x69: case 0x71: case 0x79: {
             int ri = (op >> 3) & 7;
             u8 v = ri == 6 ? 0 : get_r(cpu, bus, ri, cpu->hl);
-            if (bus->tick) bus->tick(bus->ctx, 8);
+            if (bus->tick) bus->tick(bus->ctx, 12);
             OUT(cpu->bc, v);
-            return 12;
+            return 16;
         }
         /* SBC HL,rr */
         case 0x42: case 0x52: case 0x62: case 0x72: {
@@ -397,52 +399,52 @@ static int exec_ed(Z80 *cpu, Z80Bus *bus) {
         case 0xA9: { u8 v=READ8(cpu->hl--); u8 r=cpu->a-v; cpu->bc--; cpu->f=(cpu->f&Z80_FLAG_C)|Z80_FLAG_N|sz(r)|((cpu->a^v^r)&0x10?Z80_FLAG_H:0)|(cpu->bc?Z80_FLAG_PV:0); return 16; }
         case 0xB1: { u8 v=READ8(cpu->hl++); u8 r=cpu->a-v; cpu->bc--; cpu->f=(cpu->f&Z80_FLAG_C)|Z80_FLAG_N|sz(r)|((cpu->a^v^r)&0x10?Z80_FLAG_H:0)|(cpu->bc?Z80_FLAG_PV:0); if(cpu->bc&&r){cpu->pc-=2;return 21;} return 16; }
         case 0xB9: { u8 v=READ8(cpu->hl--); u8 r=cpu->a-v; cpu->bc--; cpu->f=(cpu->f&Z80_FLAG_C)|Z80_FLAG_N|sz(r)|((cpu->a^v^r)&0x10?Z80_FLAG_H:0)|(cpu->bc?Z80_FLAG_PV:0); if(cpu->bc&&r){cpu->pc-=2;return 21;} return 16; }
-        /* Block I/O — IN ops: 16 cycles total, no pre-IO tick needed
-         * (konCePCja Iy=16 + Iy_=0). OUT ops reach the port after 12
-         * cycles and leave four base cycles after the write. */
-        case 0xA2: { u8 v=IN(cpu->bc); WRITE8(cpu->hl++,v); cpu->b--; cpu->f=sz(cpu->b)|Z80_FLAG_N; return 16; }
-        case 0xAA: { u8 v=IN(cpu->bc); WRITE8(cpu->hl--,v); cpu->b--; cpu->f=sz(cpu->b)|Z80_FLAG_N; return 16; }
-        case 0xB2: { u8 v=IN(cpu->bc); WRITE8(cpu->hl++,v); cpu->b--; cpu->f=Z80_FLAG_Z|Z80_FLAG_N; if(cpu->b){cpu->pc-=2;return 21;} return 16; }
-        case 0xBA: { u8 v=IN(cpu->bc); WRITE8(cpu->hl--,v); cpu->b--; cpu->f=Z80_FLAG_Z|Z80_FLAG_N; if(cpu->b){cpu->pc-=2;return 21;} return 16; }
+        /* Block I/O. Caprice32 accumulates the ED prefix plus the ED sub-op
+         * cycles before the port access, then leaves only the documented
+         * repeat/post-I/O remainder for the final wait-state chunk. */
+        case 0xA2: { if (bus->tick) bus->tick(bus->ctx, 20); u8 v=IN(cpu->bc); WRITE8(cpu->hl++,v); cpu->b--; cpu->f=sz(cpu->b)|Z80_FLAG_N; return 20; }
+        case 0xAA: { if (bus->tick) bus->tick(bus->ctx, 20); u8 v=IN(cpu->bc); WRITE8(cpu->hl--,v); cpu->b--; cpu->f=sz(cpu->b)|Z80_FLAG_N; return 20; }
+        case 0xB2: { if (bus->tick) bus->tick(bus->ctx, 20); u8 v=IN(cpu->bc); WRITE8(cpu->hl++,v); cpu->b--; cpu->f=Z80_FLAG_Z|Z80_FLAG_N; if(cpu->b){cpu->pc-=2;return 24;} return 20; }
+        case 0xBA: { if (bus->tick) bus->tick(bus->ctx, 20); u8 v=IN(cpu->bc); WRITE8(cpu->hl--,v); cpu->b--; cpu->f=Z80_FLAG_Z|Z80_FLAG_N; if(cpu->b){cpu->pc-=2;return 24;} return 20; }
         case 0xA3: {
             u8 v = READ8(cpu->hl++);
             cpu->b--;
-            if (bus->tick) bus->tick(bus->ctx, 12);
+            if (bus->tick) bus->tick(bus->ctx, 16);
             OUT(cpu->bc, v);
             cpu->f = sz(cpu->b) | Z80_FLAG_N;
-            return 16;
+            return 20;
         }
         case 0xAB: {
             u8 v = READ8(cpu->hl--);
             cpu->b--;
-            if (bus->tick) bus->tick(bus->ctx, 12);
+            if (bus->tick) bus->tick(bus->ctx, 16);
             OUT(cpu->bc, v);
             cpu->f = sz(cpu->b) | Z80_FLAG_N;
-            return 16;
+            return 20;
         }
         case 0xB3: {
             u8 v = READ8(cpu->hl++);
             cpu->b--;
-            if (bus->tick) bus->tick(bus->ctx, 12);
+            if (bus->tick) bus->tick(bus->ctx, 16);
             OUT(cpu->bc, v);
             cpu->f = Z80_FLAG_Z | Z80_FLAG_N;
             if (cpu->b) {
                 cpu->pc -= 2;
-                return 21;
+                return 25;
             }
-            return 16;
+            return 20;
         }
         case 0xBB: {
             u8 v = READ8(cpu->hl--);
             cpu->b--;
-            if (bus->tick) bus->tick(bus->ctx, 12);
+            if (bus->tick) bus->tick(bus->ctx, 16);
             OUT(cpu->bc, v);
             cpu->f = Z80_FLAG_Z | Z80_FLAG_N;
             if (cpu->b) {
                 cpu->pc -= 2;
-                return 21;
+                return 25;
             }
-            return 16;
+            return 20;
         }
         default:
             /* All undefined ED-prefix opcodes are documented to behave as
@@ -642,7 +644,7 @@ int z80_step(Z80 *cpu, Z80Bus *bus) {
     int cycles;
     switch (cpu->last_prefix) {
     case 0xCB: cycles = cc_cb[op];   break;
-    case 0xED: cycles = cc_ed[op];   break;
+    case 0xED: cycles = cc_op[0xED] + cc_ed[op]; break;
     case 0xDD: case 0xFD: cycles = cc_xy[op]; break;
     default:   cycles = cc_op[op];   break;
     }

--- a/tests/test_crtc.c
+++ b/tests/test_crtc.c
@@ -234,6 +234,17 @@ static void test_horizontal_total_uses_equality_not_threshold(void) {
 
     crtc_tick(&crtc);
     assert(crtc.hcc == 251);
+    assert(!crtc.new_scanline);
+
+    crtc.hcc = 255;
+    crtc_tick(&crtc);
+    assert(crtc.hcc == 0);
+    assert(!crtc.new_scanline);
+
+    crtc.hcc = 10;
+    crtc_tick(&crtc);
+    assert(crtc.hcc == 0);
+    assert(crtc.new_scanline);
 
     crtc_select(&crtc, 0);
     crtc_write(&crtc, 0);
@@ -244,9 +255,12 @@ static void test_vertical_display_enable_is_latched(void) {
     CRTC crtc;
     crtc_init(&crtc);
     crtc.reg[0] = 1;
-    crtc.reg[4] = 1;
-    crtc.reg[6] = 1;
-    crtc.reg[9] = 0;
+    crtc_select(&crtc, 4);
+    crtc_write(&crtc, 1);
+    crtc_select(&crtc, 6);
+    crtc_write(&crtc, 1);
+    crtc_select(&crtc, 9);
+    crtc_write(&crtc, 0);
 
     while (crtc.vcc != 1)
         crtc_tick(&crtc);
@@ -278,11 +292,33 @@ static void test_address_pipeline_advances_at_r1(void) {
     crtc_init(&crtc);
     crtc.reg[0] = 7;
     crtc.reg[1] = 4;
-    crtc.reg[9] = 0;
+    crtc_select(&crtc, 9);
+    crtc_write(&crtc, 0);
     u16 start = crtc.ma_row_start;
 
     tick_to_next_line(&crtc);
     assert(crtc.ma_row_start == (u16)(start + 4));
+}
+
+static void test_address_pipeline_captures_current_ma_after_hcc_overflow(void) {
+    CRTC crtc;
+    crtc_init(&crtc);
+    crtc.reg[0] = 10;
+    crtc.reg[1] = 1;
+    crtc_select(&crtc, 9);
+    crtc_write(&crtc, 0);
+    crtc.ma_row_start = 0x1000;
+    crtc.ma_next_row = 0x1000;
+    crtc.ma = 0x10FF;
+    crtc.hcc = 255;
+
+    crtc_tick(&crtc);
+    assert(crtc.hcc == 0);
+    assert(!crtc.new_scanline);
+
+    crtc_tick(&crtc);
+    assert(crtc.hcc == 1);
+    assert(crtc.ma_next_row == 0x1101);
 }
 
 static void test_address_pipeline_repeats_when_r1_is_missed(void) {
@@ -290,7 +326,8 @@ static void test_address_pipeline_repeats_when_r1_is_missed(void) {
     crtc_init(&crtc);
     crtc.reg[0] = 7;
     crtc.reg[1] = 6;
-    crtc.reg[9] = 0;
+    crtc_select(&crtc, 9);
+    crtc_write(&crtc, 0);
     u16 start = crtc.ma_row_start;
 
     tick_until_hcc(&crtc, 5);
@@ -305,7 +342,8 @@ static void test_address_pipeline_uses_new_r1_if_ahead(void) {
     crtc_init(&crtc);
     crtc.reg[0] = 7;
     crtc.reg[1] = 4;
-    crtc.reg[9] = 0;
+    crtc_select(&crtc, 9);
+    crtc_write(&crtc, 0);
     u16 start = crtc.ma_row_start;
 
     tick_until_hcc(&crtc, 2);
@@ -320,7 +358,8 @@ static void test_address_pipeline_waits_for_final_raster(void) {
     crtc_init(&crtc);
     crtc.reg[0] = 7;
     crtc.reg[1] = 4;
-    crtc.reg[9] = 1;
+    crtc_select(&crtc, 9);
+    crtc_write(&crtc, 1);
     u16 start = crtc.ma_row_start;
 
     tick_to_next_line(&crtc);
@@ -330,6 +369,59 @@ static void test_address_pipeline_waits_for_final_raster(void) {
     tick_to_next_line(&crtc);
     assert(crtc.vlc == 0);
     assert(crtc.ma_row_start == (u16)(start + 4));
+}
+
+static void test_r9_write_after_c0_one_does_not_reset_current_line(void) {
+    CRTC crtc;
+    crtc_init(&crtc);
+    crtc.reg[0] = 7;
+    crtc.reg[1] = 4;
+    crtc_select(&crtc, 9);
+    crtc_write(&crtc, 1);
+    crtc.hcc = 3;
+
+    crtc_select(&crtc, 9);
+    crtc_write(&crtc, 0);
+    tick_to_next_line(&crtc);
+
+    assert(crtc.vlc == 1);
+}
+
+static void test_r9_write_before_c0_two_can_reset_current_line(void) {
+    CRTC crtc;
+    crtc_init(&crtc);
+    crtc.reg[0] = 7;
+    crtc.reg[1] = 4;
+    crtc.vcc = 3;
+    crtc_select(&crtc, 9);
+    crtc_write(&crtc, 1);
+    crtc.hcc = 1;
+
+    crtc_select(&crtc, 9);
+    crtc_write(&crtc, 0);
+    tick_to_next_line(&crtc);
+
+    assert(crtc.vlc == 0);
+    assert(crtc.vcc == 4);
+}
+
+static void test_r4_write_after_c0_one_does_not_reset_current_frame(void) {
+    CRTC crtc;
+    crtc_init(&crtc);
+    crtc.reg[0] = 7;
+    crtc.reg[1] = 4;
+    crtc.vcc = 3;
+    crtc_select(&crtc, 9);
+    crtc_write(&crtc, 0);
+    crtc_select(&crtc, 4);
+    crtc_write(&crtc, 5);
+    crtc.hcc = 3;
+
+    crtc_select(&crtc, 4);
+    crtc_write(&crtc, 3);
+    tick_to_next_line(&crtc);
+
+    assert(crtc.vcc == 4);
 }
 
 int main(void) {
@@ -347,8 +439,12 @@ int main(void) {
     test_vertical_display_enable_is_latched();
     test_r6_write_can_disable_current_row();
     test_address_pipeline_advances_at_r1();
+    test_address_pipeline_captures_current_ma_after_hcc_overflow();
     test_address_pipeline_repeats_when_r1_is_missed();
     test_address_pipeline_uses_new_r1_if_ahead();
     test_address_pipeline_waits_for_final_raster();
+    test_r9_write_after_c0_one_does_not_reset_current_line();
+    test_r9_write_before_c0_two_can_reset_current_line();
+    test_r4_write_after_c0_one_does_not_reset_current_frame();
     return 0;
 }

--- a/tests/test_z80.c
+++ b/tests/test_z80.c
@@ -57,7 +57,7 @@ static Z80Bus make_bus(TestBus *test) {
     return bus;
 }
 
-static void test_out_c_r_is_split_8_plus_4(void) {
+static void test_out_c_r_is_split_12_plus_4(void) {
     TestBus test = {0};
     Z80Bus bus = make_bus(&test);
     Z80 cpu;
@@ -66,15 +66,15 @@ static void test_out_c_r_is_split_8_plus_4(void) {
     test.mem[0] = 0xED;
     test.mem[1] = 0x41; /* OUT (C),B */
 
-    assert(z80_step(&cpu, &bus) == 12);
+    assert(z80_step(&cpu, &bus) == 16);
     assert(test.writes == 1);
     assert(test.port == 0x7F12);
     assert(test.value == 0x7F);
-    assert(test.ticks_at_write == 8);
-    assert(test.ticked_in_step == 8);
+    assert(test.ticks_at_write == 12);
+    assert(test.ticked_in_step == 12);
 }
 
-static void test_outi_is_split_12_plus_4(void) {
+static void test_outi_is_split_16_plus_4(void) {
     TestBus test = {0};
     Z80Bus bus = make_bus(&test);
     Z80 cpu;
@@ -85,12 +85,12 @@ static void test_outi_is_split_12_plus_4(void) {
     test.mem[1] = 0xA3; /* OUTI */
     test.mem[0x1000] = 0x55;
 
-    assert(z80_step(&cpu, &bus) == 16);
+    assert(z80_step(&cpu, &bus) == 20);
     assert(test.writes == 1);
     assert(test.port == 0x017F);
     assert(test.value == 0x55);
-    assert(test.ticks_at_write == 12);
-    assert(test.ticked_in_step == 12);
+    assert(test.ticks_at_write == 16);
+    assert(test.ticked_in_step == 16);
 }
 
 static void test_repeating_otir_keeps_repeat_cycles(void) {
@@ -104,18 +104,18 @@ static void test_repeating_otir_keeps_repeat_cycles(void) {
     test.mem[1] = 0xB3; /* OTIR */
     test.mem[0x1000] = 0xAA;
 
-    assert(z80_step(&cpu, &bus) == 21);
+    assert(z80_step(&cpu, &bus) == 25);
     assert(cpu.pc == 0);
     assert(test.writes == 1);
     assert(test.port == 0x017F);
     assert(test.value == 0xAA);
-    assert(test.ticks_at_write == 12);
-    assert(test.ticked_in_step == 12);
+    assert(test.ticks_at_write == 16);
+    assert(test.ticked_in_step == 16);
 }
 
 int main(void) {
-    test_out_c_r_is_split_8_plus_4();
-    test_outi_is_split_12_plus_4();
+    test_out_c_r_is_split_12_plus_4();
+    test_outi_is_split_16_plus_4();
     test_repeating_otir_keeps_repeat_cycles();
     return 0;
 }


### PR DESCRIPTION
## Summary
- align ED-prefixed Z80 I/O timing with Caprice32 so raster CRTC writes land on the expected character clock
- latch CRTC row/frame comparator state per scanline and only finish monitor frames on real CRTC new-scanline events
- restore/save SNA v3 CRTC timing state so raster snapshots resume accurately

## Validation
- CCACHE_DISABLE=1 make -j2
- CCACHE_DISABLE=1 make -C tests clean check
- smoke-tested Bomb Jack snapshots: intro.sna, bombjack-intro.sna, bombjack-top-border.sna

Closes #181