### PR TITLE
Show LED hover labels

### DIFF
--- a/src/leds.c
+++ b/src/leds.c
@@ -1,5 +1,6 @@
 #include "leds.h"
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 typedef struct {
@@ -36,6 +37,96 @@ static const LedPalette palette_m4_net   = { 70, 70, 70,  240, 240, 240 };
 static bool   g_enabled  [LED_COUNT];
 static Uint64 g_last_ms  [LED_COUNT];   /* Generic, also used for LED_USIFAC RX half */
 static Uint64 g_last_ms_b[LED_COUNT];   /* Only used for split LEDs (TX half) */
+static bool   g_mouse_inside;
+static int    g_mouse_x;
+static int    g_mouse_y;
+static bool   g_hover_active;
+static char   g_hover_label[32];
+static float  g_hover_cx;
+static float  g_hover_bar_y;
+
+static const char *led_label(LedId id) {
+    switch (id) {
+    case LED_FDC_A:   return "Disk A";
+    case LED_FDC_B:   return "Disk B";
+    case LED_IDE:     return "IDE disk";
+    case LED_USB:     return "Albireo USB";
+    case LED_SD:      return "SD card";
+    case LED_NET:     return "Net4CPC";
+    case LED_USIFAC:  return "USIfAC";
+    case LED_M4:      return "M4";
+    case LED_PRINTER: return "Printer";
+    case LED_COUNT:   break;
+    }
+    return "";
+}
+
+static int led_width(LedId id) {
+    const int led_w = 24;
+    return id == LED_M4 ? led_w * 3 / 2 : led_w;
+}
+
+static void set_hover_label(const char *label, int x, int w, int bar_y) {
+    snprintf(g_hover_label, sizeof(g_hover_label), "%s", label);
+    g_hover_cx = (float)x + (float)w * 0.5f;
+    g_hover_bar_y = (float)bar_y;
+    g_hover_active = true;
+}
+
+static void update_hover(int x, int y, int w, int h) {
+    g_hover_active = false;
+    if (!g_mouse_inside)
+        return;
+    if (g_mouse_x < x || g_mouse_x >= x + w ||
+        g_mouse_y < y || g_mouse_y >= y + h)
+        return;
+
+    const int led_h = 10;
+    const int pad   = 8;
+
+    int n = 0, total_w = 0;
+    for (int i = 0; i < LED_COUNT; i++) {
+        if (!g_enabled[i]) continue;
+        total_w += led_width((LedId)i);
+        n++;
+    }
+    if (n == 0)
+        return;
+    total_w += (n - 1) * pad;
+
+    int cx = x + (w - total_w) / 2;
+    int cy = y + (h - led_h) / 2;
+    if (g_mouse_y < cy || g_mouse_y >= cy + led_h)
+        return;
+
+    for (int i = 0; i < LED_COUNT; i++) {
+        if (!g_enabled[i]) continue;
+
+        int this_w = led_width((LedId)i);
+        if (g_mouse_x >= cx && g_mouse_x < cx + this_w) {
+            if (i == LED_M4) {
+                int seg_w = this_w / 3;
+                int seg = (g_mouse_x - cx) / seg_w;
+                if (seg < 0) seg = 0;
+                if (seg > 2) seg = 2;
+                const char *labels[3] = {
+                    "M4 power", "M4 disk", "M4 net"
+                };
+                set_hover_label(labels[seg], cx + seg * seg_w, seg_w, y);
+            } else if (i == LED_USIFAC) {
+                int half_w = this_w / 2;
+                bool tx = (g_mouse_x - cx) >= half_w;
+                set_hover_label(tx ? "USIfAC TX" : "USIfAC RX",
+                                cx + (tx ? half_w : 0), half_w, y);
+            } else {
+                set_hover_label(led_label((LedId)i), cx, this_w, y);
+            }
+            return;
+        }
+
+        cx += this_w + pad;
+    }
+}
 
 void leds_set_enabled(LedId id, bool enabled) {
     if ((unsigned)id < LED_COUNT) g_enabled[id] = enabled;
@@ -53,6 +144,14 @@ void leds_ping_split(LedId id, bool tx) {
 void leds_ping_m4_disk(void) { g_last_ms  [LED_M4] = SDL_GetTicks(); }
 void leds_ping_m4_net (void) { g_last_ms_b[LED_M4] = SDL_GetTicks(); }
 
+void leds_set_mouse_position(int x, int y, bool inside) {
+    g_mouse_x = x;
+    g_mouse_y = y;
+    g_mouse_inside = inside;
+    if (!inside)
+        g_hover_active = false;
+}
+
 void leds_render(SDL_Renderer *r, int x, int y, int w, int h) {
     /* Bar background */
     SDL_SetRenderDrawColor(r, 18, 18, 18, 255);
@@ -65,7 +164,7 @@ void leds_render(SDL_Renderer *r, int x, int y, int w, int h) {
     SDL_RenderFillRect(r, &line);
 
     const int led_w    = 24;
-    const int led_w_m4 = led_w * 3 / 2;     /* M4 is 1.5× wide */
+    const int led_w_m4 = led_width(LED_M4); /* M4 is 1.5× wide */
     const int led_h    = 10;
     const int pad      = 8;
 
@@ -77,7 +176,10 @@ void leds_render(SDL_Renderer *r, int x, int y, int w, int h) {
         total_w += (i == LED_M4) ? led_w_m4 : led_w;
         n++;
     }
-    if (n == 0) return;
+    if (n == 0) {
+        g_hover_active = false;
+        return;
+    }
     total_w += (n - 1) * pad;
 
     int       cx = x + (w - total_w) / 2;
@@ -87,7 +189,7 @@ void leds_render(SDL_Renderer *r, int x, int y, int w, int h) {
     for (int i = 0; i < LED_COUNT; i++) {
         if (!g_enabled[i]) continue;
 
-        const int this_w = (i == LED_M4) ? led_w_m4 : led_w;
+        const int this_w = led_width((LedId)i);
         SDL_FRect led = { (float)cx, (float)cy, (float)this_w, (float)led_h };
 
         if (i == LED_M4) {
@@ -155,4 +257,35 @@ void leds_render(SDL_Renderer *r, int x, int y, int w, int h) {
 
         cx += this_w + pad;
     }
+
+    update_hover(x, y, w, h);
+}
+
+void leds_render_hover(SDL_Renderer *r, int window_w, int window_h) {
+    (void)window_h;
+    if (!g_hover_active || !g_hover_label[0])
+        return;
+
+    const int font_w = SDL_DEBUG_TEXT_FONT_CHARACTER_SIZE;
+    const int font_h = SDL_DEBUG_TEXT_FONT_CHARACTER_SIZE;
+    int text_w = (int)strlen(g_hover_label) * font_w;
+    float box_w = (float)(text_w + 12);
+    float box_h = (float)(font_h + 8);
+    float box_x = g_hover_cx - box_w * 0.5f;
+    float box_y = g_hover_bar_y - box_h - 2.0f;
+
+    if (box_x < 2.0f) box_x = 2.0f;
+    if (box_x + box_w > (float)window_w - 2.0f)
+        box_x = (float)window_w - box_w - 2.0f;
+    if (box_y < 2.0f) box_y = 2.0f;
+
+    SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_BLEND);
+    SDL_SetRenderDrawColor(r, 0, 0, 0, 220);
+    SDL_FRect bg = { box_x, box_y, box_w, box_h };
+    SDL_RenderFillRect(r, &bg);
+
+    SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_NONE);
+    SDL_SetRenderDrawColor(r, 230, 230, 230, 255);
+    SDL_RenderRect(r, &bg);
+    SDL_RenderDebugText(r, box_x + 6.0f, box_y + 4.0f, g_hover_label);
 }

--- a/src/leds.h
+++ b/src/leds.h
@@ -46,6 +46,14 @@ void leds_ping_split(LedId id, bool tx);
 void leds_ping_m4_disk(void);
 void leds_ping_m4_net(void);
 
+/* Track mouse hover over the in-window LED bar. Coordinates are window
+ * pixels. Pass inside=false on window leave/capture to clear the tooltip. */
+void leds_set_mouse_position(int x, int y, bool inside);
+
 /* Render the LED bar across (x,y,w,h). The caller has already cleared the
  * renderer and drawn the CPC screen above this rect. */
 void leds_render(SDL_Renderer *r, int x, int y, int w, int h);
+
+/* Render the active hover label, if any. Call after other bottom UI strips so
+ * the tooltip is not covered. */
+void leds_render_hover(SDL_Renderer *r, int window_w, int window_h);

--- a/src/main.c
+++ b/src/main.c
@@ -804,6 +804,7 @@ int main(int argc, char *argv[]) {
 
     bool fullscreen     = cfg.fullscreen;
     bool mouse_captured = false;
+    SDL_WindowID display_window_id = SDL_GetWindowID(cpc.display.window);
     display_set_smoothing(&cpc.display, cfg.fullscreen_smoothing);
     display_set_crt(&cpc.display, cfg.real_crt, cfg.crt_scanlines,
                     cfg.crt_brightness, cfg.crt_contrast);
@@ -908,8 +909,29 @@ int main(int argc, char *argv[]) {
                 continue;
             }
 
+            if (!mouse_captured) {
+                if (ev.type == SDL_EVENT_MOUSE_MOTION &&
+                    ev.motion.windowID == display_window_id) {
+                    leds_set_mouse_position((int)ev.motion.x,
+                                            (int)ev.motion.y, true);
+                } else if ((ev.type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
+                            ev.type == SDL_EVENT_MOUSE_BUTTON_UP) &&
+                           ev.button.windowID == display_window_id) {
+                    leds_set_mouse_position((int)ev.button.x,
+                                            (int)ev.button.y, true);
+                } else if (ev.type == SDL_EVENT_WINDOW_MOUSE_LEAVE &&
+                           ev.window.windowID == display_window_id) {
+                    leds_set_mouse_position(0, 0, false);
+                }
+            }
+
             /* Mouse events when captured — route to CPC mouse state, skip other handlers */
             if (mouse_captured) {
+                if (ev.type == SDL_EVENT_MOUSE_MOTION ||
+                    ev.type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
+                    ev.type == SDL_EVENT_MOUSE_BUTTON_UP ||
+                    ev.type == SDL_EVENT_WINDOW_MOUSE_LEAVE)
+                    leds_set_mouse_position(0, 0, false);
                 if (ev.type == SDL_EVENT_MOUSE_MOTION) {
                     if (cpc.symbiface_mouse)
                         mouse_move(&cpc.mouse, (int)ev.motion.xrel, (int)ev.motion.yrel);
@@ -955,6 +977,7 @@ int main(int argc, char *argv[]) {
                 ev.button.windowID == SDL_GetWindowID(cpc.display.window)) {
                 set_mouse_capture(cpc.display.window, true,
                                   &mouse_captured, cpc.model);
+                leds_set_mouse_position(0, 0, false);
                 int btn = (ev.button.button == SDL_BUTTON_LEFT)   ? 0 :
                           (ev.button.button == SDL_BUTTON_RIGHT)  ? 1 :
                           (ev.button.button == SDL_BUTTON_MIDDLE) ? 2 : -1;
@@ -1347,6 +1370,11 @@ int main(int argc, char *argv[]) {
             /* F-key hints: light grey, drawn right after the model string. */
             SDL_SetRenderDrawColor(cpc.display.renderer, 0xE0, 0xE0, 0xE0, 255);
             SDL_RenderDebugText(cpc.display.renderer, keys_x, text_y, keys);
+        }
+        {
+            int ww, wh;
+            SDL_GetWindowSize(cpc.display.window, &ww, &wh);
+            leds_render_hover(cpc.display.renderer, ww, wh);
         }
         display_flip(&cpc.display);
         monitor_render(monitor);


### PR DESCRIPTION
Closes #191.

Adds hover tooltips for the bottom LED strip, including split labels for multi-function LEDs such as M4 and USIfAC.

Tests:
- CCACHE_DISABLE=1 make -j$(nproc)
- make -C tests check
- SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy ./1984 --config=/dev/null --exit-after=5
- git diff --check -- src/leds.c src/leds.h src/main.c