### PR TITLE
Fix Xevious CRTC vertical adjust artifact

### DIFF
--- a/src/crtc.c
+++ b/src/crtc.c
@@ -225,7 +225,7 @@ void crtc_tick(CRTC *c) {
              * Per ACCC §6.1.1: when C5 reaches R5, the frame restarts with
              * C4=C5=C9=0 and MA reloaded from R12/R13. */
             c->vac++;
-            if (c->vac > c->reg[5]) {
+            if (c->vac >= c->reg[5]) {
                 c->in_vadjust = false;
                 c->vac = 0;
                 c->vcc = 0;
@@ -233,6 +233,8 @@ void crtc_tick(CRTC *c) {
                 c->ma_row_start = crtc_start_addr(c);
                 c->ma_next_row = c->ma_row_start;
                 c->v_display = c->reg[6] != 0;
+            } else {
+                c->vlc = c->vac & 0x1F;
             }
         } else if (end_char_row) {
             /* Raster line within character row */

--- a/tests/test_crtc.c
+++ b/tests/test_crtc.c
@@ -329,6 +329,51 @@ static void test_vertical_counter_wrap_reenables_display_and_reloads_start(void)
     assert(crtc.ma == 0x2040);
 }
 
+static void test_vertical_adjust_advances_raster_and_restarts_on_r5_match(void) {
+    CRTC crtc;
+    crtc_init(&crtc);
+    crtc.reg[0] = 1;
+    crtc.reg[1] = 1;
+    crtc.reg[4] = 3;
+    crtc.reg[5] = 2;
+    crtc.reg[9] = 7;
+    crtc.reg[12] = 0x20;
+    crtc.reg[13] = 0x40;
+    crtc.hcc = 1;
+    crtc.vcc = 3;
+    crtc.vlc = 7;
+    crtc.ma_row_start = 0x1200;
+    crtc.ma_next_row = 0x1234;
+    crtc.ma = 0x1235;
+    crtc.line_last_raster = true;
+    crtc.line_last_frame = true;
+
+    crtc_tick(&crtc);
+
+    assert(crtc.in_vadjust);
+    assert(crtc.vac == 0);
+    assert(crtc.vcc == 3);
+    assert(crtc.vlc == 0);
+    assert(crtc.ma_row_start == 0x1234);
+
+    tick_to_next_line(&crtc);
+
+    assert(crtc.in_vadjust);
+    assert(crtc.vac == 1);
+    assert(crtc.vcc == 3);
+    assert(crtc.vlc == 1);
+    assert(crtc.ma_row_start == 0x1234);
+
+    tick_to_next_line(&crtc);
+
+    assert(!crtc.in_vadjust);
+    assert(crtc.vac == 0);
+    assert(crtc.vcc == 0);
+    assert(crtc.vlc == 0);
+    assert(crtc.ma_row_start == 0x2040);
+    assert(crtc.ma == 0x2040);
+}
+
 static void test_r6_write_can_disable_current_row(void) {
     CRTC crtc;
     crtc_init(&crtc);
@@ -650,6 +695,7 @@ int main(void) {
     test_horizontal_total_uses_equality_not_threshold();
     test_vertical_display_enable_is_latched();
     test_vertical_counter_wrap_reenables_display_and_reloads_start();
+    test_vertical_adjust_advances_raster_and_restarts_on_r5_match();
     test_r6_write_can_disable_current_row();
     test_address_pipeline_advances_at_r1();
     test_address_pipeline_captures_current_ma_after_hcc_overflow();


### PR DESCRIPTION
## Summary
- fix CRTC vertical total adjust so the raster counter advances during R5 adjust
- restart the frame when the adjust counter reaches R5 instead of one line late
- add CRTC regression coverage for vertical adjust timing

## Tests
- make -C tests check
- Xevious snapshot capture no longer shows the wide orange split artifact
- Batman half/newhalf snapshots still render as expected

Refs #105