### PR TITLE
Add RGB sliders for Real CRT

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -133,6 +133,9 @@ void config_defaults(Config *cfg) {
     cfg->crt_scanlines = DISPLAY_CRT_SCANLINES_DEFAULT;
     cfg->crt_brightness = DISPLAY_CRT_BRIGHTNESS_DEFAULT;
     cfg->crt_contrast = DISPLAY_CRT_CONTRAST_DEFAULT;
+    cfg->crt_red = DISPLAY_CRT_RGB_DEFAULT;
+    cfg->crt_green = DISPLAY_CRT_RGB_DEFAULT;
+    cfg->crt_blue = DISPLAY_CRT_RGB_DEFAULT;
     cfg->tinker    = false;
     cfg->debug     = false;
     snprintf(cfg->net4cpc_tap_host_ip,    sizeof(cfg->net4cpc_tap_host_ip),    "10.0.0.1");
@@ -298,10 +301,14 @@ static void config_create_default(const char *path) {
         "fullscreen_smoothing=true\n"
         "# Lightweight CRT post-process. real_crt enables the overlay controls.\n"
         "real_crt=false\n"
-        "# Scanline opacity, 0..95. Brightness is 50..100. Contrast is 50..150.\n"
+        "# Scanline opacity, 0..95. Brightness is 50..100.\n"
+        "# Contrast and RGB channel gains are 50..150.\n"
         "crt_scanlines=35\n"
         "crt_brightness=100\n"
         "crt_contrast=100\n"
+        "crt_red=100\n"
+        "crt_green=100\n"
+        "crt_blue=100\n"
         "# Monochrome monitor tint: off | green | amber | white\n"
         "# Maps the CPC palette to shades of one phosphor colour.\n"
         "monochrome=off\n"
@@ -567,6 +574,18 @@ int config_load_from(Config *cfg, const char *path_override) {
                 int v = atoi(val);
                 if (v >= 50 && v <= 150) cfg->crt_contrast = v;
                 else { fprintf(stderr, "1984.conf:%d: crt_contrast must be 50..150\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "crt_red")) {
+                int v = atoi(val);
+                if (v >= 50 && v <= 150) cfg->crt_red = v;
+                else { fprintf(stderr, "1984.conf:%d: crt_red must be 50..150\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "crt_green")) {
+                int v = atoi(val);
+                if (v >= 50 && v <= 150) cfg->crt_green = v;
+                else { fprintf(stderr, "1984.conf:%d: crt_green must be 50..150\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "crt_blue")) {
+                int v = atoi(val);
+                if (v >= 50 && v <= 150) cfg->crt_blue = v;
+                else { fprintf(stderr, "1984.conf:%d: crt_blue must be 50..150\n", lineno); rc = -1; }
             } else if (!strcmp(key, "monochrome")) {
                 MonoMode m;
                 if (parse_mono(val, &m)) cfg->monochrome = m;
@@ -736,6 +755,9 @@ int config_save(const Config *cfg) {
         "crt_scanlines=%d\n"
         "crt_brightness=%d\n"
         "crt_contrast=%d\n"
+        "crt_red=%d\n"
+        "crt_green=%d\n"
+        "crt_blue=%d\n"
         "monochrome=%s\n\n"
         "[audio]\n"
         "audio_volume=%d\n"
@@ -785,6 +807,9 @@ int config_save(const Config *cfg) {
         cfg->crt_scanlines,
         cfg->crt_brightness,
         cfg->crt_contrast,
+        cfg->crt_red,
+        cfg->crt_green,
+        cfg->crt_blue,
         mono_to_str(cfg->monochrome),
         cfg->audio_volume,
         cfg->audio_stereo_sep,

--- a/src/config.h
+++ b/src/config.h
@@ -113,6 +113,9 @@ typedef struct {
     int  crt_scanlines;        /* scanline opacity, 0..95 */
     int  crt_brightness;       /* texture brightness, 50..100 */
     int  crt_contrast;         /* texture contrast, 50..150 */
+    int  crt_red;              /* red channel gain, 50..150 */
+    int  crt_green;            /* green channel gain, 50..150 */
+    int  crt_blue;             /* blue channel gain, 50..150 */
     MonoMode monochrome;       /* off / green / amber / white phosphor tint */
 
     /* [printer] — host-side Centronics capture (port 0xEFxx).

--- a/src/display.c
+++ b/src/display.c
@@ -9,16 +9,21 @@ static int clamp_int(int v, int lo, int hi) {
     return v;
 }
 
-static unsigned adjust_component(unsigned c, int brightness, int contrast) {
+static unsigned adjust_component(unsigned c, int brightness, int contrast,
+                                 int gain) {
     int v = 128 + (((int)c - 128) * contrast + 50) / 100;
     v = (v * brightness + 50) / 100;
+    v = (v * gain + 50) / 100;
     return (unsigned)clamp_int(v, 0, 255);
 }
 
 static const u32 *display_crt_pixels(Display *d) {
     if (!d->crt_enabled ||
         (d->crt_brightness == DISPLAY_CRT_BRIGHTNESS_DEFAULT &&
-         d->crt_contrast == DISPLAY_CRT_CONTRAST_DEFAULT))
+         d->crt_contrast == DISPLAY_CRT_CONTRAST_DEFAULT &&
+         d->crt_red == DISPLAY_CRT_RGB_DEFAULT &&
+         d->crt_green == DISPLAY_CRT_RGB_DEFAULT &&
+         d->crt_blue == DISPLAY_CRT_RGB_DEFAULT))
         return d->pixels;
 
     int n = CPC_SCREEN_W * CPC_SCREEN_H;
@@ -26,13 +31,16 @@ static const u32 *display_crt_pixels(Display *d) {
         u32 px = d->pixels[i];
         unsigned r = adjust_component((px >> 16) & 0xFF,
                                       d->crt_brightness,
-                                      d->crt_contrast);
+                                      d->crt_contrast,
+                                      d->crt_red);
         unsigned g = adjust_component((px >> 8) & 0xFF,
                                       d->crt_brightness,
-                                      d->crt_contrast);
+                                      d->crt_contrast,
+                                      d->crt_green);
         unsigned b = adjust_component(px & 0xFF,
                                       d->crt_brightness,
-                                      d->crt_contrast);
+                                      d->crt_contrast,
+                                      d->crt_blue);
         d->crt_pixels[i] = (px & 0xFF000000u) | (r << 16) | (g << 8) | b;
     }
 
@@ -74,6 +82,9 @@ int display_init(Display *d, const char *title, int scale) {
     d->crt_scanlines = DISPLAY_CRT_SCANLINES_DEFAULT;
     d->crt_brightness = DISPLAY_CRT_BRIGHTNESS_DEFAULT;
     d->crt_contrast = DISPLAY_CRT_CONTRAST_DEFAULT;
+    d->crt_red = DISPLAY_CRT_RGB_DEFAULT;
+    d->crt_green = DISPLAY_CRT_RGB_DEFAULT;
+    d->crt_blue = DISPLAY_CRT_RGB_DEFAULT;
     return 0;
 }
 
@@ -84,11 +95,14 @@ void display_set_smoothing(Display *d, bool smooth) {
 }
 
 void display_set_crt(Display *d, bool enabled, int scanlines, int brightness,
-                     int contrast) {
+                     int contrast, int red, int green, int blue) {
     d->crt_enabled = enabled;
     d->crt_scanlines = clamp_int(scanlines, 0, 95);
     d->crt_brightness = clamp_int(brightness, 50, 100);
     d->crt_contrast = clamp_int(contrast, 50, 150);
+    d->crt_red = clamp_int(red, 50, 150);
+    d->crt_green = clamp_int(green, 50, 150);
+    d->crt_blue = clamp_int(blue, 50, 150);
 }
 
 void display_destroy(Display *d) {

--- a/src/display.h
+++ b/src/display.h
@@ -19,6 +19,7 @@
 #define DISPLAY_CRT_SCANLINES_DEFAULT 35
 #define DISPLAY_CRT_BRIGHTNESS_DEFAULT 100
 #define DISPLAY_CRT_CONTRAST_DEFAULT 100
+#define DISPLAY_CRT_RGB_DEFAULT 100
 
 typedef struct {
     SDL_Window   *window;
@@ -32,6 +33,9 @@ typedef struct {
     int           crt_scanlines;
     int           crt_brightness;
     int           crt_contrast;
+    int           crt_red;
+    int           crt_green;
+    int           crt_blue;
 } Display;
 
 int  display_init(Display *d, const char *title, int scale);
@@ -46,7 +50,7 @@ void display_save_ppm(Display *d, const char *path);
 /* Switch texture scaling between linear (smooth) and nearest (sharp). */
 void display_set_smoothing(Display *d, bool smooth);
 void display_set_crt(Display *d, bool enabled, int scanlines, int brightness,
-                     int contrast);
+                     int contrast, int red, int green, int blue);
 
 /* In-place desaturate the current framebuffer (Rec. 601 luma). Used when
  * the emulator pauses so the frozen frame visibly differs from a running

--- a/src/main.c
+++ b/src/main.c
@@ -810,7 +810,8 @@ int main(int argc, char *argv[]) {
     SDL_WindowID display_window_id = SDL_GetWindowID(cpc.display.window);
     display_set_smoothing(&cpc.display, cfg.fullscreen_smoothing);
     display_set_crt(&cpc.display, cfg.real_crt, cfg.crt_scanlines,
-                    cfg.crt_brightness, cfg.crt_contrast);
+                    cfg.crt_brightness, cfg.crt_contrast,
+                    cfg.crt_red, cfg.crt_green, cfg.crt_blue);
     if (fullscreen)
         SDL_SetWindowFullscreen(cpc.display.window, true);
 

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -40,7 +40,7 @@ static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 14, 16 };
 
 static int ov_section_rows(const Overlay *ov, OvSection s) {
     if (s == OV_GENERAL && ov->cfg->model != MODEL_464) return 8;
-    if (s == OV_TINKER && ov->cfg->real_crt) return sec_row_count[s] + 3;
+    if (s == OV_TINKER && ov->cfg->real_crt) return sec_row_count[s] + 6;
     return sec_row_count[s];
 }
 
@@ -50,7 +50,10 @@ static int tinker_logical_row(const Overlay *ov, int row) {
     if (row == 2) return -1;  /* Scanlines */
     if (row == 3) return -2;  /* Brightness */
     if (row == 4) return -3;  /* Contrast */
-    if (row >= 5) return row - 3;
+    if (row == 5) return -4;  /* Red */
+    if (row == 6) return -5;  /* Green */
+    if (row == 7) return -6;  /* Blue */
+    if (row >= 8) return row - 6;
     return row;
 }
 
@@ -59,7 +62,15 @@ static void overlay_apply_crt(Overlay *ov) {
         return;
     display_set_crt(&ov->cpc->display, ov->cfg->real_crt,
                     ov->cfg->crt_scanlines, ov->cfg->crt_brightness,
-                    ov->cfg->crt_contrast);
+                    ov->cfg->crt_contrast, ov->cfg->crt_red,
+                    ov->cfg->crt_green, ov->cfg->crt_blue);
+}
+
+static int cycle_crt_percent(int v, int lo, int hi) {
+    v += 5;
+    if (v > hi)
+        v = lo;
+    return v;
 }
 
 static bool reset_tinker_crt_item(Overlay *ov) {
@@ -70,8 +81,20 @@ static bool reset_tinker_crt_item(Overlay *ov) {
     int old_scanlines = ov->cfg->crt_scanlines;
     int old_brightness = ov->cfg->crt_brightness;
     int old_contrast = ov->cfg->crt_contrast;
+    int old_red = ov->cfg->crt_red;
+    int old_green = ov->cfg->crt_green;
+    int old_blue = ov->cfg->crt_blue;
 
     switch (tinker_logical_row(ov, ov->row)) {
+    case -6:
+        ov->cfg->crt_blue = DISPLAY_CRT_RGB_DEFAULT;
+        break;
+    case -5:
+        ov->cfg->crt_green = DISPLAY_CRT_RGB_DEFAULT;
+        break;
+    case -4:
+        ov->cfg->crt_red = DISPLAY_CRT_RGB_DEFAULT;
+        break;
     case -3:
         ov->cfg->crt_contrast = DISPLAY_CRT_CONTRAST_DEFAULT;
         break;
@@ -86,6 +109,9 @@ static bool reset_tinker_crt_item(Overlay *ov) {
         ov->cfg->crt_scanlines = DISPLAY_CRT_SCANLINES_DEFAULT;
         ov->cfg->crt_brightness = DISPLAY_CRT_BRIGHTNESS_DEFAULT;
         ov->cfg->crt_contrast = DISPLAY_CRT_CONTRAST_DEFAULT;
+        ov->cfg->crt_red = DISPLAY_CRT_RGB_DEFAULT;
+        ov->cfg->crt_green = DISPLAY_CRT_RGB_DEFAULT;
+        ov->cfg->crt_blue = DISPLAY_CRT_RGB_DEFAULT;
         break;
     default:
         return false;
@@ -94,7 +120,10 @@ static bool reset_tinker_crt_item(Overlay *ov) {
     if (old_real_crt != ov->cfg->real_crt ||
         old_scanlines != ov->cfg->crt_scanlines ||
         old_brightness != ov->cfg->crt_brightness ||
-        old_contrast != ov->cfg->crt_contrast) {
+        old_contrast != ov->cfg->crt_contrast ||
+        old_red != ov->cfg->crt_red ||
+        old_green != ov->cfg->crt_green ||
+        old_blue != ov->cfg->crt_blue) {
         overlay_apply_crt(ov);
         ov->dirty = true;
     }
@@ -416,6 +445,18 @@ static void item_text(const Overlay *ov, int row,
 
     case OV_TINKER:
         switch (tinker_logical_row(ov, row)) {
+        case -6:
+            snprintf(lbl, lsz, "Blue");
+            snprintf(val, vsz, "%d%%", ov->cfg->crt_blue);
+            break;
+        case -5:
+            snprintf(lbl, lsz, "Green");
+            snprintf(val, vsz, "%d%%", ov->cfg->crt_green);
+            break;
+        case -4:
+            snprintf(lbl, lsz, "Red");
+            snprintf(val, vsz, "%d%%", ov->cfg->crt_red);
+            break;
         case -3:
             snprintf(lbl, lsz, "Contrast");
             snprintf(val, vsz, "%d%%", ov->cfg->crt_contrast);
@@ -1064,37 +1105,38 @@ static void activate_item(Overlay *ov) {
 
     case OV_TINKER:
         switch (tinker_logical_row(ov, ov->row)) {
+        case -6:
+            ov->cfg->crt_blue = cycle_crt_percent(ov->cfg->crt_blue, 50, 150);
+            overlay_apply_crt(ov);
+            ov->dirty = true;
+            break;
+        case -5:
+            ov->cfg->crt_green = cycle_crt_percent(ov->cfg->crt_green, 50, 150);
+            overlay_apply_crt(ov);
+            ov->dirty = true;
+            break;
+        case -4:
+            ov->cfg->crt_red = cycle_crt_percent(ov->cfg->crt_red, 50, 150);
+            overlay_apply_crt(ov);
+            ov->dirty = true;
+            break;
         case -3:
-            ov->cfg->crt_contrast += 5;
-            if (ov->cfg->crt_contrast > 150)
-                ov->cfg->crt_contrast = 50;
-            if (ov->cpc)
-                display_set_crt(&ov->cpc->display, ov->cfg->real_crt,
-                                ov->cfg->crt_scanlines,
-                                ov->cfg->crt_brightness,
-                                ov->cfg->crt_contrast);
+            ov->cfg->crt_contrast = cycle_crt_percent(ov->cfg->crt_contrast,
+                                                      50, 150);
+            overlay_apply_crt(ov);
             ov->dirty = true;
             break;
         case -2:
             ov->cfg->crt_brightness -= 5;
             if (ov->cfg->crt_brightness < 50)
                 ov->cfg->crt_brightness = 100;
-            if (ov->cpc)
-                display_set_crt(&ov->cpc->display, ov->cfg->real_crt,
-                                ov->cfg->crt_scanlines,
-                                ov->cfg->crt_brightness,
-                                ov->cfg->crt_contrast);
+            overlay_apply_crt(ov);
             ov->dirty = true;
             break;
         case -1:
-            ov->cfg->crt_scanlines += 5;
-            if (ov->cfg->crt_scanlines > 95)
-                ov->cfg->crt_scanlines = 0;
-            if (ov->cpc)
-                display_set_crt(&ov->cpc->display, ov->cfg->real_crt,
-                                ov->cfg->crt_scanlines,
-                                ov->cfg->crt_brightness,
-                                ov->cfg->crt_contrast);
+            ov->cfg->crt_scanlines = cycle_crt_percent(ov->cfg->crt_scanlines,
+                                                       0, 95);
+            overlay_apply_crt(ov);
             ov->dirty = true;
             break;
         case 0:
@@ -1106,11 +1148,7 @@ static void activate_item(Overlay *ov) {
             break;
         case 1:
             ov->cfg->real_crt = !ov->cfg->real_crt;
-            if (ov->cpc)
-                display_set_crt(&ov->cpc->display, ov->cfg->real_crt,
-                                ov->cfg->crt_scanlines,
-                                ov->cfg->crt_brightness,
-                                ov->cfg->crt_contrast);
+            overlay_apply_crt(ov);
             ov->dirty = true;
             break;
         case 2: {
@@ -1606,11 +1644,7 @@ bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
         }
         case SDL_SCANCODE_ESCAPE:
             *ov->cfg    = ov->saved;  /* revert */
-            if (ov->cpc)
-                display_set_crt(&ov->cpc->display, ov->cfg->real_crt,
-                                ov->cfg->crt_scanlines,
-                                ov->cfg->crt_brightness,
-                                ov->cfg->crt_contrast);
+            overlay_apply_crt(ov);
             ov->dirty   = false;
             ov->visible = false;
             break;


### PR DESCRIPTION
## Summary
- add Red, Green, and Blue gain controls under Advanced > Real CRT
- persist crt_red/crt_green/crt_blue in the display config
- apply RGB gains in the CRT post-process alongside brightness and contrast
- support DEL reset for the new RGB rows and Real CRT defaults

## Verification
- CCACHE_DISABLE=1 make -C tests check
- CCACHE_DISABLE=1 make -j$(nproc)
- SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy ./1984 --config=/tmp/issue195-crt.conf --exit-after=30

Closes #195