### PR TITLE
Fix Batman Forever sampled AY audio

### DIFF
--- a/src/cpc.c
+++ b/src/cpc.c
@@ -71,8 +71,7 @@ static void trace_check_master(void) {
     }
 }
 
-#define AUDIO_SAMPLE_RATE   44100
-#define AUDIO_SAMPLES_FRAME (AUDIO_SAMPLE_RATE / 50)   /* 882 samples @ 50 Hz */
+#define AUDIO_SAMPLE_RATE   CPC_AUDIO_SAMPLE_RATE
 #define PSG_CLOCK_HZ        1000000                    /* CPC PSG: 4 MHz / 4 */
 
 static const char *fdc_phase_name(FdcPhase phase) {
@@ -872,6 +871,8 @@ void cpc_reset(CPC *cpc) {
     cpc->prev_hsync = false;
     cpc->prev_vsync = false;
     cpc->cycle_debt = 0;
+    cpc->audio_frame_pos = 0;
+    cpc->audio_sample_cycles = 0;
 }
 
 void cpc_destroy(CPC *cpc) {
@@ -1125,8 +1126,7 @@ static inline int cpc_monitor_px(const CPC *cpc) {
 /* Advance ALL per-cycle peripheral state by `cycles` CPU T-states.
  * Covers: tape, audio sampling, CRTC/GA/render. Mirrors konCePCja's
  * z80_wait_states macro which advances CRTC + PSG + FDC + tape in
- * one bundle. 1984 doesn't model per-cycle PSG/FDC (PSG renders
- * once per frame in cpc_frame; FDC is event-driven, not per-cycle).
+ * one bundle. FDC is event-driven, not per-cycle.
  *
  * Callable both from the per-instruction tail of cpc_frame() AND from
  * the Z80Bus::tick hook mid-instruction (for konCePCja-style IO split
@@ -1137,13 +1137,26 @@ static void cpc_advance_bus(CPC *cpc, int cycles) {
     /* Tape (no-op when no tape loaded / motor off) */
     tape_step(&cpc->tape, cycles);
     ppi_set_tape_level(&cpc->ppi, tape_level(&cpc->tape));
-    /* Audio sampling at 44.1 kHz from the cassette signal */
-    cpc->tape_audio_cycles += cycles * AUDIO_SAMPLE_RATE;
-    while (cpc->tape_audio_cycles >= cpc->cpu_clk_hz &&
-           cpc->tape_audio_pos < AUDIO_SAMPLES_FRAME) {
-        cpc->tape_audio[cpc->tape_audio_pos++] =
-            (tape_level(&cpc->tape) & 0x80) ? 2500 : -2500;
-        cpc->tape_audio_cycles -= cpc->cpu_clk_hz;
+    /* Audio sampling at 44.1 kHz. PSG rendering lives here rather than at
+     * frame end so AY register writes take effect at their CPU-cycle time;
+     * this is required for volume-register sample playback. */
+    cpc->audio_sample_cycles += cycles * AUDIO_SAMPLE_RATE;
+    while (cpc->audio_sample_cycles >= cpc->cpu_clk_hz) {
+        if (cpc->audio_frame_pos < CPC_AUDIO_FRAME_CAPACITY) {
+            s16 *dst = &cpc->audio_frame[cpc->audio_frame_pos * 2];
+            psg_render_stereo(&cpc->psg, dst, 1, PSG_CLOCK_HZ, AUDIO_SAMPLE_RATE);
+            if (cpc->tape.present && cpc->tape.motor) {
+                int t  = (tape_level(&cpc->tape) & 0x80) ? 2500 : -2500;
+                int vl = (int)dst[0] + t;
+                int vr = (int)dst[1] + t;
+                if (vl >  32767) vl =  32767; else if (vl < -32768) vl = -32768;
+                if (vr >  32767) vr =  32767; else if (vr < -32768) vr = -32768;
+                dst[0] = (s16)vl;
+                dst[1] = (s16)vr;
+            }
+            cpc->audio_frame_pos++;
+        }
+        cpc->audio_sample_cycles -= cpc->cpu_clk_hz;
     }
     cpc->crtc_cycle_acc += cycles;
     while (cpc->crtc_cycle_acc >= 4) {
@@ -1715,41 +1728,31 @@ void cpc_frame(CPC *cpc) {
         }
     }
 
-    /* Push one frame of PSG audio to SDL (skip on breakpoint/step to avoid burst) */
-    if (!stop_early && cpc->audio_stream) {
-        s16 audio_buf[AUDIO_SAMPLES_FRAME * 2];     /* interleaved L,R */
-        psg_render_stereo(&cpc->psg, audio_buf, AUDIO_SAMPLES_FRAME,
-                          PSG_CLOCK_HZ, AUDIO_SAMPLE_RATE);
-        /* Mix in the cassette signal (mono → both buses) — captured per-sample
-         * inside the Z80 step loop above. Saturating add so we don't wrap. */
-        if (cpc->tape.present && cpc->tape.motor) {
-            for (int i = 0; i < cpc->tape_audio_pos; i++) {
-                int t  = (int)cpc->tape_audio[i];
-                int vl = (int)audio_buf[i*2  ] + t;
-                int vr = (int)audio_buf[i*2+1] + t;
-                if (vl >  32767) vl =  32767; else if (vl < -32768) vl = -32768;
-                if (vr >  32767) vr =  32767; else if (vr < -32768) vr = -32768;
-                audio_buf[i*2  ] = (s16)vl;
-                audio_buf[i*2+1] = (s16)vr;
-            }
-        }
-        cpc->tape_audio_pos = 0;
-        cpc->tape_audio_cycles = 0;
-        if (!SDL_PutAudioStreamData(cpc->audio_stream,
-                                    audio_buf, (int)sizeof(audio_buf))) {
+    /* Push cycle-generated audio to SDL / WAV (skip on breakpoint/step to avoid burst). */
+    if (!stop_early && cpc->audio_frame_pos > 0) {
+        int bytes = cpc->audio_frame_pos * 2 * (int)sizeof(cpc->audio_frame[0]);
+        if (audiocap_active())
+            audiocap_write(cpc->audio_frame, cpc->audio_frame_pos, AUDIO_SAMPLE_RATE);
+        if (cpc->audio_stream &&
+            !SDL_PutAudioStreamData(cpc->audio_stream,
+                                    cpc->audio_frame, bytes)) {
             fprintf(stderr, "SDL_PutAudioStreamData: %s\n", SDL_GetError());
         } else if (dbg_getenv("ONE_K_TRACE_AUDIO") &&
                    (cpc_frame_count % 50) == 0) {
-            s16 min = audio_buf[0], max = audio_buf[0];
-            for (int i = 1; i < AUDIO_SAMPLES_FRAME * 2; i++) {
-                if (audio_buf[i] < min) min = audio_buf[i];
-                if (audio_buf[i] > max) max = audio_buf[i];
+            s16 min = cpc->audio_frame[0], max = cpc->audio_frame[0];
+            for (int i = 1; i < cpc->audio_frame_pos * 2; i++) {
+                s16 sample = cpc->audio_frame[i];
+                if (sample < min) min = sample;
+                if (sample > max) max = sample;
             }
-            fprintf(stderr, "[audio f%d] samples=%d..%d queued=%d bytes\n",
-                    cpc_frame_count, min, max,
-                    SDL_GetAudioStreamQueued(cpc->audio_stream));
+            fprintf(stderr, "[audio f%d] frames=%d samples=%d..%d queued=%d bytes\n",
+                    cpc_frame_count, cpc->audio_frame_pos, min, max,
+                    cpc->audio_stream ? SDL_GetAudioStreamQueued(cpc->audio_stream) : 0);
         }
     }
+    cpc->audio_frame_pos = 0;
+    if (stop_early)
+        cpc->audio_sample_cycles = 0;
 }
 
 void cpc_key_event(CPC *cpc, SDL_Scancode sc, bool pressed) {

--- a/src/cpc.h
+++ b/src/cpc.h
@@ -25,6 +25,10 @@
 
 typedef enum { MODEL_464, MODEL_664, MODEL_6128 } CpcModel;
 
+#define CPC_AUDIO_SAMPLE_RATE     44100
+#define CPC_AUDIO_SAMPLES_FRAME   (CPC_AUDIO_SAMPLE_RATE / 50)
+#define CPC_AUDIO_FRAME_CAPACITY  (CPC_AUDIO_SAMPLES_FRAME * 4)
+
 typedef struct {
     CpcModel   model;
     Z80        cpu;
@@ -62,12 +66,12 @@ typedef struct {
                                   data port when its present flag is set)   */
     Printer    printer;        /* Centronics @ 0xEFxx (Cairo → PDF host sink) */
     Tape       tape;           /* cassette / .cdt image */
-    /* Per-sample snapshot of the cassette data line, captured inside the
-     * Z80 step loop at audio rate. Mixed into the PSG output frame so the
-     * user hears the loading screeches. */
-    s16        tape_audio[882];
-    int        tape_audio_pos;
-    int        tape_audio_cycles;
+    /* PSG + cassette audio generated inside the Z80 step loop at audio rate.
+     * This preserves AY volume-register sample players: writes affect only
+     * the samples after the corresponding CPU cycles have elapsed. */
+    s16        audio_frame[CPC_AUDIO_FRAME_CAPACITY * 2];
+    int        audio_frame_pos;
+    int        audio_sample_cycles;
 
     /* Timing */
     int  cpu_clk_hz;      /* 4 MHz */
@@ -145,6 +149,11 @@ bool videocap_start(const char *path);   /* false on open failure */
 void videocap_stop(void);
 bool videocap_active(void);
 int  videocap_frame_count(void);
+
+bool audiocap_start(const char *path);
+void audiocap_stop(void);
+bool audiocap_active(void);
+void audiocap_write(const s16 *samples, int frames, int sample_rate);
 
 int  cpc_init(CPC *cpc, CpcModel model, const char *rom_os, const char *rom_basic, int scale);
 void cpc_reset(CPC *cpc);

--- a/src/main.c
+++ b/src/main.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <time.h>
 #include <libgen.h>
 #include <strings.h>     /* strcasecmp */
@@ -36,6 +37,8 @@
 static GifCap  *g_videocap_gif  = NULL;
 static WebmCap *g_videocap_webm = NULL;
 static int      g_videocap_skip = 0;   /* GIF-only: halve to 25 fps */
+static FILE    *g_audiocap_wav  = NULL;
+static uint32_t g_audiocap_bytes = 0;
 
 bool videocap_active(void) {
     return g_videocap_gif != NULL || g_videocap_webm != NULL;
@@ -92,6 +95,70 @@ void videocap_stop(void) {
         webmcap_close(g_videocap_webm);
         g_videocap_webm = NULL;
     }
+}
+
+static void wav_u16(FILE *f, uint16_t v) {
+    fputc((int)(v & 0xFF), f);
+    fputc((int)((v >> 8) & 0xFF), f);
+}
+
+static void wav_u32(FILE *f, uint32_t v) {
+    fputc((int)(v & 0xFF), f);
+    fputc((int)((v >> 8) & 0xFF), f);
+    fputc((int)((v >> 16) & 0xFF), f);
+    fputc((int)((v >> 24) & 0xFF), f);
+}
+
+static void wav_header(FILE *f, int sample_rate, uint32_t data_bytes) {
+    uint32_t byte_rate = (uint32_t)sample_rate * 2u * 16u / 8u;
+    fwrite("RIFF", 1, 4, f);
+    wav_u32(f, 36u + data_bytes);
+    fwrite("WAVE", 1, 4, f);
+    fwrite("fmt ", 1, 4, f);
+    wav_u32(f, 16);
+    wav_u16(f, 1);                     /* PCM */
+    wav_u16(f, 2);                     /* stereo */
+    wav_u32(f, (uint32_t)sample_rate);
+    wav_u32(f, byte_rate);
+    wav_u16(f, 2u * 16u / 8u);         /* block align */
+    wav_u16(f, 16);                    /* bits per sample */
+    fwrite("data", 1, 4, f);
+    wav_u32(f, data_bytes);
+}
+
+bool audiocap_start(const char *path) {
+    if (!path || !path[0]) return false;
+    if (g_audiocap_wav) return true;
+    g_audiocap_wav = fopen(path, "wb");
+    if (!g_audiocap_wav) {
+        fprintf(stderr, "[audiocap] WAV open failed for '%s'\n", path);
+        return false;
+    }
+    g_audiocap_bytes = 0;
+    wav_header(g_audiocap_wav, CPC_AUDIO_SAMPLE_RATE, 0);
+    fprintf(stderr, "[audiocap] recording 44100 Hz stereo s16 -> %s\n", path);
+    return true;
+}
+
+bool audiocap_active(void) {
+    return g_audiocap_wav != NULL;
+}
+
+void audiocap_write(const s16 *samples, int frames, int sample_rate) {
+    if (!g_audiocap_wav || !samples || frames <= 0) return;
+    if (sample_rate != CPC_AUDIO_SAMPLE_RATE) return;
+    for (int i = 0; i < frames * 2; i++)
+        wav_u16(g_audiocap_wav, (uint16_t)samples[i]);
+    g_audiocap_bytes += (uint32_t)frames * 2u * 2u;
+}
+
+void audiocap_stop(void) {
+    if (!g_audiocap_wav) return;
+    fseek(g_audiocap_wav, 0, SEEK_SET);
+    wav_header(g_audiocap_wav, CPC_AUDIO_SAMPLE_RATE, g_audiocap_bytes);
+    fclose(g_audiocap_wav);
+    g_audiocap_wav = NULL;
+    fprintf(stderr, "[audiocap] WAV stopped (%u bytes PCM)\n", g_audiocap_bytes);
 }
 
 /* Synchronise the Net4CPC TAP backend with the current config. Used at
@@ -276,6 +343,7 @@ static void usage(const char *prog, int code) {
         "                      steps; DIRS = u d l r 1 2 (Fire1/2) or - (neutral).\n"
         "                      e.g. --joy-script=d:150,-:30,u:150 (down, rest, up)\n"
         "  --gif-out=PATH      Record a GIF from boot (finalised on exit; pairs with --exit-after)\n"
+        "  --audio-out=PATH    Record emulator audio to a WAV file from boot\n"
         "  --exit-after=N      Quit after frame N (deterministic headless capture)\n"
         "  --printer-pdf=DIR   Capture parallel-printer output to timestamped PDFs in DIR\n"
         "  --printer-real      Spool captured pages to the host's default CUPS printer (lp)\n"
@@ -331,6 +399,7 @@ int main(int argc, char *argv[]) {
     const char *save_sna_ide_path = NULL;
     const char *joyscript_arg    = NULL;  /* --joy-script=SPEC: scripted joystick */
     const char *gifout_arg       = NULL;  /* --gif-out=PATH: record a GIF from boot */
+    const char *audioout_arg     = NULL;  /* --audio-out=PATH: record WAV audio from boot */
     int         exit_after       = -1;    /* --exit-after=N: quit at frame N */
     const char *printer_pdf_dir_arg = NULL; /* --printer-pdf=DIR */
     bool        printer_real_arg = false;   /* --printer-real */
@@ -454,6 +523,8 @@ int main(int argc, char *argv[]) {
             joyscript_arg = argv[i] + 13;
         } else if (strncmp(argv[i], "--gif-out=", 10) == 0 && argv[i][10] != '\0') {
             gifout_arg = argv[i] + 10;
+        } else if (strncmp(argv[i], "--audio-out=", 12) == 0 && argv[i][12] != '\0') {
+            audioout_arg = argv[i] + 12;
         } else if (strncmp(argv[i], "--printer-pdf=", 14) == 0 && argv[i][14] != '\0') {
             printer_pdf_dir_arg = argv[i] + 14;
         } else if (strcmp(argv[i], "--printer-real") == 0) {
@@ -758,6 +829,8 @@ int main(int argc, char *argv[]) {
     bool running = true;
     if (gifout_arg)            /* --gif-out: record from boot (finalised on exit) */
         videocap_start(gifout_arg);
+    if (audioout_arg)
+        audiocap_start(audioout_arg);
     SD_LOG("entering main loop — startup complete");
     while (running) {
         SDL_Event ev;
@@ -1363,6 +1436,7 @@ int main(int argc, char *argv[]) {
     if (sfx_stream) SDL_DestroyAudioStream(sfx_stream);
     if (sfx_buf)    SDL_free(sfx_buf);
     videocap_stop();   /* finalise GIF if recording */
+    audiocap_stop();   /* finalise WAV if recording */
     printer_shutdown(&cpc.printer);
     perryfi_shutdown(&cpc.perryfi);
     cpc_destroy(&cpc);

--- a/src/psg.c
+++ b/src/psg.c
@@ -259,19 +259,20 @@ static void psg_tick(PSG *psg, int out_amp[3]) {
         bool tone_off  = (psg->reg[7] >> c)       & 1;
         bool noise_off = (psg->reg[7] >> (c + 3)) & 1;
 
+        u8 vr  = psg->reg[8 + c];
+        u8 vol = (vr & 0x10) ? env_level : (vr & 0x0F);
+
         if (tone_off && noise_off) {
-            /* Channel is gated off: AY holds the level high, but with
-             * the DC blocker downstream that becomes silence — emit 0. */
-            out_amp[c] = 0;
+            /* With both sources disabled the AY mixer output is held high.
+             * A constant volume still DC-blocks to silence, but rapid volume
+             * changes are the standard 4-bit DAC path used by sample players. */
+            out_amp[c] = (int)vol;
             continue;
         }
 
         /* Disabled source contributes high (1) to the AND mixer */
         int tone_hi  = tone_off  ? 1 : (int)psg->tone_output[c];
         int noise_hi = noise_off ? 1 : noise_out;
-
-        u8 vr  = psg->reg[8 + c];
-        u8 vol = (vr & 0x10) ? env_level : (vr & 0x0F);
 
         out_amp[c] = (tone_hi && noise_hi) ? (int)vol : 0;
     }

--- a/tests/test_psg.c
+++ b/tests/test_psg.c
@@ -83,9 +83,34 @@ static void test_snapshot_held_envelope_level(void) {
     assert(env_direction == 0x00);
 }
 
+static void test_disabled_sources_can_act_as_volume_dac(void) {
+    PSG psg;
+    s16 buf[32] = {0};
+    int heard = 0;
+
+    psg_init(&psg);
+    psg_set_volume(&psg, 100);
+    psg_select(&psg, 7);
+    psg_write(&psg, 0x3F);   /* disable tone and noise on all channels */
+    psg_select(&psg, 8);
+    psg_write(&psg, 0x00);
+    psg_render_stereo(&psg, buf, 8, 1000000, 44100);
+
+    psg_select(&psg, 8);
+    psg_write(&psg, 0x0F);   /* volume-register DAC step */
+    memset(buf, 0, sizeof(buf));
+    psg_render_stereo(&psg, buf, 8, 1000000, 44100);
+    for (int i = 0; i < 16; i++) {
+        if (buf[i] != 0)
+            heard = 1;
+    }
+    assert(heard);
+}
+
 int main(void) {
     test_register_write_masks();
     test_snapshot_register_load_and_store();
     test_snapshot_held_envelope_level();
+    test_disabled_sources_can_act_as_volume_dac();
     return 0;
 }


### PR DESCRIPTION
Fixes #186.\n\nChanges:\n- Treat AY tone-off/noise-off as the held-high volume DAC path instead of silence.\n- Generate PSG audio at CPU-cycle timing from cpc_advance_bus so rapid volume-register writes are preserved.\n- Add --audio-out=PATH WAV recording for audio debugging.\n- Add a PSG regression test for volume-register DAC output.\n\nVerified with make -C tests check, full rebuild, and Batman Forever disk audio capture showing non-flat PCM.