### PR TITLE
Add --pilot: host-PTY auto-pilot for mouse/joystick (#200)

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -34,6 +34,7 @@ Each source file maps to one hardware component:
 | `src/monitor.c` / `monitor.h` | Memory monitor / debugger — 80×25 terminal window, commands, PTY interface |
 | `src/z80dis.c` / `z80dis.h` | Z80 disassembler — standalone, no external dependencies |
 | `src/joy.c` / `joy.h` | Joystick/gamepad input — SDL gamepad + raw joystick fallback, hot-plug |
+| `src/pilot.c` / `pilot.h` | `--pilot` auto-pilot — host PTY driving the mouse pointer or CPC joystick from polar-coordinate commands (debug/automation harness) |
 | `src/main.c` | Entry point — SDL init, event loop, F4–F12 / Ctrl+V / Ctrl± window-scale handling, in-window footer draw |
 | `src/host_mount.c` / `host_mount.h` | F10 toggle: pauses the guest and mounts every active FAT card image (M4 SD / IDE / Albireo) on the host so the user can drag files in / out. Backend cascade per card: `gnome-disk-image-mounter` → bare `udisksctl loop-setup`+`mount` → libguestfs `guestmount`. udisks mounts land in `/run/media/$USER/<label>/` as first-class GNOME removable volumes; the guestmount fallback uses `~/.cache/1984/mounts/`. Press F10 again, or eject the card from the file manager (polled via `findmnt` once per frame), to unmount. The main loop then sets `overlay.needs_cold_boot` so the guest's stale FAT cache is dropped on resume. Linux-only; non-Linux stubs return false from `host_mount_open`. Issue #142. |
 
@@ -257,6 +258,7 @@ The overlay triggers a **cold boot** (ROM reload + `cpc_reset`) automatically wh
 | `--monitor-pty` | Open a PTY for the F8 memory monitor (connect with `minicom -b 9600 -D <path>` printed to stderr) |
 | `--kbd-pty` | Open a PTY that injects writes as keystrokes and streams the firmware text-out (`&BB5A`) — for external test harnesses driving BASIC / CP/M sessions |
 | `--ocr-monitor` | Adds an in-memory screen-text reader: scans video RAM each frame, decodes against the firmware font, streams the 80×25 (or 40×25) char grid on change out the kbd PTY. Lets probes follow CP/M+ output that bypasses `&BB5A`. Implies `--kbd-pty` |
+| `--pilot[=ARG]` | Open a PTY that auto-pilots the mouse pointer (or CPC joystick) from host-sent polar commands (`R THETA`, `press N`, `target mouse\|joy`). `ARG` = a symlink path for a stable alias, or `mouse`/`joystick` to pick the initial target. See [docs/PILOT.md](docs/PILOT.md) |
 
 ### Tracing (stderr)
 
@@ -556,6 +558,13 @@ The CPC reads the keyboard matrix (including the joystick row) through PSG I/O p
 3. Set PPI port C bits 7–6 = `01` (PSG read mode) → the emulator calls `psg_set_kbd_row()` then returns the row data via PPI port A.
 
 In step 3, `psg_ctrl == 0x01` always means the CPU is reading the keyboard through I/O port A (register 14). The code reads `psg->kbd_data` directly rather than going through `psg_read()`, which would only return `kbd_data` if `psg->selected == 14`. This avoids a bug where software that relies on register 14 being implicitly selected (e.g. SymbOS) would receive `psg->reg[0] = 0x00` — all keys falsely "pressed" — instead of the real matrix data.
+
+### Scripted and live injection
+
+Two host-driven paths inject into the same row-9 / mouse plumbing as real input, for headless tests and AI-driven debugging:
+
+- **`--joy-script=SPEC`** (`src/joy.c`) — replays a fixed `DIRS:FRAMES` timeline into row 9. `joyscript_tick()` runs once per frame next to `paste_tick()`. The deterministic, record-once analogue of `--paste`.
+- **`--pilot[=ARG]`** (`src/pilot.c`) — opens a host PTY and reacts *live* to polar-coordinate commands, holding the last velocity until changed. Routes to the **mouse** (`mouse_*` + `ch376_mouse_*`, gated on `cpc.symbiface_mouse` / `cpc.albireo_mouse`) or the **CPC joystick** (row 9, 8-way + Fire1/2), switchable at runtime with `target mouse|joy`. PTY setup mirrors `usifac.c`; `pilot_tick()` runs once per frame. Full protocol in [docs/PILOT.md](docs/PILOT.md).
 
 ---
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -42,6 +42,7 @@ dist_man1_MANS = 1984.1
 	src/mouse.c \
 	src/n4c_stack.c \
 	src/notify.c \
+	src/pilot.c \
 	src/snapshot.c \
 	src/tap.c \
 	src/tape.c \
@@ -74,6 +75,7 @@ noinst_HEADERS = \
 	src/n4c_stack.h \
 	src/notify.h \
 	src/overlay.h \
+	src/pilot.h \
 	src/tap.h \
 	src/paste.h \
 	src/ppi.h \

--- a/Makefile.in
+++ b/Makefile.in
@@ -137,8 +137,9 @@ am_1984_OBJECTS = src/1984-config.$(OBJEXT) src/1984-cpc.$(OBJEXT) \
 	src/1984-m4.$(OBJEXT) src/1984-symbnet.$(OBJEXT) \
 	src/1984-symbos_trace.$(OBJEXT) src/1984-mouse.$(OBJEXT) \
 	src/1984-n4c_stack.$(OBJEXT) src/1984-notify.$(OBJEXT) \
-	src/1984-snapshot.$(OBJEXT) src/1984-tap.$(OBJEXT) \
-	src/1984-tape.$(OBJEXT) src/1984-z80.$(OBJEXT)
+	src/1984-pilot.$(OBJEXT) src/1984-snapshot.$(OBJEXT) \
+	src/1984-tap.$(OBJEXT) src/1984-tape.$(OBJEXT) \
+	src/1984-z80.$(OBJEXT)
 1984_OBJECTS = $(am_1984_OBJECTS)
 am__DEPENDENCIES_1 =
 1984_LINK = $(CCLD) $(1984_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) \
@@ -172,9 +173,9 @@ am__depfiles_remade = src/$(DEPDIR)/1984-ch376.Po \
 	src/$(DEPDIR)/1984-n4c_stack.Po src/$(DEPDIR)/1984-net4cpc.Po \
 	src/$(DEPDIR)/1984-notify.Po src/$(DEPDIR)/1984-overlay.Po \
 	src/$(DEPDIR)/1984-paste.Po src/$(DEPDIR)/1984-perryfi.Po \
-	src/$(DEPDIR)/1984-ppi.Po src/$(DEPDIR)/1984-printer.Po \
-	src/$(DEPDIR)/1984-psg.Po src/$(DEPDIR)/1984-rtc.Po \
-	src/$(DEPDIR)/1984-screen_text.Po \
+	src/$(DEPDIR)/1984-pilot.Po src/$(DEPDIR)/1984-ppi.Po \
+	src/$(DEPDIR)/1984-printer.Po src/$(DEPDIR)/1984-psg.Po \
+	src/$(DEPDIR)/1984-rtc.Po src/$(DEPDIR)/1984-screen_text.Po \
 	src/$(DEPDIR)/1984-snapshot.Po src/$(DEPDIR)/1984-symbnet.Po \
 	src/$(DEPDIR)/1984-symbols.Po \
 	src/$(DEPDIR)/1984-symbos_trace.Po src/$(DEPDIR)/1984-tap.Po \
@@ -440,6 +441,7 @@ dist_man1_MANS = 1984.1
 	src/mouse.c \
 	src/n4c_stack.c \
 	src/notify.c \
+	src/pilot.c \
 	src/snapshot.c \
 	src/tap.c \
 	src/tape.c \
@@ -472,6 +474,7 @@ noinst_HEADERS = \
 	src/n4c_stack.h \
 	src/notify.h \
 	src/overlay.h \
+	src/pilot.h \
 	src/tap.h \
 	src/paste.h \
 	src/ppi.h \
@@ -704,6 +707,8 @@ src/1984-n4c_stack.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-notify.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
+src/1984-pilot.$(OBJEXT): src/$(am__dirstamp) \
+	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-snapshot.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-tap.$(OBJEXT): src/$(am__dirstamp) \
@@ -751,6 +756,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-overlay.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-paste.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-perryfi.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-pilot.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-ppi.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-printer.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-psg.Po@am__quote@ # am--include-marker
@@ -1320,6 +1326,20 @@ src/1984-notify.obj: src/notify.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/notify.c' object='src/1984-notify.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-notify.obj `if test -f 'src/notify.c'; then $(CYGPATH_W) 'src/notify.c'; else $(CYGPATH_W) '$(srcdir)/src/notify.c'; fi`
+
+src/1984-pilot.o: src/pilot.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-pilot.o -MD -MP -MF src/$(DEPDIR)/1984-pilot.Tpo -c -o src/1984-pilot.o `test -f 'src/pilot.c' || echo '$(srcdir)/'`src/pilot.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/1984-pilot.Tpo src/$(DEPDIR)/1984-pilot.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/pilot.c' object='src/1984-pilot.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-pilot.o `test -f 'src/pilot.c' || echo '$(srcdir)/'`src/pilot.c
+
+src/1984-pilot.obj: src/pilot.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-pilot.obj -MD -MP -MF src/$(DEPDIR)/1984-pilot.Tpo -c -o src/1984-pilot.obj `if test -f 'src/pilot.c'; then $(CYGPATH_W) 'src/pilot.c'; else $(CYGPATH_W) '$(srcdir)/src/pilot.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/1984-pilot.Tpo src/$(DEPDIR)/1984-pilot.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/pilot.c' object='src/1984-pilot.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-pilot.obj `if test -f 'src/pilot.c'; then $(CYGPATH_W) 'src/pilot.c'; else $(CYGPATH_W) '$(srcdir)/src/pilot.c'; fi`
 
 src/1984-snapshot.o: src/snapshot.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-snapshot.o -MD -MP -MF src/$(DEPDIR)/1984-snapshot.Tpo -c -o src/1984-snapshot.o `test -f 'src/snapshot.c' || echo '$(srcdir)/'`src/snapshot.c
@@ -1938,6 +1958,7 @@ distclean: distclean-am
 	-rm -f src/$(DEPDIR)/1984-overlay.Po
 	-rm -f src/$(DEPDIR)/1984-paste.Po
 	-rm -f src/$(DEPDIR)/1984-perryfi.Po
+	-rm -f src/$(DEPDIR)/1984-pilot.Po
 	-rm -f src/$(DEPDIR)/1984-ppi.Po
 	-rm -f src/$(DEPDIR)/1984-printer.Po
 	-rm -f src/$(DEPDIR)/1984-psg.Po
@@ -2031,6 +2052,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f src/$(DEPDIR)/1984-overlay.Po
 	-rm -f src/$(DEPDIR)/1984-paste.Po
 	-rm -f src/$(DEPDIR)/1984-perryfi.Po
+	-rm -f src/$(DEPDIR)/1984-pilot.Po
 	-rm -f src/$(DEPDIR)/1984-ppi.Po
 	-rm -f src/$(DEPDIR)/1984-printer.Po
 	-rm -f src/$(DEPDIR)/1984-psg.Po

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Per-expansion guides:
 - **[docs/FUZIX_BUILD.md](docs/FUZIX_BUILD.md)** — building ajcasado/FUZIX from source against this emulator; cpctools/hex2bin/iDSK/flip shim, `CONFIG_USIFAC_SERIAL` mode toggle
 - **[docs/SYMBOLS.md](docs/SYMBOLS.md)** — loading SDCC `.map` files for symbol-annotated disassembly in the F8 monitor; per-MMR matching, `S` / `BS` commands
 - **[docs/LEDS.md](docs/LEDS.md)** — what each LED in the activity bar means; M4's 3-segment split (power / disk / net), USIfAC's RX/TX split, colour map per slot
+- **[docs/PILOT.md](docs/PILOT.md)** — `--pilot` host-PTY auto-pilot; polar-coordinate command protocol for steering the mouse pointer or CPC joystick from a script or an AI during debugging
 
 ## Related projects
 

--- a/docs/PILOT.md
+++ b/docs/PILOT.md
@@ -1,0 +1,89 @@
+# Auto-pilot input (`--pilot`)
+
+A host-driven virtual input device. 1984 opens a pseudo-terminal (`/dev/pts/N`);
+anything that can write lines to it — a shell script, a test harness, or an AI
+given full control of the guest desktop during debugging — steers the **mouse
+pointer** or the **CPC joystick** using polar-coordinate commands.
+
+It is the live cousin of [`--joy-script`](../src/joy.h): where `--joy-script`
+replays a fixed `DIRS:FRAMES` timeline, the pilot reacts to whatever the host
+sends and holds the last velocity until told otherwise.
+
+## Invocation
+
+```bash
+./1984 --pilot                       # open a PTY, target = mouse, no alias
+./1984 --pilot=/tmp/1984-pilot.pty   # also create a stable symlink alias
+./1984 --pilot=mouse                 # explicit initial target (default)
+./1984 --pilot=joystick              # start driving CPC joystick 1
+```
+
+On startup 1984 prints the slave path and posts a toast:
+
+```
+1984: pilot PTY: /dev/pts/7 (target=mouse)
+```
+
+If the argument is `mouse`, `joystick`/`joy`, it selects the initial target;
+any other non-empty argument is treated as a symlink path for a stable alias
+(so you don't have to chase the `/dev/pts` number between runs).
+
+Linux/POSIX only. On Windows the flag prints a notice and is ignored.
+
+## Protocol
+
+One command per line. Tokens are split on spaces or commas, command words are
+case-insensitive, and `#` starts a comment. Unknown commands print a warning to
+stderr and are ignored.
+
+| Command | Meaning |
+|---------|---------|
+| `move R THETA` / `<R> <THETA>` / `v R THETA` | Set the velocity vector, **held until changed**. `R` = magnitude, `THETA` = angle in degrees. A bare line starting with a number is an implicit `move`. |
+| `stop` (`s`, `halt`, `x`) | Set magnitude to 0 (keeps the last angle). |
+| `press N` (`p N`) | Press button `N` (`1`=left/Fire1, `2`=right/Fire2, `3`=middle). |
+| `release N` (`u N`) | Release button `N`. |
+| `click N` (`c N`) | Press button `N` and auto-release after a few frames. |
+| `scroll DZ` | Mouse wheel by `DZ` (mouse target only). |
+| `target mouse` / `target joy` (`t m` / `t j`) | Switch target at runtime. |
+| `reset` | Stop and release every button/direction. |
+
+### Angle convention
+
+`THETA` is in degrees, **0 = right, 90 = up, counter-clockwise** — the usual
+mathematical orientation (the on-screen +y-is-down flip is handled internally).
+
+### Magnitude semantics
+
+- **Mouse target:** `R` is pixels per emulated frame (50 Hz), so `R=10` ≈
+  500 px/s. Sub-pixel speeds accumulate across frames, so `0.5 0` still drifts
+  right one pixel every other frame. The motion is fed to whichever mouse the
+  guest has enabled (SymbiFace II and/or Albireo/CH376 HID), exactly like a real
+  host mouse — if no mouse is enabled, motion goes nowhere.
+- **Joystick target:** `THETA` snaps to the nearest of the 8 directions and any
+  `R` above the deadzone engages it; magnitude is otherwise ignored (the CPC
+  stick is digital). Buttons 1 and 2 map to Fire1 and Fire2.
+
+## Examples
+
+```bash
+PTY=/tmp/1984-pilot.pty
+echo "8 0"       > $PTY   # glide right at 8 px/frame
+echo "8 90"      > $PTY   # turn upward
+echo "click 1"   > $PTY   # left-click where we are
+echo "stop"      > $PTY   # hold position
+echo "target joy"> $PTY   # switch to the joystick
+echo "5 270"     > $PTY   # press Down (270° = south)
+echo "press 1"   > $PTY   # hold Fire1
+echo "reset"     > $PTY   # neutral, release everything
+```
+
+## Implementation
+
+- `src/pilot.c` / `src/pilot.h` — PTY setup mirrors `usifac.c`/`kbd_pty.c`;
+  `pilot_tick()` runs once per frame from the main loop, next to
+  `joyscript_tick()`.
+- Mouse output calls `mouse_move`/`mouse_button`/`mouse_scroll` (SymbiFace II)
+  and `ch376_mouse_move`/`ch376_mouse_button` (Albireo), gated on
+  `cpc.symbiface_mouse` / `cpc.albireo_mouse`.
+- Joystick output drives keyboard matrix **row 9** bits 0–5 via
+  `kbd_key_down`/`kbd_key_up`, the same path as `joy.c`.

--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,7 @@
 #include "mem.h"
 #include "paste.h"
 #include "kbd_pty.h"
+#include "pilot.h"
 #include "symbols.h"
 #include "screen_text.h"
 #include "joy.h"
@@ -360,6 +361,11 @@ static void usage(const char *prog, int code) {
         "                      80x25 (or 40x25) char grid out the kbd PTY on change. Lets\n"
         "                      probes follow CP/M+ output that bypasses &BB5A. Implies\n"
         "                      --kbd-pty.\n"
+        "  --pilot[=ARG]       Open a PTY that auto-pilots the mouse pointer (or CPC\n"
+        "                      joystick) from host-sent polar commands. ARG = a symlink\n"
+        "                      path for a stable alias, or 'mouse'/'joystick' to pick the\n"
+        "                      initial target. Send 'R THETA' lines (R=speed, THETA=deg,\n"
+        "                      0=right/90=up); 'press N'/'click N'; 'target mouse|joy'.\n"
         "  -h, --help          Show this help and exit\n"
         "\n"
         "Keyboard shortcuts:\n"
@@ -408,6 +414,9 @@ int main(int argc, char *argv[]) {
     bool        monitor_pty      = false;
     bool        kbd_pty_enabled  = false;
     bool        ocr_monitor_enabled = false;
+    bool        pilot_enabled    = false;       /* --pilot */
+    const char *pilot_link       = NULL;        /* --pilot=LINK (symlink alias) */
+    PilotTarget pilot_target0    = PILOT_MOUSE;  /* --pilot=mouse|joystick */
     CpcModel    model_override   = (CpcModel)-1;  /* -1 = no override */
     bool        dd1_override     = false;
     int         memory_override  = 0;             /* 0 = no override */
@@ -492,6 +501,14 @@ int main(int argc, char *argv[]) {
             monitor_pty = true;
         } else if (strcmp(argv[i], "--kbd-pty") == 0) {
             kbd_pty_enabled = true;
+        } else if (strcmp(argv[i], "--pilot") == 0) {
+            pilot_enabled = true;
+        } else if (strncmp(argv[i], "--pilot=", 8) == 0) {
+            pilot_enabled = true;
+            const char *a = argv[i] + 8;
+            if (!strcmp(a, "mouse"))                         pilot_target0 = PILOT_MOUSE;
+            else if (!strcmp(a, "joystick") || !strcmp(a, "joy")) pilot_target0 = PILOT_JOY;
+            else if (a[0])                                    pilot_link = a;  /* symlink path */
         } else if (strcmp(argv[i], "--ocr-monitor") == 0) {
             kbd_pty_enabled = true;   /* OCR output piggybacks on the kbd PTY */
             ocr_monitor_enabled = true;
@@ -793,6 +810,12 @@ int main(int argc, char *argv[]) {
             return 1;
         }
     }
+
+    /* --pilot: live host-PTY auto-pilot for the mouse pointer / joystick. */
+    Pilot pilot;
+    pilot.fd = -1;
+    if (pilot_enabled)
+        pilot_open(&pilot, pilot_link, pilot_target0);
 
     /* Load a snapshot AFTER all machine init (ROMs, IDE, Albireo, joysticks
      * etc.) is done — the snapshot overrides only the CPU + GA + CRTC + PPI
@@ -1235,6 +1258,7 @@ int main(int argc, char *argv[]) {
         screen_text_tick(&cpc);
         paste_tick(&paste, &cpc.kbd);
         if (have_joyscript) joyscript_tick(&joyscript, &cpc.kbd);
+        pilot_tick(&pilot, &cpc);
         bool was_paused   = cpc.paused;
         bool was_stepping = cpc.step_once;
         net4cpc_poll();

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -1,0 +1,247 @@
+/* pilot.c — host-PTY "auto-pilot" input device. See pilot.h. */
+
+#define _XOPEN_SOURCE 600   /* posix_openpt, grantpt, unlockpt, ptsname */
+#define _DEFAULT_SOURCE     /* cfmakeraw */
+
+#include "pilot.h"
+#include "cpc.h"
+#include "mouse.h"
+#include "ch376.h"
+#include "kbd.h"
+#include "notify.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <math.h>
+
+/* CPC joystick 1 lives in keyboard matrix row 9, bits 0-5 (matches joy.c). */
+#define JOY_ROW    9
+#define JOY_UP     0
+#define JOY_DOWN   1
+#define JOY_LEFT   2
+#define JOY_RIGHT  3
+#define JOY_FIRE1  4
+#define JOY_FIRE2  5
+
+#define CLICK_HOLD_FRAMES 4   /* how long a `click` keeps a button pressed */
+#define JOY_DEADZONE      0.5 /* magnitude below which the stick is neutral */
+
+#ifndef _WIN32
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <termios.h>
+#include <errno.h>
+
+/* ---- PTY setup (mirrors usifac.c / kbd_pty.c) ----------------------------- */
+
+bool pilot_open(Pilot *p, const char *link, PilotTarget initial) {
+    memset(p, 0, sizeof(*p));
+    p->fd     = -1;
+    p->target = initial;
+
+    int fd = posix_openpt(O_RDWR | O_NOCTTY | O_NONBLOCK);
+    if (fd < 0) { perror("pilot: posix_openpt"); return false; }
+    if (grantpt(fd) < 0 || unlockpt(fd) < 0) {
+        perror("pilot: grantpt/unlockpt"); close(fd); return false;
+    }
+    const char *name = ptsname(fd);
+    if (!name) { close(fd); return false; }
+    snprintf(p->slave, sizeof(p->slave), "%s", name);
+
+    /* Open the slave once in raw mode so the /dev/pts node persists across
+     * host reconnects and carries no line-discipline cooking. See the long
+     * note in usifac.c open_pty() for why this is done on the slave fd. */
+    int sfd = open(name, O_RDWR | O_NOCTTY);
+    if (sfd >= 0) {
+        struct termios tio;
+        if (tcgetattr(sfd, &tio) == 0) {
+            cfmakeraw(&tio);
+            tio.c_cflag |= CS8 | CREAD | CLOCAL;
+            tcsetattr(sfd, TCSANOW, &tio);
+        }
+        close(sfd);
+    }
+
+    p->fd = fd;
+
+    if (link && link[0]) {
+        unlink(link);
+        if (symlink(p->slave, link) == 0) {
+            snprintf(p->link, sizeof(p->link), "%s", link);
+        } else {
+            fprintf(stderr, "pilot: symlink(%s -> %s) failed: %s\n",
+                    link, p->slave, strerror(errno));
+        }
+    }
+
+    if (p->link[0])
+        notify_post("Pilot: PTY ready at %s (alias %s)", p->slave, p->link);
+    else
+        notify_post("Pilot: PTY ready at %s", p->slave);
+    fprintf(stderr, "1984: pilot PTY: %s (target=%s)\n",
+            p->slave, initial == PILOT_JOY ? "joystick" : "mouse");
+    return true;
+}
+
+bool pilot_is_open(const Pilot *p) { return p->fd >= 0; }
+
+/* ---- command parsing ------------------------------------------------------ */
+
+/* Set the held velocity from a polar (magnitude, angle°). THETA uses the
+ * conventional maths orientation (0=right, 90=up, counter-clockwise); the
+ * mouse uses screen coordinates where +y points down, hence the negated y. */
+static void set_vector(Pilot *p, double mag, double ang_deg) {
+    p->mag = mag;
+    p->ang = ang_deg;
+    double r = ang_deg * (M_PI / 180.0);
+    p->vx =  mag * cos(r);
+    p->vy = -mag * sin(r);
+}
+
+static void release_all_buttons(Pilot *p) {
+    for (int b = 0; b < 3; b++) { p->btn[b] = false; p->click_left[b] = 0; }
+}
+
+static void exec_line(Pilot *p, char *line) {
+    /* Strip comments and surrounding whitespace, normalise commas to spaces. */
+    char *hash = strchr(line, '#');
+    if (hash) *hash = '\0';
+    for (char *c = line; *c; c++) if (*c == ',') *c = ' ';
+
+    char *tok[4]; int n = 0;
+    char *save = NULL;
+    for (char *t = strtok_r(line, " \t\r\n", &save);
+         t && n < 4; t = strtok_r(NULL, " \t\r\n", &save))
+        tok[n++] = t;
+    if (n == 0) return;
+
+    char *cmd = tok[0];
+    for (char *c = cmd; *c; c++) *c = (char)tolower((unsigned char)*c);
+
+    /* Bare "R THETA" (first token is a number) == implicit move. */
+    if (isdigit((unsigned char)cmd[0]) ||
+        ((cmd[0] == '-' || cmd[0] == '+' || cmd[0] == '.') && cmd[1])) {
+        if (n >= 2) set_vector(p, atof(tok[0]), atof(tok[1]));
+        return;
+    }
+
+    if (!strcmp(cmd, "move") || !strcmp(cmd, "m") || !strcmp(cmd, "v")) {
+        if (n >= 3) set_vector(p, atof(tok[1]), atof(tok[2]));
+    } else if (!strcmp(cmd, "stop") || !strcmp(cmd, "s") ||
+               !strcmp(cmd, "halt") || !strcmp(cmd, "x")) {
+        set_vector(p, 0.0, p->ang);
+    } else if (!strcmp(cmd, "press") || !strcmp(cmd, "p")) {
+        if (n >= 2) { int b = atoi(tok[1]) - 1; if (b >= 0 && b < 3) { p->btn[b] = true;  p->click_left[b] = 0; } }
+    } else if (!strcmp(cmd, "release") || !strcmp(cmd, "u")) {
+        if (n >= 2) { int b = atoi(tok[1]) - 1; if (b >= 0 && b < 3) { p->btn[b] = false; p->click_left[b] = 0; } }
+    } else if (!strcmp(cmd, "click") || !strcmp(cmd, "c")) {
+        if (n >= 2) { int b = atoi(tok[1]) - 1; if (b >= 0 && b < 3) { p->btn[b] = true;  p->click_left[b] = CLICK_HOLD_FRAMES; } }
+    } else if (!strcmp(cmd, "scroll")) {
+        if (n >= 2) p->scroll_pending += atoi(tok[1]);
+    } else if (!strcmp(cmd, "target") || !strcmp(cmd, "t")) {
+        if (n >= 2) {
+            char k = (char)tolower((unsigned char)tok[1][0]);
+            p->target = (k == 'j') ? PILOT_JOY : PILOT_MOUSE;
+        }
+    } else if (!strcmp(cmd, "reset")) {
+        set_vector(p, 0.0, 0.0);
+        release_all_buttons(p);
+    } else {
+        fprintf(stderr, "[pilot] unknown command: %s\n", cmd);
+    }
+}
+
+/* ---- per-frame application ------------------------------------------------ */
+
+/* The 8-way direction mask for a given angle, or 0 when below the deadzone. */
+static unsigned char joy_mask_for(double mag, double ang_deg) {
+    if (mag < JOY_DEADZONE) return 0;
+    double a = fmod(ang_deg, 360.0);
+    if (a < 0) a += 360.0;
+    int sector = ((int)floor(a / 45.0 + 0.5)) & 7;   /* 0=E,1=NE,2=N,...,7=SE */
+    static const unsigned char m[8] = {
+        1u << JOY_RIGHT,                       /* E  */
+        (1u << JOY_RIGHT) | (1u << JOY_UP),    /* NE */
+        1u << JOY_UP,                          /* N  */
+        (1u << JOY_LEFT)  | (1u << JOY_UP),    /* NW */
+        1u << JOY_LEFT,                        /* W  */
+        (1u << JOY_LEFT)  | (1u << JOY_DOWN),  /* SW */
+        1u << JOY_DOWN,                        /* S  */
+        (1u << JOY_RIGHT) | (1u << JOY_DOWN),  /* SE */
+    };
+    return m[sector];
+}
+
+void pilot_tick(Pilot *p, CPC *cpc) {
+    if (p->fd < 0) return;
+
+    /* Drain everything available into the line buffer, executing on newline. */
+    char c;
+    while (read(p->fd, &c, 1) == 1) {
+        if (c == '\n' || c == '\r') {
+            p->line[p->line_len] = '\0';
+            exec_line(p, p->line);
+            p->line_len = 0;
+        } else if (p->line_len < (int)sizeof(p->line) - 1) {
+            p->line[p->line_len++] = c;
+        }
+        /* Overlong lines past the buffer are silently truncated at newline. */
+    }
+
+    /* Auto-release expired clicks. */
+    for (int b = 0; b < 3; b++)
+        if (p->click_left[b] > 0 && --p->click_left[b] == 0)
+            p->btn[b] = false;
+
+    if (p->target == PILOT_MOUSE) {
+        if (p->joy_held) {   /* just switched away from joystick — let go of row 9 */
+            for (int col = JOY_UP; col <= JOY_FIRE2; col++)
+                kbd_key_up(&cpc->kbd, JOY_ROW, col);
+            p->joy_held = false;
+        }
+
+        /* Accumulate sub-pixel velocity, emit the integer part this frame. */
+        p->acc_x += p->vx;
+        p->acc_y += p->vy;
+        int dx = (int)p->acc_x, dy = (int)p->acc_y;
+        p->acc_x -= dx;
+        p->acc_y -= dy;
+        if (dx || dy) {
+            if (cpc->symbiface_mouse) mouse_move(&cpc->mouse, dx, dy);
+            if (cpc->albireo_mouse)   ch376_mouse_move(&cpc->ch376, dx, dy);
+        }
+        for (int b = 0; b < 3; b++) {
+            if (cpc->symbiface_mouse) mouse_button(&cpc->mouse, b, p->btn[b]);
+            if (cpc->albireo_mouse)   ch376_mouse_button(&cpc->ch376, b, p->btn[b]);
+        }
+        if (p->scroll_pending) {
+            if (cpc->symbiface_mouse) mouse_scroll(&cpc->mouse, p->scroll_pending);
+            p->scroll_pending = 0;
+        }
+    } else { /* PILOT_JOY */
+        unsigned char mask = joy_mask_for(p->mag, p->ang);
+        if (p->btn[0]) mask |= 1u << JOY_FIRE1;   /* button 1 -> Fire1 */
+        if (p->btn[1]) mask |= 1u << JOY_FIRE2;   /* button 2 -> Fire2 */
+        for (int col = JOY_UP; col <= JOY_FIRE2; col++) {
+            if (mask & (1u << col)) kbd_key_down(&cpc->kbd, JOY_ROW, col);
+            else                    kbd_key_up  (&cpc->kbd, JOY_ROW, col);
+        }
+        p->joy_held = true;
+    }
+}
+
+#else  /* _WIN32 — no PTYs */
+
+bool pilot_open(Pilot *p, const char *link, PilotTarget initial) {
+    (void)link; (void)initial;
+    memset(p, 0, sizeof(*p)); p->fd = -1;
+    fprintf(stderr, "1984: --pilot is not supported on Windows\n");
+    return false;
+}
+bool pilot_is_open(const Pilot *p) { (void)p; return false; }
+void pilot_tick(Pilot *p, CPC *cpc) { (void)p; (void)cpc; }
+
+#endif

--- a/src/pilot.h
+++ b/src/pilot.h
@@ -1,0 +1,69 @@
+#pragma once
+#include <stdbool.h>
+#include "cpc.h"
+
+/*
+ * pilot — an "auto-pilot" input device driven from a host PTY (/dev/pts).
+ *
+ * Opened with --pilot[=LINK]. 1984 prints (and notifies) the slave path; an
+ * external driver — a script, or an AI given full control of the guest
+ * desktop during debugging — writes newline-delimited polar-coordinate
+ * commands to it. The pilot translates them into mouse motion / button
+ * presses (SymbiFace II + Albireo/CH376) or CPC joystick 1 (matrix row 9).
+ *
+ * It's the interactive cousin of --joy-script: where --joy-script replays a
+ * fixed DIRS:FRAMES timeline, the pilot reacts live to whatever the host
+ * sends, and uses a held-velocity model so a single command keeps the
+ * pointer gliding until changed.
+ *
+ * Protocol (one command per line; case-insensitive; tokens split on spaces
+ * or commas; '#' starts a comment):
+ *
+ *   move R THETA   set velocity vector, held until changed. R = magnitude,
+ *   <R> <THETA>    THETA = angle in degrees (0=right, 90=up, CCW positive).
+ *   v R THETA      A bare "R THETA" line (starts with a digit) is the same.
+ *                  Mouse target: R is pixels/frame (50 Hz), so R=5 ≈ 250 px/s;
+ *                  sub-pixel speeds accumulate. Joystick target: THETA snaps
+ *                  to the nearest 8-way direction and R>0 engages it.
+ *   stop           R=0 (also: s, halt, x).
+ *   press N        press button N (1=left/Fire1, 2=right/Fire2, 3=middle). p.
+ *   release N      release button N (also: u).
+ *   click N        press button N and auto-release after a few frames (c).
+ *   scroll DZ      mouse wheel by DZ (mouse target only).
+ *   target mouse   route to the mouse pointer (default). Aliases: t m.
+ *   target joy     route to CPC joystick 1 (row 9). Aliases: t j / joystick.
+ *   reset          stop and release every button/direction.
+ *
+ * Linux/POSIX only (PTYs); Windows builds get no-op stubs.
+ */
+
+typedef enum { PILOT_MOUSE = 0, PILOT_JOY = 1 } PilotTarget;
+
+typedef struct {
+    int          fd;            /* master PTY fd, -1 when closed         */
+    char         slave[256];    /* /dev/pts/N slave path                 */
+    char         link[256];     /* optional stable symlink alias         */
+    PilotTarget  target;
+
+    double       mag, ang;      /* last commanded polar vector           */
+    double       vx, vy;        /* derived per-frame velocity (screen y+ = down) */
+    double       acc_x, acc_y;  /* sub-pixel motion remainder            */
+
+    bool         btn[3];        /* current button state (0=L 1=R 2=M)    */
+    int          click_left[3]; /* frames until auto-release (0 = none)  */
+    int          scroll_pending;/* wheel delta queued for the next tick  */
+    bool         joy_held;      /* row 9 is currently being driven       */
+
+    char         line[256];     /* partial-line accumulator              */
+    int          line_len;
+} Pilot;
+
+/* Open the pilot PTY. link may be NULL/empty (no symlink). initial sets the
+ * starting target. Returns true on success; on failure leaves fd = -1. */
+bool pilot_open(Pilot *p, const char *link, PilotTarget initial);
+
+bool pilot_is_open(const Pilot *p);
+
+/* Call once per emulated frame: drains pending commands and applies the held
+ * velocity / button state to the machine. Cheap no-op when closed. */
+void pilot_tick(Pilot *p, CPC *cpc);


### PR DESCRIPTION
Closes #200.

A debugging/automation harness that opens a host pseudo-terminal (`/dev/pts/N`) and lets an external driver — a script, or an AI given full control of the guest desktop — steer the **mouse pointer** or **CPC joystick** with polar-coordinate commands. It's the live cousin of `--joy-script`: instead of replaying a fixed `DIRS:FRAMES` timeline, it reacts to whatever the host sends and **holds the last velocity vector until changed**.

## Invocation
```bash
./1984 --pilot                       # PTY, target = mouse
./1984 --pilot=/tmp/1984-pilot.pty   # stable symlink alias
./1984 --pilot=joystick              # start in joystick mode
```
Prints (and toasts) the slave path on boot. No overlay toggle — kept CLI-only to match the sibling debug PTYs (`--kbd-pty`, `--monitor-pty`).

## Protocol (newline-delimited, written to the PTY)
| Command | Meaning |
|---------|---------|
| `move R THETA` / `<R> <THETA>` | velocity vector, held. `R`=magnitude, `THETA`=deg (0=right, 90=up, CCW) |
| `stop` | magnitude 0 |
| `press`/`release`/`click N` | button N (1=left/Fire1, 2=right/Fire2, 3=middle) |
| `scroll DZ` | wheel (mouse) |
| `target mouse`/`target joy` | switch target at runtime |
| `reset` | neutral + release all |

- **Mouse target:** `R` px/frame (50 Hz); sub-pixel speeds accumulate. Fed to SymbiFace II + Albireo/CH376, gated on `cpc.symbiface_mouse`/`cpc.albireo_mouse` exactly like a real host mouse.
- **Joystick target:** `THETA` snaps to 8-way, `R` above deadzone engages; buttons 1/2 → Fire1/2. Drives keyboard matrix row 9.

## Implementation
- `src/pilot.{c,h}` — PTY setup mirrors `usifac.c`/`kbd_pty.c`; `pilot_tick()` runs once per frame next to `joyscript_tick()`. POSIX-only (Windows no-op stubs).
- Docs: new `docs/PILOT.md`, plus `Development.md` (architecture table, headless-harness CLI table, input section) and the README documentation index.

## Testing
Builds clean (`-Wall -Wextra`, exit 0). Headless smoke test (`SDL_VIDEODRIVER=dummy --pilot=/tmp/1984-pilot.pty`) confirmed: PTY opens and prints its path, the symlink alias is created, valid commands parse, an unknown command warns to stderr, and a live `target joy` switch mid-run doesn't crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)