### PR TITLE
Fix AY envelope prescaler

### DIFF
--- a/src/psg.c
+++ b/src/psg.c
@@ -221,11 +221,11 @@ static void psg_tick(PSG *psg, int out_amp[3]) {
     }
     int noise_out = (int)(psg->noise_lfsr & 1);
 
-    /* --- Envelope: 32 steps, one step every env_period clocks --- */
+    /* --- Envelope: 32 steps, one step every env_period*2 PSG clocks --- */
     if (!psg->env_hold) {
         u16 ep = (u16)((psg->reg[12] << 8) | psg->reg[11]);
         if (!ep) ep = 1;
-        if (++psg->env_counter >= (u32)ep * 8) {
+        if (++psg->env_counter >= (u32)ep * 2) {
             psg->env_counter = 0;
             psg->env_step++;
             if (psg->env_step >= 32) {

--- a/tests/test_psg.c
+++ b/tests/test_psg.c
@@ -83,6 +83,25 @@ static void test_snapshot_held_envelope_level(void) {
     assert(env_direction == 0x00);
 }
 
+static void test_envelope_period_uses_ay_prescaler(void) {
+    PSG psg;
+    s16 buf[16] = {0};
+
+    psg_init(&psg);
+    psg_select(&psg, 11);
+    psg_write(&psg, 4);
+    psg_select(&psg, 12);
+    psg_write(&psg, 0);
+    psg_select(&psg, 13);
+    psg_write(&psg, 0x0C);
+
+    psg_render_stereo(&psg, buf, 7, 1000000, 1000000);
+    assert(psg.env_step == 0);
+
+    psg_render_stereo(&psg, buf, 1, 1000000, 1000000);
+    assert(psg.env_step == 1);
+}
+
 static void test_disabled_sources_can_act_as_volume_dac(void) {
     PSG psg;
     s16 buf[32] = {0};
@@ -111,6 +130,7 @@ int main(void) {
     test_register_write_masks();
     test_snapshot_register_load_and_store();
     test_snapshot_held_envelope_level();
+    test_envelope_period_uses_ay_prescaler();
     test_disabled_sources_can_act_as_volume_dac();
     return 0;
 }


### PR DESCRIPTION
## Summary
- change AY envelope timing from env_period*8 to env_period*2 PSG clocks
- add a PSG regression test for envelope step timing

## Tests
- make -C tests check

Fixes #179