### PR TITLE
Implement real CRT overlay controls

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -129,6 +129,10 @@ void config_defaults(Config *cfg) {
     cfg->mx4       = true;   /* expansion bus connected by default */
     cfg->rom_board = true;   /* ROM Board fitted by default */
     cfg->fullscreen_smoothing = true;  /* preserve historic linear-scale behaviour */
+    cfg->real_crt = false;
+    cfg->crt_scanlines = DISPLAY_CRT_SCANLINES_DEFAULT;
+    cfg->crt_brightness = DISPLAY_CRT_BRIGHTNESS_DEFAULT;
+    cfg->crt_contrast = DISPLAY_CRT_CONTRAST_DEFAULT;
     cfg->tinker    = false;
     cfg->debug     = false;
     snprintf(cfg->net4cpc_tap_host_ip,    sizeof(cfg->net4cpc_tap_host_ip),    "10.0.0.1");
@@ -291,6 +295,12 @@ static void config_create_default(const char *path) {
         "fullscreen=false\n"
         "# Smooth (linear) vs sharp (nearest) texture scaling\n"
         "fullscreen_smoothing=true\n"
+        "# Lightweight CRT post-process. real_crt enables the overlay controls.\n"
+        "real_crt=false\n"
+        "# Scanline opacity, 0..95. Brightness is 50..100. Contrast is 50..150.\n"
+        "crt_scanlines=35\n"
+        "crt_brightness=100\n"
+        "crt_contrast=100\n"
         "# Monochrome monitor tint: off | green | amber | white\n"
         "# Maps the CPC palette to shades of one phosphor colour.\n"
         "monochrome=off\n"
@@ -537,6 +547,22 @@ int config_load_from(Config *cfg, const char *path_override) {
                 bool b;
                 if (parse_bool(val, &b)) cfg->fullscreen_smoothing = b;
                 else { fprintf(stderr, "1984.conf:%d: fullscreen_smoothing must be true/false\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "real_crt")) {
+                bool b;
+                if (parse_bool(val, &b)) cfg->real_crt = b;
+                else { fprintf(stderr, "1984.conf:%d: real_crt must be true/false\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "crt_scanlines")) {
+                int v = atoi(val);
+                if (v >= 0 && v <= 95) cfg->crt_scanlines = v;
+                else { fprintf(stderr, "1984.conf:%d: crt_scanlines must be 0..95\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "crt_brightness")) {
+                int v = atoi(val);
+                if (v >= 50 && v <= 100) cfg->crt_brightness = v;
+                else { fprintf(stderr, "1984.conf:%d: crt_brightness must be 50..100\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "crt_contrast")) {
+                int v = atoi(val);
+                if (v >= 50 && v <= 150) cfg->crt_contrast = v;
+                else { fprintf(stderr, "1984.conf:%d: crt_contrast must be 50..150\n", lineno); rc = -1; }
             } else if (!strcmp(key, "monochrome")) {
                 MonoMode m;
                 if (parse_mono(val, &m)) cfg->monochrome = m;
@@ -697,6 +723,10 @@ int config_save(const Config *cfg) {
         "scale=%d\n"
         "fullscreen=%s\n"
         "fullscreen_smoothing=%s\n"
+        "real_crt=%s\n"
+        "crt_scanlines=%d\n"
+        "crt_brightness=%d\n"
+        "crt_contrast=%d\n"
         "monochrome=%s\n\n"
         "[audio]\n"
         "audio_volume=%d\n"
@@ -741,6 +771,10 @@ int config_save(const Config *cfg) {
         cfg->scale,
         cfg->fullscreen ? "true" : "false",
         cfg->fullscreen_smoothing ? "true" : "false",
+        cfg->real_crt ? "true" : "false",
+        cfg->crt_scanlines,
+        cfg->crt_brightness,
+        cfg->crt_contrast,
         mono_to_str(cfg->monochrome),
         cfg->audio_volume,
         cfg->audio_stereo_sep,

--- a/src/config.h
+++ b/src/config.h
@@ -108,6 +108,10 @@ typedef struct {
     int  scale;             /* 1, 2, or 3 */
     bool fullscreen;
     bool fullscreen_smoothing; /* linear (smooth) vs nearest (sharp) texture scale */
+    bool real_crt;             /* enable lightweight CRT post-process */
+    int  crt_scanlines;        /* scanline opacity, 0..95 */
+    int  crt_brightness;       /* texture brightness, 50..100 */
+    int  crt_contrast;         /* texture contrast, 50..150 */
     MonoMode monochrome;       /* off / green / amber / white phosphor tint */
 
     /* [printer] — host-side Centronics capture (port 0xEFxx).

--- a/src/display.c
+++ b/src/display.c
@@ -3,6 +3,42 @@
 #include <string.h>
 #include <stdio.h>
 
+static int clamp_int(int v, int lo, int hi) {
+    if (v < lo) return lo;
+    if (v > hi) return hi;
+    return v;
+}
+
+static unsigned adjust_component(unsigned c, int brightness, int contrast) {
+    int v = 128 + (((int)c - 128) * contrast + 50) / 100;
+    v = (v * brightness + 50) / 100;
+    return (unsigned)clamp_int(v, 0, 255);
+}
+
+static const u32 *display_crt_pixels(Display *d) {
+    if (!d->crt_enabled ||
+        (d->crt_brightness == DISPLAY_CRT_BRIGHTNESS_DEFAULT &&
+         d->crt_contrast == DISPLAY_CRT_CONTRAST_DEFAULT))
+        return d->pixels;
+
+    int n = CPC_SCREEN_W * CPC_SCREEN_H;
+    for (int i = 0; i < n; i++) {
+        u32 px = d->pixels[i];
+        unsigned r = adjust_component((px >> 16) & 0xFF,
+                                      d->crt_brightness,
+                                      d->crt_contrast);
+        unsigned g = adjust_component((px >> 8) & 0xFF,
+                                      d->crt_brightness,
+                                      d->crt_contrast);
+        unsigned b = adjust_component(px & 0xFF,
+                                      d->crt_brightness,
+                                      d->crt_contrast);
+        d->crt_pixels[i] = (px & 0xFF000000u) | (r << 16) | (g << 8) | b;
+    }
+
+    return d->crt_pixels;
+}
+
 int display_init(Display *d, const char *title, int scale) {
     memset(d, 0, sizeof(*d));
 
@@ -35,6 +71,9 @@ int display_init(Display *d, const char *title, int scale) {
     }
 
     memset(d->pixels, 0, sizeof(d->pixels));
+    d->crt_scanlines = DISPLAY_CRT_SCANLINES_DEFAULT;
+    d->crt_brightness = DISPLAY_CRT_BRIGHTNESS_DEFAULT;
+    d->crt_contrast = DISPLAY_CRT_CONTRAST_DEFAULT;
     return 0;
 }
 
@@ -42,6 +81,14 @@ void display_set_smoothing(Display *d, bool smooth) {
     if (d->texture)
         SDL_SetTextureScaleMode(d->texture,
             smooth ? SDL_SCALEMODE_LINEAR : SDL_SCALEMODE_NEAREST);
+}
+
+void display_set_crt(Display *d, bool enabled, int scanlines, int brightness,
+                     int contrast) {
+    d->crt_enabled = enabled;
+    d->crt_scanlines = clamp_int(scanlines, 0, 95);
+    d->crt_brightness = clamp_int(brightness, 50, 100);
+    d->crt_contrast = clamp_int(contrast, 50, 150);
 }
 
 void display_destroy(Display *d) {
@@ -92,7 +139,9 @@ void display_upload(Display *d) {
         (float)dst_h
     };
 
-    SDL_UpdateTexture(d->texture, NULL, d->pixels, CPC_SCREEN_W * sizeof(u32));
+    SDL_UpdateTexture(d->texture, NULL, display_crt_pixels(d),
+                      CPC_SCREEN_W * sizeof(u32));
+    SDL_SetTextureColorMod(d->texture, 255, 255, 255);
     /* Force the clear colour to opaque black before clearing — the overlay
      * leaves whatever it last drew with (often a yellow text colour or a
      * tab-highlight blue) as the renderer's draw colour, and an unset
@@ -100,6 +149,16 @@ void display_upload(Display *d) {
     SDL_SetRenderDrawColor(d->renderer, 0, 0, 0, 255);
     SDL_RenderClear(d->renderer);
     SDL_RenderTexture(d->renderer, d->texture, NULL, &dst);
+    if (d->crt_enabled && d->crt_scanlines > 0) {
+        Uint8 alpha = (Uint8)((d->crt_scanlines * 255 + 50) / 100);
+        SDL_SetRenderDrawBlendMode(d->renderer, SDL_BLENDMODE_BLEND);
+        SDL_SetRenderDrawColor(d->renderer, 0, 0, 0, alpha);
+        int lines = (int)dst.h;
+        for (int y = 1; y < lines; y += 2) {
+            SDL_FRect scan = { dst.x, dst.y + (float)y, dst.w, 1.0f };
+            SDL_RenderFillRect(d->renderer, &scan);
+        }
+    }
     leds_render(d->renderer, 0, wh - bar_h, ww, bar_h);
 }
 

--- a/src/display.h
+++ b/src/display.h
@@ -16,14 +16,22 @@
 #define WINDOW_H        576   /* 4:3 display height (768 × 3/4) */
 #define LED_BAR_HEIGHT  22    /* drive-activity LED strip below the CPC area */
 #define WINDOW_H_TOTAL  (WINDOW_H + LED_BAR_HEIGHT)
+#define DISPLAY_CRT_SCANLINES_DEFAULT 35
+#define DISPLAY_CRT_BRIGHTNESS_DEFAULT 100
+#define DISPLAY_CRT_CONTRAST_DEFAULT 100
 
 typedef struct {
     SDL_Window   *window;
     SDL_Renderer *renderer;
     SDL_Texture  *texture;
     u32           pixels[CPC_SCREEN_W * CPC_SCREEN_H];
+    u32           crt_pixels[CPC_SCREEN_W * CPC_SCREEN_H];
     int           scan_x;
     int           scan_y;
+    bool          crt_enabled;
+    int           crt_scanlines;
+    int           crt_brightness;
+    int           crt_contrast;
 } Display;
 
 int  display_init(Display *d, const char *title, int scale);
@@ -37,6 +45,8 @@ void display_save_ppm(Display *d, const char *path);
 
 /* Switch texture scaling between linear (smooth) and nearest (sharp). */
 void display_set_smoothing(Display *d, bool smooth);
+void display_set_crt(Display *d, bool enabled, int scanlines, int brightness,
+                     int contrast);
 
 /* In-place desaturate the current framebuffer (Rec. 601 luma). Used when
  * the emulator pauses so the frozen frame visibly differs from a running

--- a/src/main.c
+++ b/src/main.c
@@ -805,6 +805,8 @@ int main(int argc, char *argv[]) {
     bool fullscreen     = cfg.fullscreen;
     bool mouse_captured = false;
     display_set_smoothing(&cpc.display, cfg.fullscreen_smoothing);
+    display_set_crt(&cpc.display, cfg.real_crt, cfg.crt_scanlines,
+                    cfg.crt_brightness, cfg.crt_contrast);
     if (fullscreen)
         SDL_SetWindowFullscreen(cpc.display.window, true);
 

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -39,7 +39,65 @@ static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 14, 15 };
 
 static int ov_section_rows(const Overlay *ov, OvSection s) {
     if (s == OV_GENERAL && ov->cfg->model != MODEL_464) return 8;
+    if (s == OV_TINKER && ov->cfg->real_crt) return sec_row_count[s] + 3;
     return sec_row_count[s];
+}
+
+static int tinker_logical_row(const Overlay *ov, int row) {
+    if (!ov->cfg->real_crt)
+        return row;
+    if (row == 2) return -1;  /* Scanlines */
+    if (row == 3) return -2;  /* Brightness */
+    if (row == 4) return -3;  /* Contrast */
+    if (row >= 5) return row - 3;
+    return row;
+}
+
+static void overlay_apply_crt(Overlay *ov) {
+    if (!ov->cpc)
+        return;
+    display_set_crt(&ov->cpc->display, ov->cfg->real_crt,
+                    ov->cfg->crt_scanlines, ov->cfg->crt_brightness,
+                    ov->cfg->crt_contrast);
+}
+
+static bool reset_tinker_crt_item(Overlay *ov) {
+    if (ov->section != OV_TINKER)
+        return false;
+
+    bool old_real_crt = ov->cfg->real_crt;
+    int old_scanlines = ov->cfg->crt_scanlines;
+    int old_brightness = ov->cfg->crt_brightness;
+    int old_contrast = ov->cfg->crt_contrast;
+
+    switch (tinker_logical_row(ov, ov->row)) {
+    case -3:
+        ov->cfg->crt_contrast = DISPLAY_CRT_CONTRAST_DEFAULT;
+        break;
+    case -2:
+        ov->cfg->crt_brightness = DISPLAY_CRT_BRIGHTNESS_DEFAULT;
+        break;
+    case -1:
+        ov->cfg->crt_scanlines = DISPLAY_CRT_SCANLINES_DEFAULT;
+        break;
+    case 1:
+        ov->cfg->real_crt = false;
+        ov->cfg->crt_scanlines = DISPLAY_CRT_SCANLINES_DEFAULT;
+        ov->cfg->crt_brightness = DISPLAY_CRT_BRIGHTNESS_DEFAULT;
+        ov->cfg->crt_contrast = DISPLAY_CRT_CONTRAST_DEFAULT;
+        break;
+    default:
+        return false;
+    }
+
+    if (old_real_crt != ov->cfg->real_crt ||
+        old_scanlines != ov->cfg->crt_scanlines ||
+        old_brightness != ov->cfg->crt_brightness ||
+        old_contrast != ov->cfg->crt_contrast) {
+        overlay_apply_crt(ov);
+        ov->dirty = true;
+    }
+    return true;
 }
 
 /* ---- Drawing helpers ---- */
@@ -356,7 +414,19 @@ static void item_text(const Overlay *ov, int row,
         break;
 
     case OV_TINKER:
-        switch (row) {
+        switch (tinker_logical_row(ov, row)) {
+        case -3:
+            snprintf(lbl, lsz, "Contrast");
+            snprintf(val, vsz, "%d%%", ov->cfg->crt_contrast);
+            break;
+        case -2:
+            snprintf(lbl, lsz, "Brightness");
+            snprintf(val, vsz, "%d%%", ov->cfg->crt_brightness);
+            break;
+        case -1:
+            snprintf(lbl, lsz, "Scanlines");
+            snprintf(val, vsz, "%d%%", ov->cfg->crt_scanlines);
+            break;
         case 0:
             snprintf(lbl, lsz, "Smoothing");
             snprintf(val, vsz, "%s",
@@ -364,8 +434,7 @@ static void item_text(const Overlay *ov, int row,
             break;
         case 1:
             snprintf(lbl, lsz, "Real CRT");
-            snprintf(val, vsz, "[unimplemented]");
-            *readonly = true;
+            snprintf(val, vsz, "%s", ov->cfg->real_crt ? "enabled" : "disabled");
             break;
         case 2:
             snprintf(lbl, lsz, "Load Snapshot");
@@ -987,12 +1056,54 @@ static void activate_item(Overlay *ov) {
         break;
 
     case OV_TINKER:
-        switch (ov->row) {
+        switch (tinker_logical_row(ov, ov->row)) {
+        case -3:
+            ov->cfg->crt_contrast += 5;
+            if (ov->cfg->crt_contrast > 150)
+                ov->cfg->crt_contrast = 50;
+            if (ov->cpc)
+                display_set_crt(&ov->cpc->display, ov->cfg->real_crt,
+                                ov->cfg->crt_scanlines,
+                                ov->cfg->crt_brightness,
+                                ov->cfg->crt_contrast);
+            ov->dirty = true;
+            break;
+        case -2:
+            ov->cfg->crt_brightness -= 5;
+            if (ov->cfg->crt_brightness < 50)
+                ov->cfg->crt_brightness = 100;
+            if (ov->cpc)
+                display_set_crt(&ov->cpc->display, ov->cfg->real_crt,
+                                ov->cfg->crt_scanlines,
+                                ov->cfg->crt_brightness,
+                                ov->cfg->crt_contrast);
+            ov->dirty = true;
+            break;
+        case -1:
+            ov->cfg->crt_scanlines += 5;
+            if (ov->cfg->crt_scanlines > 95)
+                ov->cfg->crt_scanlines = 0;
+            if (ov->cpc)
+                display_set_crt(&ov->cpc->display, ov->cfg->real_crt,
+                                ov->cfg->crt_scanlines,
+                                ov->cfg->crt_brightness,
+                                ov->cfg->crt_contrast);
+            ov->dirty = true;
+            break;
         case 0:
             ov->cfg->fullscreen_smoothing = !ov->cfg->fullscreen_smoothing;
             if (ov->cpc)
                 display_set_smoothing(&ov->cpc->display,
                                       ov->cfg->fullscreen_smoothing);
+            ov->dirty = true;
+            break;
+        case 1:
+            ov->cfg->real_crt = !ov->cfg->real_crt;
+            if (ov->cpc)
+                display_set_crt(&ov->cpc->display, ov->cfg->real_crt,
+                                ov->cfg->crt_scanlines,
+                                ov->cfg->crt_brightness,
+                                ov->cfg->crt_contrast);
             ov->dirty = true;
             break;
         case 2: {
@@ -1481,6 +1592,11 @@ bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
         }
         case SDL_SCANCODE_ESCAPE:
             *ov->cfg    = ov->saved;  /* revert */
+            if (ov->cpc)
+                display_set_crt(&ov->cpc->display, ov->cfg->real_crt,
+                                ov->cfg->crt_scanlines,
+                                ov->cfg->crt_brightness,
+                                ov->cfg->crt_contrast);
             ov->dirty   = false;
             ov->visible = false;
             break;
@@ -1705,6 +1821,9 @@ bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
         break;
     case SDL_SCANCODE_DELETE:
     case SDL_SCANCODE_BACKSPACE:
+        if (reset_tinker_crt_item(ov))
+            break;
+
         /* Del on Drive A / Drive B / Tape ejects the image and clears
          * the cached path (#107 follow-up). */
         if (ov->section == OV_STORAGE) {
@@ -1912,10 +2031,12 @@ void overlay_render(const Overlay *ov, SDL_Renderer *r) {
         char lbl[48] = "", val[48] = "";
         bool readonly;
         item_text(ov, i, lbl, sizeof(lbl), val, sizeof(val), &readonly);
+        int logical = (ov->section == OV_TINKER)
+                    ? tinker_logical_row(ov, i) : i;
 
         float ty = iy + (ITEM_H - FONT_H) / 2.0f;
         draw_text(r, DROP_PAD, ty, lbl, 220, 220, 240);
-        if (ov->section == OV_TINKER && i == 9 && ov->pty_link_editing) {
+        if (ov->section == OV_TINKER && logical == 9 && ov->pty_link_editing) {
             /* Inline editor: show the live buffer with a blinking-style
              * trailing underscore cursor. Bright green to signal that
              * keystrokes are being captured. */
@@ -1924,7 +2045,7 @@ void overlay_render(const Overlay *ov, SDL_Renderer *r) {
             draw_text(r, VAL_X, ty, shown, 120, 255, 120);
         } else if (readonly) {
             draw_text(r, VAL_X, ty, val, 90, 90, 110);
-        } else if (ov->section == OV_TINKER && i == 10
+        } else if (ov->section == OV_TINKER && logical == 10
                    && ov->cfg->monochrome != MONO_OFF) {
             /* Render the tint name in its own phosphor colour so the
              * choice is recognisable at a glance. Bright values picked


### PR DESCRIPTION
Closes #81. Closes #184.

Adds the Advanced > Real CRT toggle with conditional Scanlines, Brightness, and Contrast controls. Values persist in config, apply live, and reset to defaults with Delete/Backspace.

Tests:
- make -C tests check
- SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy ./1984 --config=/tmp/1984-crt-contrast.conf --exit-after=5
- git diff --check -- src/config.c src/config.h src/display.c src/display.h src/main.c src/overlay.c