### PR TITLE
Fix Batman Forever collapsed CRTC timing

### DIFF
--- a/src/cpc.c
+++ b/src/cpc.c
@@ -59,6 +59,7 @@ static const char *const g_trace_vars[] = {
     "ONE_K_TRACE_HDCPM", "ONE_K_TRACE_LDIR_BANK", "ONE_K_RESET_SNA",
     "ONE_K_TRACE_IM1", "ONE_K_TRACE_PALETTE",
     "ONE_K_CAP_TEXT", "ONE_K_TRACE_LDIR", "ONE_K_TRACE_RTC",
+    "ONE_K_TRACE_PSG", "ONE_K_TRACE_AUDIO", "ONE_K_TRACE_FDC",
     NULL
 };
 static void trace_check_master(void) {
@@ -73,6 +74,106 @@ static void trace_check_master(void) {
 #define AUDIO_SAMPLE_RATE   44100
 #define AUDIO_SAMPLES_FRAME (AUDIO_SAMPLE_RATE / 50)   /* 882 samples @ 50 Hz */
 #define PSG_CLOCK_HZ        1000000                    /* CPC PSG: 4 MHz / 4 */
+
+static const char *fdc_phase_name(FdcPhase phase) {
+    switch (phase) {
+    case FDC_PHASE_CMD:    return "CMD";
+    case FDC_PHASE_EXEC:   return "EXEC";
+    case FDC_PHASE_RESULT: return "RESULT";
+    }
+    return "?";
+}
+
+static void trace_fdc_status(CPC *cpc, u16 port, u8 result) {
+    if (!dbg_getenv("ONE_K_TRACE_FDC"))
+        return;
+
+    static bool have_last = false;
+    static u8 last_result = 0;
+    static FdcPhase last_phase = FDC_PHASE_CMD;
+    static int last_cmd_pos = 0;
+    static int last_exec_pos = 0;
+    static int last_result_pos = 0;
+    static int repeat = 0;
+
+    bool changed = !have_last
+                || result != last_result
+                || cpc->fdc.phase != last_phase
+                || cpc->fdc.cmd_pos != last_cmd_pos
+                || cpc->fdc.exec_pos != last_exec_pos
+                || cpc->fdc.result_pos != last_result_pos;
+    if (!changed) {
+        if (++repeat == 10000) {
+            fprintf(stderr,
+                    "[FDC R f%d] status %04X -> %02X repeated 10000 times PC=%04X phase=%s\n",
+                    cpc_frame_count, port, result, cpc->cpu.pc,
+                    fdc_phase_name(cpc->fdc.phase));
+            repeat = 0;
+        }
+        return;
+    }
+
+    if (have_last && repeat > 0) {
+        fprintf(stderr,
+                "[FDC R f%d] previous status %02X repeated %d times phase=%s\n",
+                cpc_frame_count, last_result, repeat, fdc_phase_name(last_phase));
+    }
+    fprintf(stderr,
+            "[FDC R f%d] status %04X -> %02X PC=%04X phase=%s cmd=%d/%d exec=%d/%d result=%d/%d\n",
+            cpc_frame_count, port, result, cpc->cpu.pc,
+            fdc_phase_name(cpc->fdc.phase), cpc->fdc.cmd_pos, cpc->fdc.cmd_len,
+            cpc->fdc.exec_pos, cpc->fdc.exec_len,
+            cpc->fdc.result_pos, cpc->fdc.result_len);
+
+    have_last = true;
+    last_result = result;
+    last_phase = cpc->fdc.phase;
+    last_cmd_pos = cpc->fdc.cmd_pos;
+    last_exec_pos = cpc->fdc.exec_pos;
+    last_result_pos = cpc->fdc.result_pos;
+    repeat = 0;
+}
+
+static void trace_fdc_data_read(CPC *cpc, u16 port, u8 result,
+                                FdcPhase phase_before, int exec_pos_before,
+                                int result_pos_before) {
+    if (!dbg_getenv("ONE_K_TRACE_FDC"))
+        return;
+
+    bool log = phase_before != FDC_PHASE_EXEC
+            || cpc->fdc.phase != phase_before
+            || exec_pos_before < 8
+            || (cpc->fdc.exec_len > 0 && exec_pos_before >= cpc->fdc.exec_len - 8);
+    if (!log)
+        return;
+
+    fprintf(stderr,
+            "[FDC R f%d] data %04X -> %02X PC=%04X phase=%s->%s exec=%d->%d/%d result=%d->%d/%d\n",
+            cpc_frame_count, port, result, cpc->cpu.pc,
+            fdc_phase_name(phase_before), fdc_phase_name(cpc->fdc.phase),
+            exec_pos_before, cpc->fdc.exec_pos, cpc->fdc.exec_len,
+            result_pos_before, cpc->fdc.result_pos, cpc->fdc.result_len);
+}
+
+static void trace_fdc_data_write(CPC *cpc, u16 port, u8 val,
+                                 FdcPhase phase_before, int cmd_pos_before,
+                                 int exec_pos_before) {
+    if (!dbg_getenv("ONE_K_TRACE_FDC"))
+        return;
+
+    fprintf(stderr,
+            "[FDC W f%d] data %04X <- %02X PC=%04X phase=%s->%s cmd=%d->%d/%d exec=%d->%d/%d",
+            cpc_frame_count, port, val, cpc->cpu.pc,
+            fdc_phase_name(phase_before), fdc_phase_name(cpc->fdc.phase),
+            cmd_pos_before, cpc->fdc.cmd_pos, cpc->fdc.cmd_len,
+            exec_pos_before, cpc->fdc.exec_pos, cpc->fdc.exec_len);
+    if (cpc->fdc.cmd_len > 0) {
+        fprintf(stderr, " bytes:");
+        for (int i = 0; i < cpc->fdc.cmd_len && i < 9; i++)
+            fprintf(stderr, " %02X", cpc->fdc.cmd[i]);
+    }
+    fprintf(stderr, "\n");
+}
 
 /* ---- Z80 bus callbacks ---- */
 
@@ -269,8 +370,17 @@ static u8 bus_io_read(void *ctx, u16 port) {
      * 0xFF and mistake the FDC for a different device. */
     else if (hi == 0xFB && !(port & 0x80)) {
         u8 lo = port & 0xFF;
-        result = (lo & 0x01) ? fdc_read_data(&cpc->fdc)
-                             : fdc_read_status(&cpc->fdc);
+        if (lo & 0x01) {
+            FdcPhase phase_before = cpc->fdc.phase;
+            int exec_pos_before = cpc->fdc.exec_pos;
+            int result_pos_before = cpc->fdc.result_pos;
+            result = fdc_read_data(&cpc->fdc);
+            trace_fdc_data_read(cpc, port, result, phase_before,
+                                exec_pos_before, result_pos_before);
+        } else {
+            result = fdc_read_status(&cpc->fdc);
+            trace_fdc_status(cpc, port, result);
+        }
     }
     else if (hi == 0xFA) {
         result = 0xFF;
@@ -498,7 +608,13 @@ static void bus_io_write(void *ctx, u16 port, u8 val) {
         return;
     }
     /* FDC motor: hi=0xFA, write */
-    if (hi == 0xFA) { fdc_motor_write(&cpc->fdc, val); return; }
+    if (hi == 0xFA) {
+        fdc_motor_write(&cpc->fdc, val);
+        if (dbg_getenv("ONE_K_TRACE_FDC"))
+            fprintf(stderr, "[FDC W f%d] motor %04X <- %02X PC=%04X on=%d\n",
+                    cpc_frame_count, port, val, cpc->cpu.pc, cpc->fdc.motor);
+        return;
+    }
     /* USIfAC II serial @ 0xFBD0..FBDF (write). */
     if (cpc->mx4 && cpc->usifac.present && hi == 0xFB &&
         (port & 0xF0) == 0xD0) {
@@ -508,7 +624,14 @@ static void bus_io_write(void *ctx, u16 port, u8 val) {
     /* FDC data: hi=0xFB, lo bit 7 = 0, write */
     if (hi == 0xFB) {
         u8 lo = port & 0xFF;
-        if (!(lo & 0x80)) fdc_write_data(&cpc->fdc, val);
+        if (!(lo & 0x80)) {
+            FdcPhase phase_before = cpc->fdc.phase;
+            int cmd_pos_before = cpc->fdc.cmd_pos;
+            int exec_pos_before = cpc->fdc.exec_pos;
+            fdc_write_data(&cpc->fdc, val);
+            trace_fdc_data_write(cpc, port, val, phase_before,
+                                 cmd_pos_before, exec_pos_before);
+        }
         return;
     }
     /* hi=0xFD: IDE (0xFD06, 0xFD08-0xFD0F), RTC (0xFD14/0xFD15), Net4CPC (0xFD20-0xFD23) */
@@ -656,6 +779,7 @@ static void cpc_monitor_reset(CPC *cpc) {
     cpc->monitor_hs_peak_to_end = 0;
     cpc->monitor_had_peak = false;
     cpc->monitor_in_hsync = false;
+    cpc->monitor_frame_completed = false;
 }
 
 int cpc_init(CPC *cpc, CpcModel model, const char *rom_os, const char *rom_basic, int scale) {
@@ -986,6 +1110,7 @@ static bool cpc_monitor_finish_frame(CPC *cpc, bool crtc_vsync) {
      * early/short CRTC VSYNC tricks to pass without rolling the monitor. */
     cpc->raster_y = -(((cpc->monitor_vline - MONITOR_MIN_VHOLD) + 1) >> 1);
     cpc->monitor_vline = 0;
+    cpc->monitor_frame_completed = true;
     return true;
 }
 
@@ -1112,14 +1237,23 @@ void cpc_frame(CPC *cpc) {
     cpc->step_once = false;
 
     int target = cpc->cycles_per_frame + cpc->cycle_debt;
+    if (target <= 0)
+        target = cpc->cycles_per_frame;
+    int max_target = target + cpc->cycles_per_frame;
     int done   = 0;
     bool stop_early = false;
+    bool frame_done = false;
+    cpc->monitor_frame_completed = false;
 
     /* Master gate: when no trace env is set, the entire per-instruction
      * debug block is short-circuited. Branch is predicted-taken to
      * "off" in production runs (no env vars set). */
     trace_check_master();
-    while (done < target) {
+    /* The frontend presents once after cpc_frame(). If a CRTC frame runs
+     * slightly past the nominal budget, returning before display_upload()
+     * leaves the host presenting stale renderer contents, visible as rapid
+     * flashing. Run a bounded overrun until one monitor frame completed. */
+    while ((done < target || !frame_done) && done < max_target) {
         /* #102 wedge instrumentation: at every firmware-IRQ-handler
          * 'CALL $BDF4' site ($00D9 in OS ROM), capture what's actually
          * at $BDF4 and the value of the secondary-tick counter $B8BF.
@@ -1466,6 +1600,7 @@ void cpc_frame(CPC *cpc) {
         int remaining = t - cpc->bus_ticked_in_step;
         if (remaining < 0) remaining = 0;
         cpc_advance_bus(cpc, remaining);
+        frame_done = cpc->monitor_frame_completed;
 
         /* Deliver pending Gate Array interrupt. */
         if (cpc->ga.interrupt_pending) {
@@ -1495,10 +1630,10 @@ void cpc_frame(CPC *cpc) {
                 break;
             }
         }
-        if (stop_early || was_stepping) break;
+        if (frame_done || stop_early || was_stepping) break;
     }
 
-    cpc->cycle_debt = stop_early ? 0 : (done - target);
+    cpc->cycle_debt = (frame_done || stop_early) ? 0 : (done - target);
     cpc_frame_count++;
 
     /* Drive M4 sockets so non-blocking TCP work makes progress while CPC

--- a/src/cpc.c
+++ b/src/cpc.c
@@ -749,7 +749,7 @@ static void cpc_bus_tick(void *ctx, int cycles);
 #define MONITOR_HSYNC_DURATION   0x0A00
 #define MONITOR_BASE_HSYNC       (0x4000 - MONITOR_HSYNC_DURATION)
 #define MONITOR_SYNC_TOLERANCE   257
-#define MONITOR_X_ADJUST_PIXELS  -16
+#define MONITOR_X_ADJUST_PIXELS  0
 #define MONITOR_MIN_VHOLD        250
 #define MONITOR_MIN_VSYNC        295
 #define MONITOR_MAX_VSYNC        351

--- a/src/cpc.c
+++ b/src/cpc.c
@@ -1105,10 +1105,14 @@ static bool cpc_monitor_finish_frame(CPC *cpc, bool crtc_vsync) {
         cpc->monitor_vline < MONITOR_MAX_VSYNC)
         return false;
 
-    /* Match the vertical hold used by Caprice32. A standard 312-line frame
-     * restarts drawing at -31, which centres the CPC image while allowing
-     * early/short CRTC VSYNC tricks to pass without rolling the monitor. */
-    cpc->raster_y = -(((cpc->monitor_vline - MONITOR_MIN_VHOLD) + 1) >> 1);
+    /* Match Caprice32's vertical hold. Standard 312-line frames restart at
+     * -31; collapsed vertical-total frames (Batman Forever's top-line CRTC
+     * tricks) need the extra bias Caprice gets from finishing one scanline
+     * later. */
+    int vhold_bias = 1;
+    if (cpc->crtc.reg[4] <= 1 && cpc->crtc.reg[7] <= 1)
+        vhold_bias = 2;
+    cpc->raster_y = -(((cpc->monitor_vline - MONITOR_MIN_VHOLD) + vhold_bias) >> 1);
     cpc->monitor_vline = 0;
     cpc->monitor_frame_completed = true;
     return true;

--- a/src/cpc.h
+++ b/src/cpc.h
@@ -97,6 +97,7 @@ typedef struct {
     int  monitor_hs_peak_to_end;
     bool monitor_had_peak;
     bool monitor_in_hsync;
+    bool monitor_frame_completed;
     bool prev_hsync;
     bool prev_vsync;
 

--- a/src/crtc.c
+++ b/src/crtc.c
@@ -46,6 +46,20 @@ static void crtc_latch_line_state(CRTC *c) {
     c->line_last_frame = c->line_last_raster && c->vcc == c->reg[4];
 }
 
+static void crtc_update_r7_match(CRTC *c, bool allow_start) {
+    if (c->vcc == c->reg[7]) {
+        if (!c->r7_match) {
+            c->r7_match = true;
+            if (allow_start && !c->vsync) {
+                c->vsync = true;
+                c->vsc = 0;
+            }
+        }
+    } else {
+        c->r7_match = false;
+    }
+}
+
 void crtc_init(CRTC *c) {
     memset(c, 0, sizeof(*c));
     c->type = CRTC_TYPE_1;
@@ -79,6 +93,7 @@ void crtc_set_type(CRTC *c, CrtcType type) {
 
 void crtc_recompute_state(CRTC *c) {
     crtc_latch_line_state(c);
+    c->r7_match = c->vcc == c->reg[7];
     c->h_display = c->reg[1] != 0 && c->hcc < c->reg[1];
     c->v_display = c->reg[6] != 0 && c->vcc < c->reg[6];
     c->display_enable = c->h_display && c->v_display;
@@ -96,11 +111,15 @@ void crtc_write(CRTC *c, u8 val) {
          * but moving R6 beyond the beam does not re-enable it this frame. */
         if (c->selected == 6 && c->vcc == c->reg[6])
             c->v_display = false;
-        /* C9/R9 and C4/R4 are sampled for the current scanline while C0 is
-         * still in its first two character positions. Later writes affect
-         * following lines, not this line's row/frame reset decision. */
-        if ((c->selected == 4 || c->selected == 9) && c->hcc <= 1)
+        /* R9/R4 are comparators. A write that matches the current raster or
+         * row counter can still arm the current line's reset/frame decision;
+         * a write behind the beam simply misses until the counter wraps. */
+        if (c->selected == 9)
             crtc_latch_line_state(c);
+        else if (c->selected == 4)
+            c->line_last_frame = c->line_last_raster && c->vcc == c->reg[4];
+        else if (c->selected == 7)
+            crtc_update_r7_match(c, c->hcc >= 2);
         c->display_enable = c->h_display && c->v_display;
     }
 }
@@ -184,6 +203,7 @@ void crtc_tick(CRTC *c) {
     /* --- End of line --- */
     if (end_of_line) {
         c->new_scanline = true;
+        c->last_hend = old_hcc;
         c->hcc = 0;
         c->h_display = c->reg[1] != 0;
 
@@ -249,17 +269,9 @@ void crtc_tick(CRTC *c) {
         c->ma_row_start = c->ma_next_row;
         c->ma = c->ma_row_start;
         crtc_latch_line_state(c);
+        crtc_update_r7_match(c, c->last_hend >= 2);
     } else if (c->hcc == c->reg[1]) {
         c->h_display = false;
-    }
-
-    /* Continuous R7 comparator: real CRTC starts VSYNC the moment C4
-     * matches R7, not only at the next row-boundary. Demos that re-time
-     * VSYNC by writing R7 mid-frame (HBL effects, second-VSYNC tricks)
-     * depend on this. */
-    if (c->vcc == c->reg[7] && !c->vsync) {
-        c->vsync = true;
-        c->vsc = 0;
     }
 
     c->display_enable = c->h_display && c->v_display;

--- a/src/crtc.c
+++ b/src/crtc.c
@@ -111,13 +111,18 @@ void crtc_write(CRTC *c, u8 val) {
          * but moving R6 beyond the beam does not re-enable it this frame. */
         if (c->selected == 6 && c->vcc == c->reg[6])
             c->v_display = false;
-        /* R9/R4 are comparators. A write that matches the current raster or
-         * row counter can still arm the current line's reset/frame decision;
-         * a write behind the beam simply misses until the counter wraps. */
+        /* R9 is a raster comparator. A write that matches the current raster
+         * can still arm the current line's reset/frame decision; a write
+         * behind the beam simply misses until the counter wraps. */
         if (c->selected == 9)
             crtc_latch_line_state(c);
-        else if (c->selected == 4)
-            c->line_last_frame = c->line_last_raster && c->vcc == c->reg[4];
+        else if (c->selected == 4) {
+            /* Vertical total changes do not freely re-arm the current scanline.
+             * The 6845 has a delayed maximum-raster path; a full model handles
+             * the narrow CharMR2 window explicitly.  Leaving the current-line
+             * decision latched avoids treating late R4 writes as a new frame
+             * reset request. */
+        }
         else if (c->selected == 7)
             crtc_update_r7_match(c, c->hcc >= 2);
         c->display_enable = c->h_display && c->v_display;

--- a/src/crtc.c
+++ b/src/crtc.c
@@ -116,9 +116,13 @@ void crtc_write(CRTC *c, u8 val) {
         else if (c->selected == 4) {
             /* Vertical total changes do not freely re-arm the current scanline.
              * The 6845 has a delayed maximum-raster path; a full model handles
-             * the narrow CharMR2 window explicitly.  Leaving the current-line
-             * decision latched avoids treating late R4 writes as a new frame
-             * reset request. */
+             * the narrow CharMR2 window explicitly. Batman Forever writes
+             * R9=0 then R4=0 while the beam is already on row/raster zero; that
+             * is inside the delayed path and must arm the collapsed frame. */
+            if (c->reg[4] == 0 && c->vcc == 0 && c->vlc == c->reg[9]) {
+                c->line_last_raster = true;
+                c->line_last_frame = true;
+            }
         }
         else if (c->selected == 7)
             crtc_update_r7_match(c, c->hcc >= 2);
@@ -251,17 +255,24 @@ void crtc_tick(CRTC *c) {
                 }
             } else {
                 c->vcc = (c->vcc + 1) & 0x7F;
-                if (c->vcc == c->reg[6])
+                if (c->vcc == 0) {
+                    c->ma_row_start = crtc_start_addr(c);
+                    c->ma_next_row = c->ma_row_start;
+                    c->v_display = c->reg[6] != 0;
+                } else if (c->vcc == c->reg[6]) {
                     c->v_display = false;
+                }
             }
         } else {
             c->vlc = (c->vlc + 1) & 0x1F;
         }
 
-        /* The UM6845R re-reads R12/R13 at the start of every scanline while
-         * VCC is zero. A write changes the register immediately, but must not
-         * splice a new address into the scanline currently being output. */
-        if (c->type == CRTC_TYPE_1 && c->vcc == 0) {
+        /* The UM6845R re-reads R12/R13 at the start of scanlines while VCC is
+         * zero. Do not do that during the R4=0/R9=0 collapsed-total window:
+         * demos use that state to keep the row-address pipeline moving while
+         * suppressing normal vertical line-count progress. */
+        if (c->type == CRTC_TYPE_1 && c->vcc == 0 &&
+            !(c->reg[4] == 0 && c->reg[9] == 0)) {
             c->ma_row_start = crtc_start_addr(c);
             c->ma_next_row = c->ma_row_start;
         }

--- a/src/crtc.c
+++ b/src/crtc.c
@@ -30,11 +30,8 @@ static u16 crtc_hsync_width(const CRTC *c) {
 }
 
 static u16 crtc_vsync_width(const CRTC *c) {
-    if (c->type == CRTC_TYPE_0 || c->type == CRTC_TYPE_3) {
-        u16 vsw = c->reg[3] >> 4;
-        return vsw ? vsw : 16;
-    }
-    return 16;
+    u16 vsw = c->reg[3] >> 4;
+    return vsw ? vsw : 16;
 }
 
 static u16 crtc_start_addr(const CRTC *c) {

--- a/src/crtc.h
+++ b/src/crtc.h
@@ -29,6 +29,7 @@ typedef struct {
     u16 vsc;               /* C3h: vertical sync counter */
     u16 hsc;               /* C3l: horizontal sync counter */
     u16 vac;               /* C5: vertical-adjust raster counter (R5) */
+    u16 last_hend;         /* previous C0/R0 match, used by R7 VSYNC logic */
     bool in_vadjust;       /* true while we're in the R5 vertical-adjust period */
 
     u16 ma;                /* memory address */
@@ -42,6 +43,7 @@ typedef struct {
     bool display_enable;
     bool line_last_raster; /* C9 == R9 latched near C0=0 */
     bool line_last_frame;  /* C4 == R4 && C9 == R9 latched near C0=0 */
+    bool r7_match;         /* C4 == R7 already matched for this character row */
     bool new_scanline;     /* one-tick R0 comparator event */
     bool mode_latch;       /* one-tick GA mode-latch event */
     bool mode_latched_this_hsync;

--- a/src/psg.c
+++ b/src/psg.c
@@ -13,6 +13,25 @@ void psg_init(PSG *psg) {
     psg->noise_lfsr = 1;
 }
 
+static u8 psg_register_mask(u8 reg, u8 val) {
+    switch (reg) {
+    case 1:
+    case 3:
+    case 5:
+    case 13:
+        return val & 0x0F;
+    case 6:
+    case 8:
+    case 9:
+    case 10:
+        return val & 0x1F;
+    case 7:
+        return val & 0x3F;
+    default:
+        return val;
+    }
+}
+
 void psg_select(PSG *psg, u8 reg) {
     psg->selected = reg;
 }
@@ -20,6 +39,7 @@ void psg_select(PSG *psg, u8 reg) {
 void psg_write(PSG *psg, u8 val) {
     if (psg->selected >= PSG_NUM_REGS)
         return;
+    val = psg_register_mask(psg->selected, val);
     psg->reg[psg->selected] = val;
     if (psg->selected == 13) {
         psg->env_step    = 0;
@@ -39,6 +59,60 @@ u8 psg_read(PSG *psg) {
 
 void psg_set_kbd_row(PSG *psg, u8 row_data) {
     psg->kbd_data = row_data;
+}
+
+void psg_load_registers(PSG *psg, const u8 regs[PSG_NUM_REGS], u8 selected,
+                        bool has_env_state, u8 env_step, u8 env_direction) {
+    u8 kbd_data = psg->kbd_data;
+
+    memset(psg->reg, 0, sizeof(psg->reg));
+    for (u8 i = 0; i < PSG_NUM_REGS; i++)
+        psg->reg[i] = psg_register_mask(i, regs[i]);
+
+    psg->selected = selected;
+    memset(psg->tone_counter, 0, sizeof(psg->tone_counter));
+    memset(psg->tone_output, 0, sizeof(psg->tone_output));
+    psg->noise_counter = 0;
+    psg->noise_lfsr = 1;
+    psg->env_counter = 0;
+    psg->clock_rem = 0.0f;
+    psg->lp_state = 0;
+    psg->kbd_data = kbd_data;
+
+    if (has_env_state) {
+        u8 level = (u8)(env_step & 0x0F);
+        if (env_direction == 0x01) {
+            psg->env_dir = true;
+            psg->env_step = (u8)(level * 2);
+            psg->env_hold = false;
+        } else if (env_direction == 0xFF) {
+            psg->env_dir = false;
+            psg->env_step = (u8)(31 - (level * 2));
+            psg->env_hold = false;
+        } else {
+            psg->env_dir = true;
+            psg->env_step = (u8)(level * 2);
+            psg->env_hold = true;
+        }
+    } else {
+        psg->env_step = 0;
+        psg->env_hold = false;
+        psg->env_dir = (psg->reg[13] >> 2) & 1;
+    }
+}
+
+void psg_store_registers(const PSG *psg, u8 regs[PSG_NUM_REGS], u8 *selected,
+                         u8 *env_step, u8 *env_direction) {
+    memcpy(regs, psg->reg, PSG_NUM_REGS);
+    if (selected)
+        *selected = psg->selected;
+    if (env_step) {
+        *env_step = (u8)(psg->env_dir
+                         ? (psg->env_step / 2)
+                         : ((31 - psg->env_step) / 2));
+    }
+    if (env_direction)
+        *env_direction = psg->env_hold ? 0x00 : (psg->env_dir ? 0x01 : 0xFF);
 }
 
 /* Run one AY clock tick and return the mixed level for all three channels. */

--- a/src/psg.h
+++ b/src/psg.h
@@ -45,6 +45,10 @@ void psg_select(PSG *psg, u8 reg);
 void psg_write(PSG *psg, u8 val);
 u8   psg_read(PSG *psg);
 void psg_set_kbd_row(PSG *psg, u8 row_data);
+void psg_load_registers(PSG *psg, const u8 regs[PSG_NUM_REGS], u8 selected,
+                        bool has_env_state, u8 env_step, u8 env_direction);
+void psg_store_registers(const PSG *psg, u8 regs[PSG_NUM_REGS], u8 *selected,
+                         u8 *env_step, u8 *env_direction);
 
 /* Generate `n` samples into `buf` (mono, 16-bit signed) at the given clock rate */
 void psg_render(PSG *psg, s16 *buf, int n, int clock_hz, int sample_rate);

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -187,16 +187,32 @@ int snapshot_load(CPC *cpc, const char *path) {
         cpc->crtc.ma = cpc->crtc.ma_row_start;
     }
     crtc_recompute_state(&cpc->crtc);
+    if (version >= 3) {
+        /* SNA v3 does not store the CRTC's delayed display-timing latch.
+         * Caprice32 loads the CRTC registers while the counters are still at
+         * reset, then restores the counters, so display timing remains enabled
+         * until the next hardware comparator event. Recomputing it directly
+         * from the restored counters blanks Batman Forever's mid-frame
+         * snapshots too early. */
+        cpc->crtc.h_display = cpc->crtc.reg[1] != 0;
+        cpc->crtc.v_display = cpc->crtc.reg[6] != 0;
+        cpc->crtc.display_enable = cpc->crtc.h_display && cpc->crtc.v_display;
+    }
     cpc->crtc_pre_ma = cpc->crtc.ma;
     cpc->crtc_pre_ra = cpc->crtc.vlc;
     cpc->crtc_pre_de = cpc->crtc.display_enable;
 
     size_t want = (size_t)ram_kb * 1024;
+    if (want > RAM_SIZE) {
+        fprintf(stderr, "snapshot: '%s' wants %u KB RAM, emulator supports %d KB max\n",
+                path, ram_kb, RAM_SIZE / 1024);
+        fclose(f);
+        return -1;
+    }
     if (want > (size_t)cpc->mem.ram_size) {
-        fprintf(stderr, "snapshot: '%s' wants %u KB RAM, emulator configured for %d KB — "
-                        "loading first %d KB only\n",
-                path, ram_kb, cpc->mem.ram_size / 1024, cpc->mem.ram_size / 1024);
-        want = (size_t)cpc->mem.ram_size;
+        fprintf(stderr, "snapshot: '%s' wants %u KB RAM, expanding from %d KB\n",
+                path, ram_kb, cpc->mem.ram_size / 1024);
+        cpc->mem.ram_size = (int)want;
     }
 
     /* SNA stores RAM as a flat dump: bytes 0..64KB are the standard main bank,

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -11,6 +11,13 @@ static u16 le16(const u8 *p) {
 }
 
 #define SNA_CPC_MODEL           0x6D
+#define SNA_PSG_SELECT          0x5A
+#define SNA_PSG_REGS            0x5B
+#define SNA_V3_FDC_MOTOR        0x9C
+#define SNA_V3_DRVA_TRACK       0x9D
+#define SNA_V3_DRVB_TRACK       0x9E
+#define SNA_V3_PSG_ENV_STEP     0xA2
+#define SNA_V3_PSG_ENV_DIR      0xA3
 #define SNA_V3_CRTC_TYPE        0xA4
 #define SNA_V3_CRTC_ADDR        0xA5
 #define SNA_V3_CRTC_SCANLINE    0xA7
@@ -129,18 +136,21 @@ int snapshot_load(CPC *cpc, const char *path) {
     cpc->ppi.kbd_row = cpc->ppi.port_c & 0x0F;
 
     /* ---- PSG ---- */
-    cpc->psg.selected = hdr[0x5A];
-    /* PSG registers — best-effort: write straight into the reg[] array if
-     * the PSG struct exposes one; otherwise the snapshot's PSG state is
-     * lost (sound only). We don't poke private PSG state to avoid breaking
-     * the synthesiser; the running program will reprogram the PSG anyway. */
-    /* (Skipped intentionally — PSG private fields aren't part of public ABI.) */
+    psg_load_registers(&cpc->psg, &hdr[SNA_PSG_REGS], hdr[SNA_PSG_SELECT],
+                       version >= 3, hdr[SNA_V3_PSG_ENV_STEP],
+                       hdr[SNA_V3_PSG_ENV_DIR]);
 
     /* ---- RAM size (KB) ---- */
     u16 ram_kb = (version >= 2) ? le16(&hdr[0x6B]) : 64;
     if (ram_kb == 0) ram_kb = 64;   /* v1 default */
 
     if (version >= 3) {
+        cpc->fdc.motor = hdr[SNA_V3_FDC_MOTOR] != 0;
+        cpc->drive[0].cur_track = hdr[SNA_V3_DRVA_TRACK] < DISK_MAX_TRACKS
+                                ? hdr[SNA_V3_DRVA_TRACK] : DISK_MAX_TRACKS - 1;
+        cpc->drive[1].cur_track = hdr[SNA_V3_DRVB_TRACK] < DISK_MAX_TRACKS
+                                ? hdr[SNA_V3_DRVB_TRACK] : DISK_MAX_TRACKS - 1;
+
         u8 type = hdr[SNA_V3_CRTC_TYPE];
         if (type <= CRTC_TYPE_3)
             crtc_set_type(&cpc->crtc, (CrtcType)type);
@@ -163,7 +173,7 @@ int snapshot_load(CPC *cpc, const char *path) {
         cpc->crtc.ma = (u16)((row_start + cpc->crtc.hcc) & 0x3FFF);
 
         cpc->monitor_vline = le16(&hdr[SNA_V3_CRTC_SCANLINE]);
-        cpc->raster_y = cpc->monitor_vline;
+        cpc->raster_y = 0;
         cpc->ga.vsync_delay = hdr[SNA_V3_GA_INT_DELAY] & 0x03;
         cpc->ga.interrupt_counter = hdr[SNA_V3_GA_SL_COUNT];
         cpc->ga.interrupt_pending = false;
@@ -252,9 +262,8 @@ int snapshot_save(CPC *cpc, const char *path) {
     hdr[0x58] = cpc->ppi.port_c;
     hdr[0x59] = cpc->ppi.control;
 
-    hdr[0x5A] = cpc->psg.selected;
-    /* PSG register file isn't part of the public PSG struct ABI; leave
-     * 0x5B..0x6A zero. Running programs reprogram the PSG on load. */
+    psg_store_registers(&cpc->psg, &hdr[SNA_PSG_REGS], &hdr[SNA_PSG_SELECT],
+                        &hdr[SNA_V3_PSG_ENV_STEP], &hdr[SNA_V3_PSG_ENV_DIR]);
 
     u16 ram_kb = (u16)(cpc->mem.ram_size / 1024);
     put16(&hdr[0x6B], ram_kb);
@@ -278,6 +287,9 @@ int snapshot_save(CPC *cpc, const char *path) {
     hdr[SNA_V3_GA_INT_DELAY] = cpc->ga.vsync_delay & 0x03;
     hdr[SNA_V3_GA_SL_COUNT] = cpc->ga.interrupt_counter;
     hdr[SNA_V3_Z80_INT_PENDING] = cpc->cpu.pending_irq ? 1 : 0;
+    hdr[SNA_V3_FDC_MOTOR] = cpc->fdc.motor ? 1 : 0;
+    hdr[SNA_V3_DRVA_TRACK] = (u8)cpc->drive[0].cur_track;
+    hdr[SNA_V3_DRVB_TRACK] = (u8)cpc->drive[1].cur_track;
 
     FILE *f = fopen(path, "wb");
     if (!f) {

--- a/src/z80.c
+++ b/src/z80.c
@@ -501,6 +501,8 @@ static int exec_xy(Z80 *cpu, Z80Bus *bus, u16 *xy) {
         /* DDCB / FDCB */
         case 0xCB: {
             s8 d = (s8)FETCH8(); u8 cb = FETCH8();
+            cpu->last_op = cb;
+            cpu->last_xycb = true;
             u16 a = (u16)(*xy + d); u8 v = READ8(a);
             int b = (cb >> 3) & 7;
             if (cb < 0x40) {
@@ -570,6 +572,7 @@ static int exec_xy(Z80 *cpu, Z80Bus *bus, u16 *xy) {
         case 0xBD: do_cp(cpu,(u8)(*xy&0xFF)); return 8;
         /* Unrecognised DD/FD — treat prefix as NOP and re-execute op */
         default:
+            cpu->last_prefix_ignored = true;
             cpu->pc--;   /* put the opcode back */
             return 4;
     }
@@ -592,6 +595,8 @@ void z80_reset(Z80 *cpu) {
     cpu->halted = false;
     cpu->pending_irq = false;
     cpu->int_accepted = false;
+    cpu->last_xycb = false;
+    cpu->last_prefix_ignored = false;
     cpu->iWSAdjust = 0;
 }
 
@@ -643,9 +648,17 @@ int z80_step(Z80 *cpu, Z80Bus *bus) {
     u8 op = cpu->last_op;
     int cycles;
     switch (cpu->last_prefix) {
-    case 0xCB: cycles = cc_cb[op];   break;
+    case 0xCB: cycles = cc_op[0xCB] + cc_cb[op];   break;
     case 0xED: cycles = cc_op[0xED] + cc_ed[op]; break;
-    case 0xDD: case 0xFD: cycles = cc_xy[op]; break;
+    case 0xDD:
+    case 0xFD:
+        if (cpu->last_prefix_ignored)
+            cycles = cc_op[cpu->last_prefix];
+        else if (cpu->last_xycb)
+            cycles = cc_op[cpu->last_prefix] + cc_xy[0xCB] + cc_xycb[op];
+        else
+            cycles = cc_op[cpu->last_prefix] + cc_xy[op];
+        break;
     default:   cycles = cc_op[op];   break;
     }
 
@@ -744,6 +757,9 @@ int z80_step(Z80 *cpu, Z80Bus *bus) {
 }
 
 static int z80_step_impl(Z80 *cpu, Z80Bus *bus) {
+    cpu->last_xycb = false;
+    cpu->last_prefix_ignored = false;
+
     /* Service maskable interrupt (blocked for one instruction after EI) */
     if (cpu->pending_irq && cpu->iff1 && !cpu->ei_delay) {
         cpu->pending_irq = false;

--- a/src/z80.h
+++ b/src/z80.h
@@ -37,6 +37,8 @@ typedef struct {
     int cycles;        /* T-states consumed this step */
     u8   last_op;      /* opcode just fetched by z80_step (for CPC cc_op[] lookup) */
     u8   last_prefix;  /* 0, 0xCB, 0xED, 0xDD, 0xFD — for prefix-table dispatch */
+    bool last_xycb;    /* last DD/FD-prefixed opcode was the DD/FD CB d op form */
+    bool last_prefix_ignored; /* DD/FD prefix was ignored and op will be re-run */
 
     /* Pipeline-state hint left by the previous instruction. Set to 1 by
      * z80_step when the last opcode was a 16-bit INC/DEC rr, EX (SP),rr,

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@ CC ?= cc
 CFLAGS ?= -O2
 CPPFLAGS ?=
 
-TESTS = test-gate-array test-crtc test-z80
+TESTS = test-gate-array test-crtc test-z80 test-psg
 
 .PHONY: all check clean
 
@@ -20,10 +20,15 @@ test-z80: test_z80.c ../src/z80.c ../src/z80.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -std=c11 -Wall -Wextra -I../src \
 		test_z80.c ../src/z80.c -o $@
 
+test-psg: test_psg.c ../src/psg.c ../src/psg.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) -std=c11 -Wall -Wextra -I../src \
+		test_psg.c ../src/psg.c -o $@
+
 check: $(TESTS)
 	./test-gate-array
 	./test-crtc
 	./test-z80
+	./test-psg
 
 clean:
 	rm -f $(TESTS)

--- a/tests/test_crtc.c
+++ b/tests/test_crtc.c
@@ -137,6 +137,28 @@ static void test_type1_r12_r13_reloads_at_scanline_start_while_vcc_zero(void) {
     assert(crtc.ma_row_start == 0);
 }
 
+static void test_type1_collapsed_total_keeps_row_pipeline(void) {
+    CRTC crtc;
+    crtc_init(&crtc);
+    crtc_set_type(&crtc, CRTC_TYPE_1);
+    crtc.reg[0] = 7;
+    crtc.reg[4] = 0;
+    crtc.reg[9] = 0;
+    crtc.reg[12] = 0x10;
+    crtc.reg[13] = 0x20;
+    crtc.vcc = 0;
+    crtc.vlc = 0;
+    crtc.hcc = 7;
+    crtc.ma_next_row = 0x3040;
+    crtc.line_last_raster = false;
+    crtc.line_last_frame = false;
+
+    crtc_tick(&crtc);
+
+    assert(crtc.ma_row_start == 0x3040);
+    assert(crtc.ma == 0x3040);
+}
+
 static void test_hsync_width_zero_depends_on_type(void) {
     CRTC crtc;
     crtc_init(&crtc);
@@ -275,6 +297,36 @@ static void test_vertical_display_enable_is_latched(void) {
         crtc_tick(&crtc);
     assert(crtc.v_display);
     assert(crtc.display_enable);
+}
+
+static void test_vertical_counter_wrap_reenables_display_and_reloads_start(void) {
+    CRTC crtc;
+    crtc_init(&crtc);
+    crtc.reg[0] = 1;
+    crtc.reg[1] = 1;
+    crtc.reg[4] = 5;
+    crtc.reg[6] = 14;
+    crtc.reg[9] = 0;
+    crtc.reg[12] = 0x20;
+    crtc.reg[13] = 0x40;
+    crtc.hcc = 1;
+    crtc.vcc = 127;
+    crtc.vlc = 0;
+    crtc.ma_row_start = 0x1234;
+    crtc.ma_next_row = 0x1234;
+    crtc.ma = 0x1235;
+    crtc.v_display = false;
+    crtc.display_enable = false;
+    crtc.line_last_raster = true;
+    crtc.line_last_frame = false;
+
+    crtc_tick(&crtc);
+
+    assert(crtc.vcc == 0);
+    assert(crtc.v_display);
+    assert(crtc.display_enable);
+    assert(crtc.ma_row_start == 0x2040);
+    assert(crtc.ma == 0x2040);
 }
 
 static void test_r6_write_can_disable_current_row(void) {
@@ -463,6 +515,28 @@ static void test_r4_write_matching_current_row_does_not_rearm_current_frame(void
     assert(crtc.vcc == 4);
 }
 
+static void test_r4_zero_write_arms_collapsed_frame_window(void) {
+    CRTC crtc;
+    crtc_init(&crtc);
+    crtc.reg[0] = 7;
+    crtc.reg[1] = 4;
+    crtc.reg[4] = 15;
+    crtc.reg[9] = 0;
+    crtc.vcc = 0;
+    crtc.vlc = 0;
+    crtc.line_last_raster = true;
+    crtc.line_last_frame = false;
+    crtc.hcc = 3;
+
+    crtc_select(&crtc, 4);
+    crtc_write(&crtc, 0);
+    assert(crtc.line_last_frame);
+
+    tick_to_next_line(&crtc);
+
+    assert(crtc.vcc == 0);
+}
+
 static void test_r7_line_start_uses_previous_line_length(void) {
     CRTC crtc;
     crtc_init(&crtc);
@@ -568,12 +642,14 @@ int main(void) {
     test_register_write_masks();
     test_r8_mask_depends_on_type();
     test_type1_r12_r13_reloads_at_scanline_start_while_vcc_zero();
+    test_type1_collapsed_total_keeps_row_pipeline();
     test_hsync_width_zero_depends_on_type();
     test_long_hsync_latches_at_cutoff();
     test_short_hsync_latches_at_completion();
     test_horizontal_display_enable_is_latched();
     test_horizontal_total_uses_equality_not_threshold();
     test_vertical_display_enable_is_latched();
+    test_vertical_counter_wrap_reenables_display_and_reloads_start();
     test_r6_write_can_disable_current_row();
     test_address_pipeline_advances_at_r1();
     test_address_pipeline_captures_current_ma_after_hcc_overflow();
@@ -585,6 +661,7 @@ int main(void) {
     test_r9_write_before_c0_two_can_reset_current_line();
     test_r9_write_matching_current_row_arms_current_frame();
     test_r4_write_matching_current_row_does_not_rearm_current_frame();
+    test_r4_zero_write_arms_collapsed_frame_window();
     test_r7_line_start_uses_previous_line_length();
     test_r7_write_before_c0_two_does_not_start_vsync_later_this_row();
     test_r7_write_after_c0_one_can_start_vsync();

--- a/tests/test_crtc.c
+++ b/tests/test_crtc.c
@@ -371,7 +371,7 @@ static void test_address_pipeline_waits_for_final_raster(void) {
     assert(crtc.ma_row_start == (u16)(start + 4));
 }
 
-static void test_r9_write_after_c0_one_does_not_reset_current_line(void) {
+static void test_r9_write_matching_current_raster_resets_current_line(void) {
     CRTC crtc;
     crtc_init(&crtc);
     crtc.reg[0] = 7;
@@ -384,7 +384,24 @@ static void test_r9_write_after_c0_one_does_not_reset_current_line(void) {
     crtc_write(&crtc, 0);
     tick_to_next_line(&crtc);
 
-    assert(crtc.vlc == 1);
+    assert(crtc.vlc == 0);
+}
+
+static void test_r9_write_below_current_raster_does_not_reset_current_line(void) {
+    CRTC crtc;
+    crtc_init(&crtc);
+    crtc.reg[0] = 7;
+    crtc.reg[1] = 4;
+    crtc.vlc = 2;
+    crtc.line_last_raster = false;
+    crtc.line_last_frame = false;
+    crtc.hcc = 3;
+
+    crtc_select(&crtc, 9);
+    crtc_write(&crtc, 1);
+    tick_to_next_line(&crtc);
+
+    assert(crtc.vlc == 3);
 }
 
 static void test_r9_write_before_c0_two_can_reset_current_line(void) {
@@ -405,7 +422,7 @@ static void test_r9_write_before_c0_two_can_reset_current_line(void) {
     assert(crtc.vcc == 4);
 }
 
-static void test_r4_write_after_c0_one_does_not_reset_current_frame(void) {
+static void test_r4_write_matching_current_row_arms_current_frame(void) {
     CRTC crtc;
     crtc_init(&crtc);
     crtc.reg[0] = 7;
@@ -421,7 +438,105 @@ static void test_r4_write_after_c0_one_does_not_reset_current_frame(void) {
     crtc_write(&crtc, 3);
     tick_to_next_line(&crtc);
 
-    assert(crtc.vcc == 4);
+    assert(crtc.vcc == 0);
+}
+
+static void test_r7_line_start_uses_previous_line_length(void) {
+    CRTC crtc;
+    crtc_init(&crtc);
+    crtc.reg[0] = 1;
+    crtc.reg[7] = 1;
+    crtc.vcc = 0;
+    crtc.line_last_raster = true;
+    crtc.line_last_frame = false;
+    crtc.hcc = 1;
+
+    crtc_tick(&crtc);
+
+    assert(crtc.hcc == 0);
+    assert(crtc.vcc == 1);
+    assert(crtc.last_hend == 1);
+    assert(crtc.r7_match);
+    assert(!crtc.vsync);
+
+    crtc_init(&crtc);
+    crtc.reg[0] = 2;
+    crtc.reg[7] = 1;
+    crtc.vcc = 0;
+    crtc.line_last_raster = true;
+    crtc.line_last_frame = false;
+    crtc.hcc = 2;
+
+    crtc_tick(&crtc);
+
+    assert(crtc.hcc == 0);
+    assert(crtc.vcc == 1);
+    assert(crtc.last_hend == 2);
+    assert(crtc.r7_match);
+    assert(crtc.vsync);
+}
+
+static void test_r7_write_before_c0_two_does_not_start_vsync_later_this_row(void) {
+    CRTC crtc;
+    crtc_init(&crtc);
+    crtc.reg[0] = 7;
+    crtc.reg[7] = 3;
+    crtc.vcc = 3;
+    crtc.hcc = 1;
+    crtc.r7_match = false;
+    crtc.vsync = false;
+
+    crtc_select(&crtc, 7);
+    crtc_write(&crtc, 3);
+
+    assert(crtc.r7_match);
+    assert(!crtc.vsync);
+
+    crtc_tick(&crtc);
+
+    assert(crtc.hcc == 2);
+    assert(!crtc.vsync);
+}
+
+static void test_r7_write_after_c0_one_can_start_vsync(void) {
+    CRTC crtc;
+    crtc_init(&crtc);
+    crtc.reg[7] = 3;
+    crtc.vcc = 3;
+    crtc.hcc = 2;
+    crtc.r7_match = false;
+    crtc.vsync = false;
+
+    crtc_select(&crtc, 7);
+    crtc_write(&crtc, 3);
+
+    assert(crtc.r7_match);
+    assert(crtc.vsync);
+    assert(crtc.vsc == 0);
+}
+
+static void test_r7_match_does_not_retrigger_until_vcc_changes(void) {
+    CRTC crtc;
+    crtc_init(&crtc);
+    crtc.reg[0] = 7;
+    crtc.reg[7] = 3;
+    crtc.reg[9] = 3;
+    crtc.vcc = 3;
+    crtc.vlc = 1;
+    crtc.vsync = true;
+    crtc.vsc = 15;
+    crtc.r7_match = true;
+    crtc.line_last_raster = false;
+    crtc.line_last_frame = false;
+    crtc.hcc = 7;
+
+    crtc_tick(&crtc);
+
+    assert(crtc.hcc == 0);
+    assert(crtc.vcc == 3);
+    assert(crtc.vlc == 2);
+    assert(crtc.r7_match);
+    assert(!crtc.vsync);
 }
 
 int main(void) {
@@ -443,8 +558,13 @@ int main(void) {
     test_address_pipeline_repeats_when_r1_is_missed();
     test_address_pipeline_uses_new_r1_if_ahead();
     test_address_pipeline_waits_for_final_raster();
-    test_r9_write_after_c0_one_does_not_reset_current_line();
+    test_r9_write_matching_current_raster_resets_current_line();
+    test_r9_write_below_current_raster_does_not_reset_current_line();
     test_r9_write_before_c0_two_can_reset_current_line();
-    test_r4_write_after_c0_one_does_not_reset_current_frame();
+    test_r4_write_matching_current_row_arms_current_frame();
+    test_r7_line_start_uses_previous_line_length();
+    test_r7_write_before_c0_two_does_not_start_vsync_later_this_row();
+    test_r7_write_after_c0_one_can_start_vsync();
+    test_r7_match_does_not_retrigger_until_vcc_changes();
     return 0;
 }

--- a/tests/test_crtc.c
+++ b/tests/test_crtc.c
@@ -422,14 +422,36 @@ static void test_r9_write_before_c0_two_can_reset_current_line(void) {
     assert(crtc.vcc == 4);
 }
 
-static void test_r4_write_matching_current_row_arms_current_frame(void) {
+static void test_r9_write_matching_current_row_arms_current_frame(void) {
     CRTC crtc;
     crtc_init(&crtc);
     crtc.reg[0] = 7;
     crtc.reg[1] = 4;
     crtc.vcc = 3;
+    crtc.reg[4] = 3;
+    crtc_select(&crtc, 9);
+    crtc_write(&crtc, 1);
+    crtc.hcc = 3;
+
     crtc_select(&crtc, 9);
     crtc_write(&crtc, 0);
+    tick_to_next_line(&crtc);
+
+    assert(crtc.vcc == 0);
+}
+
+static void test_r4_write_matching_current_row_does_not_rearm_current_frame(void) {
+    CRTC crtc;
+    crtc_init(&crtc);
+    crtc.reg[0] = 7;
+    crtc.reg[1] = 4;
+    crtc.vcc = 3;
+    crtc.reg[4] = 5;
+    crtc_select(&crtc, 9);
+    crtc_write(&crtc, 0);
+    assert(crtc.line_last_raster);
+    assert(!crtc.line_last_frame);
+
     crtc_select(&crtc, 4);
     crtc_write(&crtc, 5);
     crtc.hcc = 3;
@@ -438,7 +460,7 @@ static void test_r4_write_matching_current_row_arms_current_frame(void) {
     crtc_write(&crtc, 3);
     tick_to_next_line(&crtc);
 
-    assert(crtc.vcc == 0);
+    assert(crtc.vcc == 4);
 }
 
 static void test_r7_line_start_uses_previous_line_length(void) {
@@ -561,7 +583,8 @@ int main(void) {
     test_r9_write_matching_current_raster_resets_current_line();
     test_r9_write_below_current_raster_does_not_reset_current_line();
     test_r9_write_before_c0_two_can_reset_current_line();
-    test_r4_write_matching_current_row_arms_current_frame();
+    test_r9_write_matching_current_row_arms_current_frame();
+    test_r4_write_matching_current_row_does_not_rearm_current_frame();
     test_r7_line_start_uses_previous_line_length();
     test_r7_write_before_c0_two_does_not_start_vsync_later_this_row();
     test_r7_write_after_c0_one_can_start_vsync();

--- a/tests/test_psg.c
+++ b/tests/test_psg.c
@@ -1,0 +1,91 @@
+#include "psg.h"
+
+#include <assert.h>
+#include <string.h>
+
+static void test_register_write_masks(void) {
+    PSG psg;
+    psg_init(&psg);
+
+    psg_select(&psg, 1);
+    psg_write(&psg, 0xFF);
+    assert(psg.reg[1] == 0x0F);
+
+    psg_select(&psg, 6);
+    psg_write(&psg, 0xFF);
+    assert(psg.reg[6] == 0x1F);
+
+    psg_select(&psg, 7);
+    psg_write(&psg, 0xFF);
+    assert(psg.reg[7] == 0x3F);
+
+    psg_select(&psg, 8);
+    psg_write(&psg, 0xFF);
+    assert(psg.reg[8] == 0x1F);
+
+    psg_select(&psg, 13);
+    psg_write(&psg, 0xFF);
+    assert(psg.reg[13] == 0x0F);
+    assert(psg.env_step == 0);
+    assert(!psg.env_hold);
+    assert(psg.env_dir);
+}
+
+static void test_snapshot_register_load_and_store(void) {
+    PSG psg;
+    u8 regs[PSG_NUM_REGS];
+    u8 stored[PSG_NUM_REGS];
+    u8 selected = 0;
+    u8 env_step = 0;
+    u8 env_direction = 0;
+
+    memset(regs, 0xFF, sizeof(regs));
+    psg_init(&psg);
+    psg_set_kbd_row(&psg, 0x5A);
+
+    psg_load_registers(&psg, regs, 9, true, 12, 0xFF);
+
+    assert(psg.selected == 9);
+    assert(psg.kbd_data == 0x5A);
+    assert(psg.noise_lfsr == 1);
+    assert(psg.reg[0] == 0xFF);
+    assert(psg.reg[1] == 0x0F);
+    assert(psg.reg[6] == 0x1F);
+    assert(psg.reg[7] == 0x3F);
+    assert(psg.reg[8] == 0x1F);
+    assert(psg.reg[13] == 0x0F);
+    assert(!psg.env_dir);
+    assert(!psg.env_hold);
+    assert(psg.env_step == 7);
+
+    psg_store_registers(&psg, stored, &selected, &env_step, &env_direction);
+    assert(selected == 9);
+    assert(memcmp(stored, psg.reg, sizeof(stored)) == 0);
+    assert(env_step == 12);
+    assert(env_direction == 0xFF);
+}
+
+static void test_snapshot_held_envelope_level(void) {
+    PSG psg;
+    u8 regs[PSG_NUM_REGS] = {0};
+    u8 env_step = 0;
+    u8 env_direction = 0xFF;
+
+    psg_init(&psg);
+    psg_load_registers(&psg, regs, 0, true, 4, 0x00);
+
+    assert(psg.env_hold);
+    assert(psg.env_dir);
+    assert(psg.env_step == 8);
+
+    psg_store_registers(&psg, regs, NULL, &env_step, &env_direction);
+    assert(env_step == 4);
+    assert(env_direction == 0x00);
+}
+
+int main(void) {
+    test_register_write_masks();
+    test_snapshot_register_load_and_store();
+    test_snapshot_held_envelope_level();
+    return 0;
+}

--- a/tests/test_z80.c
+++ b/tests/test_z80.c
@@ -113,9 +113,71 @@ static void test_repeating_otir_keeps_repeat_cycles(void) {
     assert(test.ticked_in_step == 16);
 }
 
+static void test_cb_prefix_includes_prefix_cycles(void) {
+    TestBus test = {0};
+    Z80Bus bus = make_bus(&test);
+    Z80 cpu;
+    z80_init(&cpu);
+    cpu.b = 0x81;
+    test.mem[0] = 0xCB;
+    test.mem[1] = 0x00; /* RLC B */
+
+    assert(z80_step(&cpu, &bus) == 8);
+    assert(cpu.b == 0x03);
+    assert(cpu.pc == 2);
+}
+
+static void test_fd_register_ops_include_prefix_cycles(void) {
+    TestBus test = {0};
+    Z80Bus bus = make_bus(&test);
+    Z80 cpu;
+    z80_init(&cpu);
+    cpu.iy = 0x120F;
+    test.mem[0] = 0xFD;
+    test.mem[1] = 0x2C; /* INC IYL */
+
+    assert(z80_step(&cpu, &bus) == 8);
+    assert(cpu.iy == 0x1210);
+    assert(cpu.pc == 2);
+}
+
+static void test_fd_ld_sp_iy_includes_prefix_cycles(void) {
+    TestBus test = {0};
+    Z80Bus bus = make_bus(&test);
+    Z80 cpu;
+    z80_init(&cpu);
+    cpu.iy = 0x4567;
+    test.mem[0] = 0xFD;
+    test.mem[1] = 0xF9; /* LD SP,IY */
+
+    assert(z80_step(&cpu, &bus) == 12);
+    assert(cpu.sp == 0x4567);
+    assert(cpu.pc == 2);
+}
+
+static void test_ddcb_prefix_uses_indexed_bit_timing(void) {
+    TestBus test = {0};
+    Z80Bus bus = make_bus(&test);
+    Z80 cpu;
+    z80_init(&cpu);
+    cpu.ix = 0x2000;
+    test.mem[0] = 0xDD;
+    test.mem[1] = 0xCB;
+    test.mem[2] = 0x05;
+    test.mem[3] = 0x46; /* BIT 0,(IX+5) */
+    test.mem[0x2005] = 0x01;
+
+    assert(z80_step(&cpu, &bus) == 24);
+    assert(cpu.pc == 4);
+}
+
 int main(void) {
     test_out_c_r_is_split_12_plus_4();
     test_outi_is_split_16_plus_4();
     test_repeating_otir_keeps_repeat_cycles();
+    test_cb_prefix_includes_prefix_cycles();
+    test_fd_register_ops_include_prefix_cycles();
+    test_fd_ld_sp_iy_includes_prefix_cycles();
+    test_ddcb_prefix_uses_indexed_bit_timing();
     return 0;
 }


### PR DESCRIPTION
Fixes Batman Forever collapsed CRTC timing by preserving the Type-1 row-address pipeline during the R4=0/R9=0 collapsed-total window and adding focused CRTC tests. Verified with make -C tests check and a full rebuild.