### PR TITLE
On-screen toast notifications + Advanced toggle (#190)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,6 +41,7 @@ dist_man1_MANS = 1984.1
 	src/symbos_trace.c \
 	src/mouse.c \
 	src/n4c_stack.c \
+	src/notify.c \
 	src/snapshot.c \
 	src/tap.c \
 	src/tape.c \
@@ -71,6 +72,7 @@ noinst_HEADERS = \
 	src/mouse.h \
 	src/net4cpc.h \
 	src/n4c_stack.h \
+	src/notify.h \
 	src/overlay.h \
 	src/tap.h \
 	src/paste.h \

--- a/Makefile.in
+++ b/Makefile.in
@@ -136,9 +136,9 @@ am_1984_OBJECTS = src/1984-config.$(OBJEXT) src/1984-cpc.$(OBJEXT) \
 	src/1984-host_mount.$(OBJEXT) src/1984-leds.$(OBJEXT) \
 	src/1984-m4.$(OBJEXT) src/1984-symbnet.$(OBJEXT) \
 	src/1984-symbos_trace.$(OBJEXT) src/1984-mouse.$(OBJEXT) \
-	src/1984-n4c_stack.$(OBJEXT) src/1984-snapshot.$(OBJEXT) \
-	src/1984-tap.$(OBJEXT) src/1984-tape.$(OBJEXT) \
-	src/1984-z80.$(OBJEXT)
+	src/1984-n4c_stack.$(OBJEXT) src/1984-notify.$(OBJEXT) \
+	src/1984-snapshot.$(OBJEXT) src/1984-tap.$(OBJEXT) \
+	src/1984-tape.$(OBJEXT) src/1984-z80.$(OBJEXT)
 1984_OBJECTS = $(am_1984_OBJECTS)
 am__DEPENDENCIES_1 =
 1984_LINK = $(CCLD) $(1984_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) \
@@ -170,10 +170,11 @@ am__depfiles_remade = src/$(DEPDIR)/1984-ch376.Po \
 	src/$(DEPDIR)/1984-main.Po src/$(DEPDIR)/1984-mem.Po \
 	src/$(DEPDIR)/1984-monitor.Po src/$(DEPDIR)/1984-mouse.Po \
 	src/$(DEPDIR)/1984-n4c_stack.Po src/$(DEPDIR)/1984-net4cpc.Po \
-	src/$(DEPDIR)/1984-overlay.Po src/$(DEPDIR)/1984-paste.Po \
-	src/$(DEPDIR)/1984-perryfi.Po src/$(DEPDIR)/1984-ppi.Po \
-	src/$(DEPDIR)/1984-printer.Po src/$(DEPDIR)/1984-psg.Po \
-	src/$(DEPDIR)/1984-rtc.Po src/$(DEPDIR)/1984-screen_text.Po \
+	src/$(DEPDIR)/1984-notify.Po src/$(DEPDIR)/1984-overlay.Po \
+	src/$(DEPDIR)/1984-paste.Po src/$(DEPDIR)/1984-perryfi.Po \
+	src/$(DEPDIR)/1984-ppi.Po src/$(DEPDIR)/1984-printer.Po \
+	src/$(DEPDIR)/1984-psg.Po src/$(DEPDIR)/1984-rtc.Po \
+	src/$(DEPDIR)/1984-screen_text.Po \
 	src/$(DEPDIR)/1984-snapshot.Po src/$(DEPDIR)/1984-symbnet.Po \
 	src/$(DEPDIR)/1984-symbols.Po \
 	src/$(DEPDIR)/1984-symbos_trace.Po src/$(DEPDIR)/1984-tap.Po \
@@ -438,6 +439,7 @@ dist_man1_MANS = 1984.1
 	src/symbos_trace.c \
 	src/mouse.c \
 	src/n4c_stack.c \
+	src/notify.c \
 	src/snapshot.c \
 	src/tap.c \
 	src/tape.c \
@@ -468,6 +470,7 @@ noinst_HEADERS = \
 	src/mouse.h \
 	src/net4cpc.h \
 	src/n4c_stack.h \
+	src/notify.h \
 	src/overlay.h \
 	src/tap.h \
 	src/paste.h \
@@ -699,6 +702,8 @@ src/1984-mouse.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-n4c_stack.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
+src/1984-notify.$(OBJEXT): src/$(am__dirstamp) \
+	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-snapshot.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-tap.$(OBJEXT): src/$(am__dirstamp) \
@@ -742,6 +747,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-mouse.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-n4c_stack.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-net4cpc.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-notify.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-overlay.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-paste.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-perryfi.Po@am__quote@ # am--include-marker
@@ -1300,6 +1306,20 @@ src/1984-n4c_stack.obj: src/n4c_stack.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/n4c_stack.c' object='src/1984-n4c_stack.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-n4c_stack.obj `if test -f 'src/n4c_stack.c'; then $(CYGPATH_W) 'src/n4c_stack.c'; else $(CYGPATH_W) '$(srcdir)/src/n4c_stack.c'; fi`
+
+src/1984-notify.o: src/notify.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-notify.o -MD -MP -MF src/$(DEPDIR)/1984-notify.Tpo -c -o src/1984-notify.o `test -f 'src/notify.c' || echo '$(srcdir)/'`src/notify.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/1984-notify.Tpo src/$(DEPDIR)/1984-notify.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/notify.c' object='src/1984-notify.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-notify.o `test -f 'src/notify.c' || echo '$(srcdir)/'`src/notify.c
+
+src/1984-notify.obj: src/notify.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-notify.obj -MD -MP -MF src/$(DEPDIR)/1984-notify.Tpo -c -o src/1984-notify.obj `if test -f 'src/notify.c'; then $(CYGPATH_W) 'src/notify.c'; else $(CYGPATH_W) '$(srcdir)/src/notify.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/1984-notify.Tpo src/$(DEPDIR)/1984-notify.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/notify.c' object='src/1984-notify.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-notify.obj `if test -f 'src/notify.c'; then $(CYGPATH_W) 'src/notify.c'; else $(CYGPATH_W) '$(srcdir)/src/notify.c'; fi`
 
 src/1984-snapshot.o: src/snapshot.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-snapshot.o -MD -MP -MF src/$(DEPDIR)/1984-snapshot.Tpo -c -o src/1984-snapshot.o `test -f 'src/snapshot.c' || echo '$(srcdir)/'`src/snapshot.c
@@ -1914,6 +1934,7 @@ distclean: distclean-am
 	-rm -f src/$(DEPDIR)/1984-mouse.Po
 	-rm -f src/$(DEPDIR)/1984-n4c_stack.Po
 	-rm -f src/$(DEPDIR)/1984-net4cpc.Po
+	-rm -f src/$(DEPDIR)/1984-notify.Po
 	-rm -f src/$(DEPDIR)/1984-overlay.Po
 	-rm -f src/$(DEPDIR)/1984-paste.Po
 	-rm -f src/$(DEPDIR)/1984-perryfi.Po
@@ -2006,6 +2027,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f src/$(DEPDIR)/1984-mouse.Po
 	-rm -f src/$(DEPDIR)/1984-n4c_stack.Po
 	-rm -f src/$(DEPDIR)/1984-net4cpc.Po
+	-rm -f src/$(DEPDIR)/1984-notify.Po
 	-rm -f src/$(DEPDIR)/1984-overlay.Po
 	-rm -f src/$(DEPDIR)/1984-paste.Po
 	-rm -f src/$(DEPDIR)/1984-perryfi.Po

--- a/src/config.c
+++ b/src/config.c
@@ -145,6 +145,7 @@ void config_defaults(Config *cfg) {
     cfg->perryfi = false;
     cfg->audio_volume    = 80;
     cfg->audio_stereo_sep = 0;
+    cfg->notifications   = NOTIFY_MODE_SCREEN;
     config_set_model(cfg, MODEL_6128);  /* sets model, memory, OS, BASIC, AMSDOS */
 }
 
@@ -319,6 +320,9 @@ static void config_create_default(const char *path) {
         "# text capture, etc.). Off by default; when off, none of the\n"
         "# debug machinery runs and ONE_K_* trace env vars are no-ops.\n"
         "debug=false\n"
+        "# On-screen notifications: screen=fading bottom-left toast,\n"
+        "# console=stderr only, off=silent.\n"
+        "notifications=screen\n"
     );
 
     fclose(f);
@@ -587,6 +591,11 @@ int config_load_from(Config *cfg, const char *path_override) {
                 bool b;
                 if (parse_bool(val, &b)) cfg->debug = b;
                 else { fprintf(stderr, "1984.conf:%d: debug must be true/false\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "notifications")) {
+                if      (!strcasecmp(val, "screen"))  cfg->notifications = NOTIFY_MODE_SCREEN;
+                else if (!strcasecmp(val, "console")) cfg->notifications = NOTIFY_MODE_CONSOLE;
+                else if (!strcasecmp(val, "off"))     cfg->notifications = NOTIFY_MODE_OFF;
+                else { fprintf(stderr, "1984.conf:%d: notifications must be screen/console/off\n", lineno); rc = -1; }
             } else if (!strcmp(key, "last_dir")) {
                 if (val[0]) expand_path(val, cfg->last_dir, sizeof(cfg->last_dir));
             }
@@ -734,6 +743,7 @@ int config_save(const Config *cfg) {
         "[advanced]\n"
         "tinker=%s\n"
         "debug=%s\n"
+        "notifications=%s\n"
         "last_dir=%s\n",
         cfg->disk_a,
         cfg->disk_b,
@@ -780,6 +790,8 @@ int config_save(const Config *cfg) {
         cfg->audio_stereo_sep,
         cfg->tinker     ? "true" : "false",
         cfg->debug      ? "true" : "false",
+        cfg->notifications == NOTIFY_MODE_SCREEN  ? "screen"  :
+        cfg->notifications == NOTIFY_MODE_CONSOLE ? "console" : "off",
         cfg->last_dir
     );
 

--- a/src/config.h
+++ b/src/config.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <stdbool.h>
 #include "cpc.h"
+#include "notify.h"   /* NotifyMode */
 
 /* Re-declared here because including printer.h pulls in <limits.h>
  * and we want config.h to stay narrow. PrintSink: see src/printer.h. */
@@ -138,6 +139,7 @@ typedef struct {
 
     /* [advanced] */
     bool tinker;             /* enable Advanced overlay tab with low-level toggles */
+    NotifyMode notifications; /* screen / console / off; default screen */
     bool debug;              /* enable debug machinery (env-var traces, panic
                               * dumps, text capture). Off by default; when off,
                               * setting ONE_K_TRACE_* / ONE_K_CAP_TEXT / etc.

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,7 @@
 #include <strings.h>     /* strcasecmp */
 #include "config.h"
 #include "overlay.h"
+#include "notify.h"
 #include "host_mount.h"
 #include "cpc.h"
 #include "mem.h"
@@ -619,6 +620,8 @@ int main(int argc, char *argv[]) {
     ga_set_monochrome(&cpc.ga, cfg.monochrome);
     psg_set_volume(&cpc.psg, cfg.audio_volume);
     psg_set_stereo(&cpc.psg, cfg.audio_stereo_sep);
+    notify_init();
+    notify_set_mode(cfg.notifications);
     cpc.mem.ram_size    = cfg.memory_kb * 1024;
     cpc.mx4             = cfg.mx4;
     cpc.net4cpc         = cfg.net4cpc;
@@ -1297,6 +1300,7 @@ int main(int argc, char *argv[]) {
         }
         prev_paused = cpc.paused;
         overlay_render(&overlay, cpc.display.renderer);
+        notify_tick(20);   /* 50 Hz frame => 20 ms per displayed frame */
         if (cpc.paused)
             display_draw_paused_label(&cpc.display);
         /* Debug-mode FPS overlay (bottom-left, just above the LED bar).
@@ -1376,6 +1380,7 @@ int main(int argc, char *argv[]) {
             SDL_GetWindowSize(cpc.display.window, &ww, &wh);
             leds_render_hover(cpc.display.renderer, ww, wh);
         }
+        notify_render(cpc.display.renderer);
         display_flip(&cpc.display);
         monitor_render(monitor);
 

--- a/src/notify.c
+++ b/src/notify.c
@@ -30,6 +30,12 @@ typedef struct {
 static NotifyEntry g_slots[NOTIFY_MAX];
 static NotifyMode  g_mode = NOTIFY_MODE_SCREEN;
 
+/* Debug master switch (defined in cpc.c). Forward-declared here, like z80.c,
+ * to avoid pulling cpc.h into this otherwise self-contained module. When
+ * debug is live we also echo screen toasts to stderr so the log trail
+ * survives past the transient on-screen panel. */
+extern int g_debug_enabled;
+
 void notify_init(void) {
     for (int i = 0; i < NOTIFY_MAX; i++) g_slots[i].age_ms = -1;
     g_mode = NOTIFY_MODE_SCREEN;
@@ -57,6 +63,12 @@ void notify_post(const char *fmt, ...) {
         fprintf(stderr, "%s\n", buf);
         return;
     }
+
+    /* SCREEN mode: queue the toast, and additionally mirror to stderr when
+     * the debug master switch is on so the message isn't lost once the
+     * panel fades. */
+    if (g_debug_enabled)
+        fprintf(stderr, "%s\n", buf);
 
     int slot = -1;
     for (int i = 0; i < NOTIFY_MAX; i++) {

--- a/src/notify.c
+++ b/src/notify.c
@@ -1,0 +1,132 @@
+#include "notify.h"
+
+#include <SDL3/SDL.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Logical render scale — must match overlay.c's SCALE so toasts share the
+ * 1.5x logical-pixel coordinate space the rest of the on-screen UI uses. */
+#define NOTIFY_SCALE     1.5f
+
+#define NOTIFY_MAX       5
+#define NOTIFY_TEXT_MAX  96
+#define NOTIFY_TTL_MS    3500
+#define NOTIFY_FADE_MS   600
+#define LINE_H           14
+#define PAD_X            8
+#define PAD_Y            4
+#define MARGIN           10
+/* Clear the persistent bottom status bar (LED bar 24px + hint strip 16px =
+ * 40 window px) so toasts stack just above it. In 1.5x logical space that is
+ * 40 / 1.5 ~= 27px; round up and add MARGIN of breathing room. */
+#define BOTTOM_INSET     (28 + MARGIN)
+
+typedef struct {
+    char text[NOTIFY_TEXT_MAX];
+    int  age_ms;          /* -1 = empty slot */
+} NotifyEntry;
+
+static NotifyEntry g_slots[NOTIFY_MAX];
+static NotifyMode  g_mode = NOTIFY_MODE_SCREEN;
+
+void notify_init(void) {
+    for (int i = 0; i < NOTIFY_MAX; i++) g_slots[i].age_ms = -1;
+    g_mode = NOTIFY_MODE_SCREEN;
+}
+
+void notify_set_mode(NotifyMode mode) { g_mode = mode; }
+
+static int oldest_slot(void) {
+    int best = 0;
+    for (int i = 1; i < NOTIFY_MAX; i++)
+        if (g_slots[i].age_ms > g_slots[best].age_ms) best = i;
+    return best;
+}
+
+void notify_post(const char *fmt, ...) {
+    if (g_mode == NOTIFY_MODE_OFF) return;
+
+    char buf[NOTIFY_TEXT_MAX];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+
+    if (g_mode == NOTIFY_MODE_CONSOLE) {
+        fprintf(stderr, "%s\n", buf);
+        return;
+    }
+
+    int slot = -1;
+    for (int i = 0; i < NOTIFY_MAX; i++) {
+        if (g_slots[i].age_ms < 0) { slot = i; break; }
+    }
+    if (slot < 0) slot = oldest_slot();
+
+    snprintf(g_slots[slot].text, NOTIFY_TEXT_MAX, "%s", buf);
+    g_slots[slot].age_ms = 0;
+}
+
+void notify_tick(int dt_ms) {
+    for (int i = 0; i < NOTIFY_MAX; i++) {
+        if (g_slots[i].age_ms < 0) continue;
+        g_slots[i].age_ms += dt_ms;
+        if (g_slots[i].age_ms >= NOTIFY_TTL_MS) g_slots[i].age_ms = -1;
+    }
+}
+
+void notify_render(struct SDL_Renderer *r) {
+    if (g_mode != NOTIFY_MODE_SCREEN || !r) return;
+
+    /* Build an ordered list of active entries by age, oldest first
+     * (those are drawn highest; newest sits at the bottom). */
+    int idx[NOTIFY_MAX], n = 0;
+    for (int i = 0; i < NOTIFY_MAX; i++)
+        if (g_slots[i].age_ms >= 0) idx[n++] = i;
+    if (!n) return;
+    for (int i = 0; i < n - 1; i++)
+        for (int j = i + 1; j < n; j++)
+            if (g_slots[idx[i]].age_ms < g_slots[idx[j]].age_ms) {
+                int t = idx[i]; idx[i] = idx[j]; idx[j] = t;
+            }
+
+    /* Work in the same 1.5x logical space as overlay.c. Restore scale to
+     * 1.0 on the way out so we don't disturb the next frame's rendering. */
+    int rw, rh;
+    SDL_GetRenderOutputSize(r, &rw, &rh);
+    int win_h = (int)(rh / NOTIFY_SCALE);
+    SDL_SetRenderScale(r, NOTIFY_SCALE, NOTIFY_SCALE);
+
+    SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_BLEND);
+
+    int y = win_h - BOTTOM_INSET - LINE_H - PAD_Y;
+    for (int k = n - 1; k >= 0; k--) {
+        NotifyEntry *e = &g_slots[idx[k]];
+        int fade_in = NOTIFY_TTL_MS - NOTIFY_FADE_MS;
+        Uint8 alpha = 255;
+        if (e->age_ms > fade_in) {
+            int t = e->age_ms - fade_in;
+            int a = 255 - (255 * t) / NOTIFY_FADE_MS;
+            if (a < 0) a = 0;
+            alpha = (Uint8)a;
+        }
+
+        int tw = (int)strlen(e->text) * 8;
+        SDL_FRect bg = { (float)MARGIN,
+                         (float)y,
+                         (float)(tw + 2 * PAD_X),
+                         (float)(LINE_H + 2 * PAD_Y) };
+        SDL_SetRenderDrawColor(r, 0, 0, 0, (Uint8)((alpha * 180) / 255));
+        SDL_RenderFillRect(r, &bg);
+
+        SDL_SetRenderDrawColor(r, 255, 220, 120, alpha);
+        SDL_RenderDebugText(r, (float)(MARGIN + PAD_X),
+                            (float)(y + PAD_Y + 2), e->text);
+
+        y -= (LINE_H + 2 * PAD_Y + 4);
+        if (y < 0) break;
+    }
+
+    SDL_SetRenderScale(r, 1.0f, 1.0f);
+}

--- a/src/notify.h
+++ b/src/notify.h
@@ -1,0 +1,27 @@
+#pragma once
+
+struct SDL_Renderer;
+
+/* Tri-state notification sink for short informational messages (USIfAC
+ * PTY/TCP readiness, client connect/disconnect, etc.). Toggle via
+ * F9 -> Advanced "Notifications".
+ *
+ *   NOTIFY_MODE_SCREEN  - fading bottom-left "smoked" toast overlay (default)
+ *   NOTIFY_MODE_CONSOLE - stderr only (legacy behaviour)
+ *   NOTIFY_MODE_OFF     - silent
+ *
+ * Single global singleton - call-sites need no context handle. */
+
+typedef enum {
+    NOTIFY_MODE_OFF = 0,
+    NOTIFY_MODE_SCREEN,
+    NOTIFY_MODE_CONSOLE,
+} NotifyMode;
+
+void notify_init(void);
+void notify_set_mode(NotifyMode mode);
+
+void notify_post(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+
+void notify_tick(int dt_ms);
+void notify_render(struct SDL_Renderer *r);

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -7,6 +7,7 @@
 #include "snapshot.h"
 #include "webmcap.h"   /* WEBMCAP_SUPPORTED */
 #include "leds.h"
+#include "notify.h"
 #include <string.h>
 #include <stdio.h>
 #include <libgen.h>
@@ -35,7 +36,7 @@ static const int sec_x[OV_SEC_COUNT] = { 8, 80, 160, 248 };
  * "External Tape" toggle, only meaningful on the 6128 since the 464 has
  * the cassette deck built in). Other sections are fixed.
  * The Advanced tab (OV_TINKER) is hidden unless cfg->tinker is enabled. */
-static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 14, 15 };
+static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 14, 16 };
 
 static int ov_section_rows(const Overlay *ov, OvSection s) {
     if (s == OV_GENERAL && ov->cfg->model != MODEL_464) return 8;
@@ -550,6 +551,12 @@ static void item_text(const Overlay *ov, int row,
                 snprintf(val, vsz, "ABC %d/255", ov->cfg->audio_stereo_sep);
             break;
         case 14:
+            snprintf(lbl, lsz, "Notifications");
+            snprintf(val, vsz, "%s",
+                     ov->cfg->notifications == NOTIFY_MODE_SCREEN  ? "screen"  :
+                     ov->cfg->notifications == NOTIFY_MODE_CONSOLE ? "console" : "off");
+            break;
+        case 15:
             snprintf(lbl, lsz, "Version");
             snprintf(val, vsz, "%s (commit %s)", PACKAGE_VERSION, PROG_GIT_COMMIT);
             *readonly = true;
@@ -1229,6 +1236,13 @@ static void activate_item(Overlay *ov) {
                 ov->cfg->audio_stereo_sep == 0     ? 128 :
                 ov->cfg->audio_stereo_sep == 128   ? 255 : 0;
             if (ov->cpc) psg_set_stereo(&ov->cpc->psg, ov->cfg->audio_stereo_sep);
+            ov->dirty = true;
+            break;
+        case 14:
+            /* Notifications: cycle screen -> console -> off. */
+            ov->cfg->notifications =
+                (NotifyMode)((ov->cfg->notifications + 1) % 3);
+            notify_set_mode(ov->cfg->notifications);
             ov->dirty = true;
             break;
         }

--- a/src/usifac.c
+++ b/src/usifac.c
@@ -6,6 +6,7 @@
 #include "usifac.h"
 #include "perryfi.h"
 #include "leds.h"
+#include "notify.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -110,10 +111,10 @@ static int open_pty(USIfAC *u, const char *link_path) {
     }
 
     if (u->pty_link[0])
-        fprintf(stderr, "usifac: PTY ready at %s (alias %s)\n",
-                u->pty_slave, u->pty_link);
+        notify_post("USIfAC: PTY ready at %s (alias %s)",
+                    u->pty_slave, u->pty_link);
     else
-        fprintf(stderr, "usifac: PTY ready at %s\n", u->pty_slave);
+        notify_post("USIfAC: PTY ready at %s", u->pty_slave);
     return 0;
 }
 
@@ -141,7 +142,7 @@ static int open_tcp(USIfAC *u, int port) {
 
     u->tcp_listen = fd;
     u->tcp_port   = port;
-    fprintf(stderr, "usifac: TCP listening on localhost:%d\n", port);
+    notify_post("USIfAC: TCP listening on localhost:%d", port);
     return 0;
 }
 
@@ -246,7 +247,7 @@ static void poll_tcp(USIfAC *u) {
             int one = 1;
             setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
             u->tcp_client = fd;
-            fprintf(stderr, "usifac: TCP client connected\n");
+            notify_post("USIfAC: TCP client connected");
         }
     }
 
@@ -274,7 +275,7 @@ static void poll_tcp(USIfAC *u) {
              * the accept loop. */
             close(u->tcp_client);
             u->tcp_client = -1;
-            fprintf(stderr, "usifac: TCP client disconnected\n");
+            notify_post("USIfAC: TCP client disconnected");
             return;
         }
         leds_ping_split(LED_USIFAC, true);   /* TX (green) — CPC → host */


### PR DESCRIPTION
Closes #190.

## Summary

Replicates the 1985 toast-notification feature: a fading **smoked panel**
anchored **bottom-left** that surfaces short informational messages
(USIfAC PTY/TCP readiness, client connect/disconnect) for ~3.5 s, then
fades out. Previously these only went to stderr, invisible to anyone not
watching a terminal.

- **`src/notify.{c,h}`** — single global singleton, 5-slot ring, 3.5 s TTL
  with a 0.6 s alpha fade-out. Drawn in overlay.c's 1.5× logical-pixel
  space and inset above the persistent bottom LED/hint status bar so it
  never collides with it. Tri-state mode: `screen` / `console` / `off`.
- **`main.c`** — `notify_init` + `notify_set_mode` after config load,
  `notify_tick(20)` per displayed frame (50 Hz → 20 ms), `notify_render()`
  just before the buffer flip so toasts sit on top of everything.
- **F9 ▸ Advanced ▸ "Notifications"** row cycles `screen → console → off`
  live; persists as `notifications` in `1984.conf` (default `screen`).
- **`usifac.c`** — PTY-ready, TCP-listening, and client connect/disconnect
  messages switched from `fprintf(stderr)` to `notify_post()`.

## Test plan
- [x] Build clean inside distrobox (`make -s`, no new warnings)
- [x] Headless boot + screenshot succeeds with the new per-frame render path
- [x] Console mode emits `USIfAC: TCP listening on localhost:NNNN` to stderr
- [x] Xvfb+x11 capture confirms the toast renders in a smoked panel at
      bottom-left, above the LED/hint bar, with amber text (see below)
- [ ] **Manual check**: cycle the Advanced "Notifications" row through
      screen → console → off and confirm each mode behaves; confirm a
      real USIfAC connect/disconnect toast appears and fades during use

🤖 Generated with [Claude Code](https://claude.com/claude-code)