### PR TITLE
Fix CP/M Plus boot ROM probe

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -175,7 +175,11 @@ u8 mem_read(Mem *m, u16 addr) {
             return m->rom_basic[addr - 0xC000];
         if (slot == 7 && m->amsdos_present)
             return m->rom_amsdos[addr - 0xC000];
-        return 0xFF;
+        /* On a stock CPC, selecting an unpopulated expansion ROM leaves the
+         * internal BASIC ROM visible. Caprice32 mirrors this by falling back
+         * to pbROMhi when memmap_ROM[slot] is null. The CP/M Plus loader
+         * probes ROM 0xFF and expects to see BASIC's header there. */
+        return m->rom_basic[addr - 0xC000];
     }
 
     /* RAM read — apply banking for all regions when active */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@ CC ?= cc
 CFLAGS ?= -O2
 CPPFLAGS ?=
 
-TESTS = test-gate-array test-crtc test-z80 test-psg
+TESTS = test-gate-array test-crtc test-z80 test-psg test-mem
 
 .PHONY: all check clean
 
@@ -24,11 +24,16 @@ test-psg: test_psg.c ../src/psg.c ../src/psg.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -std=c11 -Wall -Wextra -I../src \
 		test_psg.c ../src/psg.c -o $@
 
+test-mem: test_mem.c ../src/mem.c ../src/mem.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) -std=c11 -Wall -Wextra -I../src \
+		test_mem.c ../src/mem.c -o $@
+
 check: $(TESTS)
 	./test-gate-array
 	./test-crtc
 	./test-z80
 	./test-psg
+	./test-mem
 
 clean:
 	rm -f $(TESTS)

--- a/tests/test_mem.c
+++ b/tests/test_mem.c
@@ -1,0 +1,70 @@
+#include "mem.h"
+
+#include <assert.h>
+#include <string.h>
+
+static void seed_basic_header(Mem *mem) {
+    memset(mem->rom_basic, 0xA5, sizeof(mem->rom_basic));
+    mem->rom_basic[0] = 0x80;
+    mem->rom_basic[1] = 0x01;
+    mem->rom_basic[2] = 0x02;
+}
+
+static void test_absent_upper_rom_falls_back_to_basic(void) {
+    Mem mem;
+    mem_init(&mem);
+    seed_basic_header(&mem);
+
+    mem.upper_rom_enabled = true;
+    mem.upper_rom_select = 0xFF;
+
+    assert(mem_read(&mem, 0xC000) == 0x80);
+    assert(mem_read(&mem, 0xC001) == 0x01);
+    assert(mem_read(&mem, 0xC002) == 0x02);
+}
+
+static void test_present_extension_rom_wins(void) {
+    Mem mem;
+    mem_init(&mem);
+    seed_basic_header(&mem);
+
+    mem.upper_rom_enabled = true;
+    mem.upper_rom_select = 5;
+    mem.rom_ext_present[5] = true;
+    mem.rom_ext[5][0] = 0x42;
+
+    assert(mem_read(&mem, 0xC000) == 0x42);
+}
+
+static void test_amsdos_slot_still_wins(void) {
+    Mem mem;
+    mem_init(&mem);
+    seed_basic_header(&mem);
+
+    mem.upper_rom_enabled = true;
+    mem.upper_rom_select = 7;
+    mem.amsdos_present = true;
+    mem.rom_amsdos[0] = 0x01;
+
+    assert(mem_read(&mem, 0xC000) == 0x01);
+}
+
+static void test_disabled_upper_rom_reads_ram(void) {
+    Mem mem;
+    mem_init(&mem);
+    seed_basic_header(&mem);
+
+    mem.upper_rom_enabled = false;
+    mem.upper_rom_select = 0xFF;
+    mem.ram[0xC000] = 0x55;
+
+    assert(mem_read(&mem, 0xC000) == 0x55);
+}
+
+int main(void) {
+    test_absent_upper_rom_falls_back_to_basic();
+    test_present_extension_rom_wins();
+    test_amsdos_slot_still_wins();
+    test_disabled_upper_rom_reads_ram();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- fall back to BASIC ROM when an unpopulated upper ROM slot is selected
- add mem regression coverage for absent ROM fallback, extension ROM priority, AMSDOS slot priority, and upper-ROM-disabled RAM reads

## Verification
- CCACHE_DISABLE=1 make -C tests check
- CCACHE_DISABLE=1 make -j$(nproc)
- SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy ./1984 --config=/dev/null --6128 --memory=128 --disk-a=/var/home/salvogendut/Downloads/cpmplus6128_1.dsk --paste='|cpm\n' --screenshot-at=1200:/tmp/cpm108-final.ppm --exit-after=1200

Closes #108