### PR TITLE
Extend pilot diagnostics protocol

### DIFF
--- a/docs/PILOT.md
+++ b/docs/PILOT.md
@@ -2,8 +2,12 @@
 
 A host-driven virtual input device. 1984 opens a pseudo-terminal (`/dev/pts/N`);
 anything that can write lines to it — a shell script, a test harness, or an AI
-given full control of the guest desktop during debugging — steers the **mouse
-pointer** or the **CPC joystick** using polar-coordinate commands.
+given full control of the guest desktop during debugging — drives the emulator
+through a small **command/reply diagnostics protocol**.
+
+For AI and harness use, `--pilot-replies-stderr` mirrors the structured reply
+lines to stderr. That lets the host keep the PTY traffic write-only, which is
+more reliable than a long-lived bidirectional slave session.
 
 It is the live cousin of [`--joy-script`](../src/joy.h): where `--joy-script`
 replays a fixed `DIRS:FRAMES` timeline, the pilot reacts to whatever the host
@@ -34,18 +38,43 @@ Linux/POSIX only. On Windows the flag prints a notice and is ignored.
 
 One command per line. Tokens are split on spaces or commas, command words are
 case-insensitive, and `#` starts a comment. Unknown commands print a warning to
-stderr and are ignored.
+stderr and also return an `err ...` line on the PTY. Successful commands return
+`ok ...`, while queries return `state ...`, `frame ...`, `hash ...`, or
+`changed ...`. The PTY is therefore both the control plane and the cheapest
+diagnostics surface.
+
+When `--pilot-replies-stderr` is enabled, the same replies are mirrored as:
+
+```text
+1984: pilot reply: ok ...
+1984: pilot reply: state ...
+```
 
 | Command | Meaning |
 |---------|---------|
 | `move R THETA` / `<R> <THETA>` / `v R THETA` | Set the velocity vector, **held until changed**. `R` = magnitude, `THETA` = angle in degrees. A bare line starting with a number is an implicit `move`. |
+| `hold F R THETA` | Set the velocity vector for `F` frames, then auto-stop. |
 | `stop` (`s`, `halt`, `x`) | Set magnitude to 0 (keeps the last angle). |
 | `press N` (`p N`) | Press button `N` (`1`=left/Fire1, `2`=right/Fire2, `3`=middle). |
 | `release N` (`u N`) | Release button `N`. |
 | `click N` (`c N`) | Press button `N` and auto-release after a few frames. |
+| `hold-click F N` | Press button `N` for `F` frames, then auto-release. |
 | `scroll DZ` | Mouse wheel by `DZ` (mouse target only). |
+| `key-down NAME` / `key-up NAME` | Press or release a CPC key by SDL scancode name. Examples: `A`, `Return`, `Left Shift`. |
+| `key-tap NAME F` | Press the key for `F` frames, then release it. |
+| `paste TEXT` | Queue `TEXT` through the existing CPC paste path. |
 | `target mouse` / `target joy` (`t m` / `t j`) | Switch target at runtime. |
 | `reset` | Stop and release every button/direction. |
+| `state` | Emit a machine-readable state line on the PTY. |
+| `frame` | Emit the current completed frame counter. |
+| `hash` | Emit the current framebuffer hash. |
+| `changed` | Emit the latest changed rectangle and quiet-frame count. |
+| `wait frames N [T]` | Complete after `N` more frames, or timeout after `T` frames. |
+| `wait hash-eq HEX [T]` / `wait hash-ne HEX [T]` | Wait on the framebuffer hash. |
+| `wait change [T]` | Wait for any visible framebuffer change. |
+| `wait quiet N [T]` | Wait for `N` consecutive quiet frames. |
+| `crop PATH X Y W H [SCALE]` | Save a cropped screenshot region to `PATH`. |
+| `snapshot-save PATH` / `snapshot-load PATH` | Save or restore an SNA snapshot. |
 
 ### Angle convention
 
@@ -68,22 +97,49 @@ mathematical orientation (the on-screen +y-is-down flip is handled internally).
 ```bash
 PTY=/tmp/1984-pilot.pty
 echo "8 0"       > $PTY   # glide right at 8 px/frame
+echo "hold 25 8 0" > $PTY # glide right for 25 frames, then stop
 echo "8 90"      > $PTY   # turn upward
 echo "click 1"   > $PTY   # left-click where we are
+echo "hold-click 12 1" > $PTY   # hold button 1 for 12 frames
 echo "stop"      > $PTY   # hold position
 echo "target joy"> $PTY   # switch to the joystick
 echo "5 270"     > $PTY   # press Down (270° = south)
 echo "press 1"   > $PTY   # hold Fire1
+echo "state"     > $PTY   # dump the current target/vector/button state
+echo "hash"      > $PTY   # current visible framebuffer hash
+echo "wait change 200" > $PTY     # block until something changes, max 200 frames
+echo "crop /tmp/top.ppm 0 0 256 96 2" > $PTY   # 2x scaled crop
+echo "snapshot-save /tmp/point.sna" > $PTY
+echo "snapshot-load /tmp/point.sna" > $PTY
 echo "reset"     > $PTY   # neutral, release everything
+```
+
+## Smoke Driver
+
+`debug/ai_diag.py` is a minimal tracked host harness for this protocol. It:
+
+- launches `./1984` headlessly,
+- discovers the pilot PTY from stderr,
+- sends pilot commands through one-shot write-only PTY opens,
+- reads replies from `--pilot-replies-stderr`,
+- prints replies verbatim,
+- can run a simple smoke sequence (`--smoke`) or a line-based script (`--script`).
+
+Example:
+
+```bash
+python3 debug/ai_diag.py --smoke -- --config=/dev/null --exit-after=200
 ```
 
 ## Implementation
 
-- `src/pilot.c` / `src/pilot.h` — PTY setup mirrors `usifac.c`/`kbd_pty.c`;
-  `pilot_tick()` runs once per frame from the main loop, next to
-  `joyscript_tick()`.
+- `src/pilot.c` / `src/pilot.h` — PTY setup mirrors `usifac.c`/`kbd_pty.c`.
+  The protocol now runs in two passes: a pre-frame input/control pass and a
+  post-frame diagnostics pass.
 - Mouse output calls `mouse_move`/`mouse_button`/`mouse_scroll` (SymbiFace II)
   and `ch376_mouse_move`/`ch376_mouse_button` (Albireo), gated on
   `cpc.symbiface_mouse` / `cpc.albireo_mouse`.
 - Joystick output drives keyboard matrix **row 9** bits 0–5 via
   `kbd_key_down`/`kbd_key_up`, the same path as `joy.c`.
+- `src/display.c` provides cheap framebuffer observability: hash, changed-rect
+  detection, and crop capture.

--- a/src/display.c
+++ b/src/display.c
@@ -258,3 +258,82 @@ void display_save_ppm(Display *d, const char *path) {
 
     fclose(f);
 }
+
+u32 display_hash(Display *d) {
+    /* FNV-1a over the visible CPC framebuffer after any CRT colour transform. */
+    const u32 *px = display_crt_pixels(d);
+    u32 h = 2166136261u;
+    int n = CPC_SCREEN_W * CPC_SCREEN_H;
+    for (int i = 0; i < n; i++) {
+        h ^= px[i];
+        h *= 16777619u;
+    }
+    return h;
+}
+
+void display_copy_visible(Display *d, u32 *dst) {
+    const u32 *px = display_crt_pixels(d);
+    memcpy(dst, px, (size_t)CPC_SCREEN_W * CPC_SCREEN_H * sizeof(u32));
+}
+
+bool display_changed_rect(Display *d, u32 *prev, int *x, int *y, int *w, int *h) {
+    const u32 *cur = display_crt_pixels(d);
+    int min_x = CPC_SCREEN_W, min_y = CPC_SCREEN_H, max_x = -1, max_y = -1;
+
+    for (int yy = 0; yy < CPC_SCREEN_H; yy++) {
+        int row = yy * CPC_SCREEN_W;
+        for (int xx = 0; xx < CPC_SCREEN_W; xx++) {
+            int i = row + xx;
+            if (cur[i] != prev[i]) {
+                prev[i] = cur[i];
+                if (xx < min_x) min_x = xx;
+                if (yy < min_y) min_y = yy;
+                if (xx > max_x) max_x = xx;
+                if (yy > max_y) max_y = yy;
+            }
+        }
+    }
+
+    if (max_x < min_x || max_y < min_y) {
+        *x = *y = *w = *h = 0;
+        return false;
+    }
+
+    *x = min_x;
+    *y = min_y;
+    *w = max_x - min_x + 1;
+    *h = max_y - min_y + 1;
+    return true;
+}
+
+bool display_save_crop_ppm(Display *d, const char *path,
+                           int x, int y, int w, int h, int scale) {
+    FILE *f;
+    if (scale < 1) scale = 1;
+    if (x < 0) { w += x; x = 0; }
+    if (y < 0) { h += y; y = 0; }
+    if (x >= CPC_SCREEN_W || y >= CPC_SCREEN_H || w <= 0 || h <= 0) return false;
+    if (x + w > CPC_SCREEN_W) w = CPC_SCREEN_W - x;
+    if (y + h > CPC_SCREEN_H) h = CPC_SCREEN_H - y;
+    if (w <= 0 || h <= 0) return false;
+
+    f = fopen(path, "wb");
+    if (!f) return false;
+    fprintf(f, "P6\n%d %d\n255\n", w * scale, h * scale);
+    for (int yy = 0; yy < h; yy++) {
+        for (int sy = 0; sy < scale; sy++) {
+            for (int xx = 0; xx < w; xx++) {
+                u32 px = d->pixels[(y + yy) * CPC_SCREEN_W + (x + xx)];
+                unsigned char rgb[3] = {
+                    (unsigned char)((px >> 16) & 0xFF),
+                    (unsigned char)((px >> 8) & 0xFF),
+                    (unsigned char)(px & 0xFF),
+                };
+                for (int sx = 0; sx < scale; sx++)
+                    fwrite(rgb, 1, 3, f);
+            }
+        }
+    }
+    fclose(f);
+    return true;
+}

--- a/src/display.h
+++ b/src/display.h
@@ -46,6 +46,11 @@ void display_vsync(Display *d);
 void display_upload(Display *d);   /* update texture + blit to renderer (no flip) */
 void display_flip(Display *d);     /* SDL_RenderPresent */
 void display_save_ppm(Display *d, const char *path);
+u32  display_hash(Display *d);
+void display_copy_visible(Display *d, u32 *dst);
+bool display_changed_rect(Display *d, u32 *prev, int *x, int *y, int *w, int *h);
+bool display_save_crop_ppm(Display *d, const char *path,
+                           int x, int y, int w, int h, int scale);
 
 /* Switch texture scaling between linear (smooth) and nearest (sharp). */
 void display_set_smoothing(Display *d, bool smooth);

--- a/src/main.c
+++ b/src/main.c
@@ -366,6 +366,7 @@ static void usage(const char *prog, int code) {
         "                      path for a stable alias, or 'mouse'/'joystick' to pick the\n"
         "                      initial target. Send 'R THETA' lines (R=speed, THETA=deg,\n"
         "                      0=right/90=up); 'press N'/'click N'; 'target mouse|joy'.\n"
+        "  --pilot-replies-stderr Mirror machine-readable pilot replies to stderr.\n"
         "  -h, --help          Show this help and exit\n"
         "\n"
         "Keyboard shortcuts:\n"
@@ -417,6 +418,7 @@ int main(int argc, char *argv[]) {
     bool        pilot_enabled    = false;       /* --pilot */
     const char *pilot_link       = NULL;        /* --pilot=LINK (symlink alias) */
     PilotTarget pilot_target0    = PILOT_MOUSE;  /* --pilot=mouse|joystick */
+    bool        pilot_reply_stderr = false;    /* --pilot-replies-stderr */
     CpcModel    model_override   = (CpcModel)-1;  /* -1 = no override */
     bool        dd1_override     = false;
     int         memory_override  = 0;             /* 0 = no override */
@@ -509,6 +511,8 @@ int main(int argc, char *argv[]) {
             if (!strcmp(a, "mouse"))                         pilot_target0 = PILOT_MOUSE;
             else if (!strcmp(a, "joystick") || !strcmp(a, "joy")) pilot_target0 = PILOT_JOY;
             else if (a[0])                                    pilot_link = a;  /* symlink path */
+        } else if (strcmp(argv[i], "--pilot-replies-stderr") == 0) {
+            pilot_reply_stderr = true;
         } else if (strcmp(argv[i], "--ocr-monitor") == 0) {
             kbd_pty_enabled = true;   /* OCR output piggybacks on the kbd PTY */
             ocr_monitor_enabled = true;
@@ -815,7 +819,7 @@ int main(int argc, char *argv[]) {
     Pilot pilot;
     pilot.fd = -1;
     if (pilot_enabled)
-        pilot_open(&pilot, pilot_link, pilot_target0);
+        pilot_open(&pilot, pilot_link, pilot_target0, pilot_reply_stderr);
 
     /* Load a snapshot AFTER all machine init (ROMs, IDE, Albireo, joysticks
      * etc.) is done — the snapshot overrides only the CPU + GA + CRTC + PPI
@@ -1258,7 +1262,7 @@ int main(int argc, char *argv[]) {
         screen_text_tick(&cpc);
         paste_tick(&paste, &cpc.kbd);
         if (have_joyscript) joyscript_tick(&joyscript, &cpc.kbd);
-        pilot_tick(&pilot, &cpc);
+        pilot_tick(&pilot, &cpc, &cpc.display, &paste);
         bool was_paused   = cpc.paused;
         bool was_stepping = cpc.step_once;
         net4cpc_poll();
@@ -1266,6 +1270,7 @@ int main(int argc, char *argv[]) {
         perryfi_poll(&cpc.perryfi);
         printer_tick(&cpc.printer);
         cpc_frame(&cpc);
+        pilot_post_frame(&pilot, &cpc, &cpc.display, frame_count + 1);
         /* Auto-open monitor on breakpoint hit */
         if (!was_paused && cpc.paused) {
             /* Debug hook: ONE_K_DUMP_RAM=/path/to/file writes physical RAM

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -9,12 +9,14 @@
 #include "ch376.h"
 #include "kbd.h"
 #include "notify.h"
+#include "snapshot.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include <math.h>
+#include <stdarg.h>
 
 /* CPC joystick 1 lives in keyboard matrix row 9, bits 0-5 (matches joy.c). */
 #define JOY_ROW    9
@@ -37,10 +39,14 @@
 
 /* ---- PTY setup (mirrors usifac.c / kbd_pty.c) ----------------------------- */
 
-bool pilot_open(Pilot *p, const char *link, PilotTarget initial) {
+bool pilot_open(Pilot *p, const char *link, PilotTarget initial, bool reply_stderr) {
     memset(p, 0, sizeof(*p));
     p->fd     = -1;
     p->target = initial;
+    p->reply_stderr = reply_stderr;
+    p->wait_timeout_frame = -1;
+    p->keytap_scancode = -1;
+    p->last_pixels = calloc((size_t)CPC_SCREEN_W * CPC_SCREEN_H, sizeof(u32));
 
     int fd = posix_openpt(O_RDWR | O_NOCTTY | O_NONBLOCK);
     if (fd < 0) { perror("pilot: posix_openpt"); return false; }
@@ -105,16 +111,113 @@ static void release_all_buttons(Pilot *p) {
     for (int b = 0; b < 3; b++) { p->btn[b] = false; p->click_left[b] = 0; }
 }
 
-static void exec_line(Pilot *p, char *line) {
+static void release_keytap(Pilot *p, CPC *cpc) {
+    if (p->keytap_left > 0 && p->keytap_scancode >= 0)
+        kbd_sdl_key(&cpc->kbd, (SDL_Scancode)p->keytap_scancode, false);
+    p->keytap_left = 0;
+    p->keytap_scancode = -1;
+}
+
+static int parse_timeout(char *const *tok, int n, int idx, int frame_now) {
+    if (idx < n) {
+        int frames = atoi(tok[idx]);
+        if (frames >= 0) return frame_now + frames;
+    }
+    return -1;
+}
+
+static void start_wait(Pilot *p, PilotWaitMode mode, int frame_now, int timeout_frame) {
+    p->wait_mode = mode;
+    p->wait_start_frame = frame_now;
+    p->wait_timeout_frame = timeout_frame;
+}
+
+static void pilot_reply(Pilot *p, const char *fmt, ...) {
+    char buf[256];
+    char line[256];
+    va_list ap;
+    int n;
+
+    if (p->fd < 0) return;
+    va_start(ap, fmt);
+    n = vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    if (n < 0) return;
+    snprintf(line, sizeof(line), "%s", buf);
+    if (n >= (int)sizeof(buf) - 1) n = (int)sizeof(buf) - 2;
+    buf[n++] = '\n';
+    (void)!write(p->fd, buf, (size_t)n);
+    if (p->reply_stderr) {
+        fprintf(stderr, "1984: pilot reply: %s\n", line);
+        fflush(stderr);
+    }
+}
+
+static void reply_state(Pilot *p, CPC *cpc) {
+    pilot_reply(p,
+                "state target=%s mag=%.3f ang=%.3f move_left=%d "
+                "buttons=%d%d%d click_left=%d,%d,%d joy_held=%d "
+                "frame=%d hash=%08X changed=%d,%d,%d,%d quiet=%d "
+                "mouse_symbiface=%d mouse_albireo=%d",
+                p->target == PILOT_JOY ? "joy" : "mouse",
+                p->mag, p->ang, p->move_left,
+                p->btn[0] ? 1 : 0, p->btn[1] ? 1 : 0, p->btn[2] ? 1 : 0,
+                p->click_left[0], p->click_left[1], p->click_left[2],
+                p->joy_held ? 1 : 0, p->frame_count, (unsigned)p->fb_hash,
+                p->changed_x, p->changed_y, p->changed_w, p->changed_h, p->quiet_frames,
+                cpc->symbiface_mouse ? 1 : 0, cpc->albireo_mouse ? 1 : 0);
+}
+
+static SDL_Scancode scancode_from_token(const char *name) {
+    SDL_Scancode sc = SDL_SCANCODE_UNKNOWN;
+    char buf[64];
+    size_t j = 0;
+    if (!name || !name[0]) return SDL_SCANCODE_UNKNOWN;
+    sc = SDL_GetScancodeFromName(name);
+    if (sc != SDL_SCANCODE_UNKNOWN) return sc;
+    for (size_t i = 0; name[i] && j + 1 < sizeof(buf); i++) {
+        buf[j++] = (name[i] == '_') ? ' ' : name[i];
+    }
+    buf[j] = '\0';
+    return SDL_GetScancodeFromName(buf);
+}
+
+static void reply_changed(Pilot *p) {
+    int count = (p->changed_w > 0 && p->changed_h > 0) ? 1 : 0;
+    pilot_reply(p, "changed count=%d rect=%d,%d,%d,%d quiet=%d",
+                count, p->changed_x, p->changed_y, p->changed_w, p->changed_h,
+                p->quiet_frames);
+}
+
+static void finish_wait(Pilot *p, const char *reason) {
+    pilot_reply(p, "ok wait reason=%s frame=%d hash=%08X changed=%d,%d,%d,%d quiet=%d",
+                reason, p->frame_count, (unsigned)p->fb_hash,
+                p->changed_x, p->changed_y, p->changed_w, p->changed_h,
+                p->quiet_frames);
+    p->wait_mode = PILOT_WAIT_NONE;
+    p->wait_timeout_frame = -1;
+}
+
+static void fail_wait(Pilot *p, const char *reason) {
+    pilot_reply(p, "err wait reason=%s frame=%d hash=%08X",
+                reason, p->frame_count, (unsigned)p->fb_hash);
+    p->wait_mode = PILOT_WAIT_NONE;
+    p->wait_timeout_frame = -1;
+}
+
+static void exec_line(Pilot *p, CPC *cpc, Display *d, Paste *paste, char *line) {
     /* Strip comments and surrounding whitespace, normalise commas to spaces. */
     char *hash = strchr(line, '#');
+    char raw[256];
+    int frame_now = p->frame_count;
     if (hash) *hash = '\0';
+    snprintf(raw, sizeof(raw), "%s", line);
     for (char *c = line; *c; c++) if (*c == ',') *c = ' ';
 
-    char *tok[4]; int n = 0;
+    char *tok[8]; int n = 0;
     char *save = NULL;
     for (char *t = strtok_r(line, " \t\r\n", &save);
-         t && n < 4; t = strtok_r(NULL, " \t\r\n", &save))
+         t && n < 8; t = strtok_r(NULL, " \t\r\n", &save))
         tok[n++] = t;
     if (n == 0) return;
 
@@ -124,33 +227,225 @@ static void exec_line(Pilot *p, char *line) {
     /* Bare "R THETA" (first token is a number) == implicit move. */
     if (isdigit((unsigned char)cmd[0]) ||
         ((cmd[0] == '-' || cmd[0] == '+' || cmd[0] == '.') && cmd[1])) {
-        if (n >= 2) set_vector(p, atof(tok[0]), atof(tok[1]));
+        if (n >= 2) {
+            set_vector(p, atof(tok[0]), atof(tok[1]));
+            p->move_left = 0;
+            pilot_reply(p, "ok move mag=%.3f ang=%.3f", p->mag, p->ang);
+        } else {
+            pilot_reply(p, "err move needs R THETA");
+        }
         return;
     }
 
     if (!strcmp(cmd, "move") || !strcmp(cmd, "m") || !strcmp(cmd, "v")) {
-        if (n >= 3) set_vector(p, atof(tok[1]), atof(tok[2]));
+        if (n >= 3) {
+            set_vector(p, atof(tok[1]), atof(tok[2]));
+            p->move_left = 0;
+            pilot_reply(p, "ok move mag=%.3f ang=%.3f", p->mag, p->ang);
+        } else {
+            pilot_reply(p, "err move needs R THETA");
+        }
+    } else if (!strcmp(cmd, "hold")) {
+        if (n >= 4) {
+            p->move_left = atoi(tok[1]);
+            if (p->move_left < 0) p->move_left = 0;
+            set_vector(p, atof(tok[2]), atof(tok[3]));
+            pilot_reply(p, "ok hold frames=%d mag=%.3f ang=%.3f",
+                        p->move_left, p->mag, p->ang);
+        } else {
+            pilot_reply(p, "err hold needs FRAMES R THETA");
+        }
     } else if (!strcmp(cmd, "stop") || !strcmp(cmd, "s") ||
                !strcmp(cmd, "halt") || !strcmp(cmd, "x")) {
         set_vector(p, 0.0, p->ang);
+        p->move_left = 0;
+        pilot_reply(p, "ok stop");
     } else if (!strcmp(cmd, "press") || !strcmp(cmd, "p")) {
-        if (n >= 2) { int b = atoi(tok[1]) - 1; if (b >= 0 && b < 3) { p->btn[b] = true;  p->click_left[b] = 0; } }
+        if (n >= 2) {
+            int b = atoi(tok[1]) - 1;
+            if (b >= 0 && b < 3) {
+                p->btn[b] = true; p->click_left[b] = 0;
+                pilot_reply(p, "ok press button=%d", b + 1);
+            } else {
+                pilot_reply(p, "err invalid button");
+            }
+        } else {
+            pilot_reply(p, "err press needs BUTTON");
+        }
     } else if (!strcmp(cmd, "release") || !strcmp(cmd, "u")) {
-        if (n >= 2) { int b = atoi(tok[1]) - 1; if (b >= 0 && b < 3) { p->btn[b] = false; p->click_left[b] = 0; } }
+        if (n >= 2) {
+            int b = atoi(tok[1]) - 1;
+            if (b >= 0 && b < 3) {
+                p->btn[b] = false; p->click_left[b] = 0;
+                pilot_reply(p, "ok release button=%d", b + 1);
+            } else {
+                pilot_reply(p, "err invalid button");
+            }
+        } else {
+            pilot_reply(p, "err release needs BUTTON");
+        }
     } else if (!strcmp(cmd, "click") || !strcmp(cmd, "c")) {
-        if (n >= 2) { int b = atoi(tok[1]) - 1; if (b >= 0 && b < 3) { p->btn[b] = true;  p->click_left[b] = CLICK_HOLD_FRAMES; } }
+        if (n >= 2) {
+            int b = atoi(tok[1]) - 1;
+            if (b >= 0 && b < 3) {
+                p->btn[b] = true; p->click_left[b] = CLICK_HOLD_FRAMES;
+                pilot_reply(p, "ok click button=%d frames=%d", b + 1, CLICK_HOLD_FRAMES);
+            } else {
+                pilot_reply(p, "err invalid button");
+            }
+        } else {
+            pilot_reply(p, "err click needs BUTTON");
+        }
+    } else if (!strcmp(cmd, "hold-click") || !strcmp(cmd, "holdclick")) {
+        if (n >= 3) {
+            int frames = atoi(tok[1]);
+            int b = atoi(tok[2]) - 1;
+            if (frames < 0) frames = 0;
+            if (b >= 0 && b < 3) {
+                p->btn[b] = true; p->click_left[b] = frames;
+                pilot_reply(p, "ok hold-click button=%d frames=%d", b + 1, frames);
+            } else {
+                pilot_reply(p, "err invalid button");
+            }
+        } else {
+            pilot_reply(p, "err hold-click needs FRAMES BUTTON");
+        }
     } else if (!strcmp(cmd, "scroll")) {
-        if (n >= 2) p->scroll_pending += atoi(tok[1]);
+        if (n >= 2) {
+            p->scroll_pending += atoi(tok[1]);
+            pilot_reply(p, "ok scroll pending=%d", p->scroll_pending);
+        } else {
+            pilot_reply(p, "err scroll needs DELTA");
+        }
     } else if (!strcmp(cmd, "target") || !strcmp(cmd, "t")) {
         if (n >= 2) {
             char k = (char)tolower((unsigned char)tok[1][0]);
             p->target = (k == 'j') ? PILOT_JOY : PILOT_MOUSE;
+            pilot_reply(p, "ok target=%s", p->target == PILOT_JOY ? "joy" : "mouse");
+        } else {
+            pilot_reply(p, "err target needs mouse|joy");
         }
     } else if (!strcmp(cmd, "reset")) {
         set_vector(p, 0.0, 0.0);
+        p->move_left = 0;
         release_all_buttons(p);
+        release_keytap(p, cpc);
+        pilot_reply(p, "ok reset");
+    } else if (!strcmp(cmd, "state")) {
+        reply_state(p, cpc);
+    } else if (!strcmp(cmd, "frame")) {
+        pilot_reply(p, "frame value=%d", p->frame_count);
+    } else if (!strcmp(cmd, "hash")) {
+        pilot_reply(p, "hash value=%08X", (unsigned)p->fb_hash);
+    } else if (!strcmp(cmd, "changed")) {
+        reply_changed(p);
+    } else if (!strcmp(cmd, "key-down")) {
+        if (n >= 2) {
+            SDL_Scancode sc = scancode_from_token(tok[1]);
+            if (sc != SDL_SCANCODE_UNKNOWN && kbd_sdl_key(&cpc->kbd, sc, true))
+                pilot_reply(p, "ok key-down name=%s", tok[1]);
+            else
+                pilot_reply(p, "err key-down unknown=%s", tok[1]);
+        } else {
+            pilot_reply(p, "err key-down needs NAME");
+        }
+    } else if (!strcmp(cmd, "key-up")) {
+        if (n >= 2) {
+            SDL_Scancode sc = scancode_from_token(tok[1]);
+            if (sc != SDL_SCANCODE_UNKNOWN && kbd_sdl_key(&cpc->kbd, sc, false))
+                pilot_reply(p, "ok key-up name=%s", tok[1]);
+            else
+                pilot_reply(p, "err key-up unknown=%s", tok[1]);
+        } else {
+            pilot_reply(p, "err key-up needs NAME");
+        }
+    } else if (!strcmp(cmd, "key-tap")) {
+        if (n >= 3) {
+            SDL_Scancode sc = scancode_from_token(tok[1]);
+            int frames = atoi(tok[2]);
+            if (frames < 1) frames = 1;
+            if (sc != SDL_SCANCODE_UNKNOWN && kbd_sdl_key(&cpc->kbd, sc, true)) {
+                release_keytap(p, cpc);
+                p->keytap_scancode = (int)sc;
+                p->keytap_left = frames;
+                pilot_reply(p, "ok key-tap name=%s frames=%d", tok[1], frames);
+            } else {
+                pilot_reply(p, "err key-tap unknown=%s", tok[1]);
+            }
+        } else {
+            pilot_reply(p, "err key-tap needs NAME FRAMES");
+        }
+    } else if (!strcmp(cmd, "paste")) {
+        char *text = raw;
+        while (*text && !isspace((unsigned char)*text)) text++;
+        while (*text && isspace((unsigned char)*text)) text++;
+        paste_text_raw(paste, text);
+        pilot_reply(p, "ok paste len=%d", (int)strlen(text));
+    } else if (!strcmp(cmd, "snapshot-save")) {
+        if (n >= 2) {
+            if (snapshot_save(cpc, tok[1]) == 0) pilot_reply(p, "ok snapshot-save path=%s", tok[1]);
+            else pilot_reply(p, "err snapshot-save path=%s", tok[1]);
+        } else {
+            pilot_reply(p, "err snapshot-save needs PATH");
+        }
+    } else if (!strcmp(cmd, "snapshot-load")) {
+        if (n >= 2) {
+            if (snapshot_load(cpc, tok[1]) == 0) {
+                p->have_last_pixels = false;
+                p->changed_w = p->changed_h = 0;
+                p->quiet_frames = 0;
+                pilot_reply(p, "ok snapshot-load path=%s", tok[1]);
+            } else pilot_reply(p, "err snapshot-load path=%s", tok[1]);
+        } else {
+            pilot_reply(p, "err snapshot-load needs PATH");
+        }
+    } else if (!strcmp(cmd, "crop")) {
+        if (n >= 6) {
+            int x = atoi(tok[2]), y = atoi(tok[3]), w = atoi(tok[4]), h = atoi(tok[5]);
+            int scale = (n >= 7) ? atoi(tok[6]) : 1;
+            if (display_save_crop_ppm(d, tok[1], x, y, w, h, scale)) {
+                pilot_reply(p, "ok crop path=%s rect=%d,%d,%d,%d scale=%d",
+                            tok[1], x, y, w, h, scale < 1 ? 1 : scale);
+            } else {
+                pilot_reply(p, "err crop path=%s rect=%d,%d,%d,%d scale=%d",
+                            tok[1], x, y, w, h, scale < 1 ? 1 : scale);
+            }
+        } else {
+            pilot_reply(p, "err crop needs PATH X Y W H [SCALE]");
+        }
+    } else if (!strcmp(cmd, "wait")) {
+        if (n < 2) {
+            pilot_reply(p, "err wait needs MODE");
+        } else if (!strcmp(tok[1], "frames")) {
+            if (n >= 3) {
+                p->wait_target_frames = atoi(tok[2]);
+                if (p->wait_target_frames < 0) p->wait_target_frames = 0;
+                start_wait(p, PILOT_WAIT_FRAMES, frame_now, parse_timeout(tok, n, 3, frame_now));
+            } else pilot_reply(p, "err wait frames needs N [TIMEOUT]");
+        } else if (!strcmp(tok[1], "hash-eq")) {
+            if (n >= 3) {
+                p->wait_hash = (u32)strtoul(tok[2], NULL, 16);
+                start_wait(p, PILOT_WAIT_HASH_EQ, frame_now, parse_timeout(tok, n, 3, frame_now));
+            } else pilot_reply(p, "err wait hash-eq needs HEX [TIMEOUT]");
+        } else if (!strcmp(tok[1], "hash-ne")) {
+            if (n >= 3) {
+                p->wait_hash = (u32)strtoul(tok[2], NULL, 16);
+                start_wait(p, PILOT_WAIT_HASH_NE, frame_now, parse_timeout(tok, n, 3, frame_now));
+            } else pilot_reply(p, "err wait hash-ne needs HEX [TIMEOUT]");
+        } else if (!strcmp(tok[1], "change")) {
+            start_wait(p, PILOT_WAIT_CHANGE, frame_now, parse_timeout(tok, n, 2, frame_now));
+        } else if (!strcmp(tok[1], "quiet")) {
+            if (n >= 3) {
+                p->wait_quiet_need = atoi(tok[2]);
+                if (p->wait_quiet_need < 1) p->wait_quiet_need = 1;
+                start_wait(p, PILOT_WAIT_QUIET, frame_now, parse_timeout(tok, n, 3, frame_now));
+            } else pilot_reply(p, "err wait quiet needs N [TIMEOUT]");
+        } else {
+            pilot_reply(p, "err wait unknown=%s", tok[1]);
+        }
     } else {
         fprintf(stderr, "[pilot] unknown command: %s\n", cmd);
+        pilot_reply(p, "err unknown command=%s", cmd);
     }
 }
 
@@ -175,15 +470,15 @@ static unsigned char joy_mask_for(double mag, double ang_deg) {
     return m[sector];
 }
 
-void pilot_tick(Pilot *p, CPC *cpc) {
+void pilot_tick(Pilot *p, CPC *cpc, Display *d, Paste *paste) {
     if (p->fd < 0) return;
 
     /* Drain everything available into the line buffer, executing on newline. */
     char c;
-    while (read(p->fd, &c, 1) == 1) {
+    while (p->wait_mode == PILOT_WAIT_NONE && read(p->fd, &c, 1) == 1) {
         if (c == '\n' || c == '\r') {
             p->line[p->line_len] = '\0';
-            exec_line(p, p->line);
+            exec_line(p, cpc, d, paste, p->line);
             p->line_len = 0;
         } else if (p->line_len < (int)sizeof(p->line) - 1) {
             p->line[p->line_len++] = c;
@@ -195,6 +490,8 @@ void pilot_tick(Pilot *p, CPC *cpc) {
     for (int b = 0; b < 3; b++)
         if (p->click_left[b] > 0 && --p->click_left[b] == 0)
             p->btn[b] = false;
+    if (p->keytap_left > 0 && --p->keytap_left == 0)
+        release_keytap(p, cpc);
 
     if (p->target == PILOT_MOUSE) {
         if (p->joy_held) {   /* just switched away from joystick — let go of row 9 */
@@ -231,17 +528,77 @@ void pilot_tick(Pilot *p, CPC *cpc) {
         }
         p->joy_held = true;
     }
+
+    if (p->move_left > 0 && --p->move_left == 0)
+        set_vector(p, 0.0, p->ang);
+}
+
+void pilot_post_frame(Pilot *p, CPC *cpc, Display *d, int frame_count) {
+    bool changed;
+    if (p->fd < 0) return;
+
+    p->frame_count = frame_count;
+    p->fb_hash = display_hash(d);
+    if (!p->last_pixels) return;
+    if (!p->have_last_pixels) {
+        display_copy_visible(d, p->last_pixels);
+        p->have_last_pixels = true;
+        p->changed_x = p->changed_y = 0;
+        p->changed_w = p->changed_h = 0;
+        p->quiet_frames = 0;
+        return;
+    }
+
+    changed = display_changed_rect(d, p->last_pixels,
+                                   &p->changed_x, &p->changed_y,
+                                   &p->changed_w, &p->changed_h);
+    if (changed) p->quiet_frames = 0;
+    else p->quiet_frames++;
+
+    if (p->wait_mode == PILOT_WAIT_NONE) return;
+    if (p->wait_timeout_frame >= 0 && frame_count >= p->wait_timeout_frame) {
+        fail_wait(p, "timeout");
+        return;
+    }
+
+    switch (p->wait_mode) {
+    case PILOT_WAIT_FRAMES:
+        if (frame_count - p->wait_start_frame >= p->wait_target_frames)
+            finish_wait(p, "frames");
+        break;
+    case PILOT_WAIT_HASH_EQ:
+        if (p->fb_hash == p->wait_hash) finish_wait(p, "hash-eq");
+        break;
+    case PILOT_WAIT_HASH_NE:
+        if (p->fb_hash != p->wait_hash) finish_wait(p, "hash-ne");
+        break;
+    case PILOT_WAIT_CHANGE:
+        if (changed) finish_wait(p, "change");
+        break;
+    case PILOT_WAIT_QUIET:
+        if (p->quiet_frames >= p->wait_quiet_need) finish_wait(p, "quiet");
+        break;
+    case PILOT_WAIT_NONE:
+    default:
+        break;
+    }
+    (void)cpc;
 }
 
 #else  /* _WIN32 — no PTYs */
 
-bool pilot_open(Pilot *p, const char *link, PilotTarget initial) {
-    (void)link; (void)initial;
+bool pilot_open(Pilot *p, const char *link, PilotTarget initial, bool reply_stderr) {
+    (void)link; (void)initial; (void)reply_stderr;
     memset(p, 0, sizeof(*p)); p->fd = -1;
     fprintf(stderr, "1984: --pilot is not supported on Windows\n");
     return false;
 }
 bool pilot_is_open(const Pilot *p) { (void)p; return false; }
-void pilot_tick(Pilot *p, CPC *cpc) { (void)p; (void)cpc; }
+void pilot_tick(Pilot *p, CPC *cpc, Display *d, Paste *paste) {
+    (void)p; (void)cpc; (void)d; (void)paste;
+}
+void pilot_post_frame(Pilot *p, CPC *cpc, Display *d, int frame_count) {
+    (void)p; (void)cpc; (void)d; (void)frame_count;
+}
 
 #endif

--- a/src/pilot.h
+++ b/src/pilot.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <stdbool.h>
 #include "cpc.h"
+#include "display.h"
+#include "paste.h"
 
 /*
  * pilot — an "auto-pilot" input device driven from a host PTY (/dev/pts).
@@ -29,20 +31,42 @@
  *   press N        press button N (1=left/Fire1, 2=right/Fire2, 3=middle). p.
  *   release N      release button N (also: u).
  *   click N        press button N and auto-release after a few frames (c).
+ *   hold F R THETA hold the vector for F frames, then auto-stop.
+ *   hold-click F N press button N for F frames, then auto-release.
  *   scroll DZ      mouse wheel by DZ (mouse target only).
+ *   key-down NAME   press a CPC key by SDL scancode name (e.g. A, Return).
+ *   key-up NAME     release that key.
+ *   key-tap NAME F  press for F frames, then release.
+ *   paste TEXT      queue TEXT through the existing paste path.
  *   target mouse   route to the mouse pointer (default). Aliases: t m.
  *   target joy     route to CPC joystick 1 (row 9). Aliases: t j / joystick.
  *   reset          stop and release every button/direction.
+ *   state          emit a machine-readable state line on the PTY.
+ *   frame          emit the current frame counter.
+ *   hash           emit the current framebuffer hash.
+ *   changed        emit the latest changed-rectangle summary.
+ *   wait ...       block until a frame/hash/change/quiet condition is met.
+ *   crop PATH X Y W H [SCALE]  save a cropped screenshot.
+ *   snapshot-save PATH / snapshot-load PATH
  *
  * Linux/POSIX only (PTYs); Windows builds get no-op stubs.
  */
 
 typedef enum { PILOT_MOUSE = 0, PILOT_JOY = 1 } PilotTarget;
+typedef enum {
+    PILOT_WAIT_NONE = 0,
+    PILOT_WAIT_FRAMES,
+    PILOT_WAIT_HASH_EQ,
+    PILOT_WAIT_HASH_NE,
+    PILOT_WAIT_CHANGE,
+    PILOT_WAIT_QUIET,
+} PilotWaitMode;
 
 typedef struct {
     int          fd;            /* master PTY fd, -1 when closed         */
     char         slave[256];    /* /dev/pts/N slave path                 */
     char         link[256];     /* optional stable symlink alias         */
+    bool         reply_stderr;  /* mirror machine replies to stderr      */
     PilotTarget  target;
 
     double       mag, ang;      /* last commanded polar vector           */
@@ -51,19 +75,42 @@ typedef struct {
 
     bool         btn[3];        /* current button state (0=L 1=R 2=M)    */
     int          click_left[3]; /* frames until auto-release (0 = none)  */
+    int          move_left;     /* frames until auto-stop (0 = none)      */
+    int          keytap_left;   /* frames until auto-release of key tap   */
+    int          keytap_scancode;
     int          scroll_pending;/* wheel delta queued for the next tick  */
     bool         joy_held;      /* row 9 is currently being driven       */
+
+    int          frame_count;   /* most recent completed frame           */
+    u32          fb_hash;       /* most recent completed framebuffer hash */
+    u32         *last_pixels;   /* previous frame for diffing             */
+    bool         have_last_pixels;
+    int          changed_x, changed_y, changed_w, changed_h;
+    int          quiet_frames;
+
+    PilotWaitMode wait_mode;
+    int           wait_target_frames;
+    int           wait_start_frame;
+    int           wait_timeout_frame;   /* -1 = no timeout */
+    u32           wait_hash;
+    int           wait_quiet_need;
 
     char         line[256];     /* partial-line accumulator              */
     int          line_len;
 } Pilot;
 
 /* Open the pilot PTY. link may be NULL/empty (no symlink). initial sets the
- * starting target. Returns true on success; on failure leaves fd = -1. */
-bool pilot_open(Pilot *p, const char *link, PilotTarget initial);
+ * starting target. reply_stderr mirrors machine replies to stderr for
+ * harnesses that want one-shot PTY writes plus out-of-band responses.
+ * Returns true on success; on failure leaves fd = -1. */
+bool pilot_open(Pilot *p, const char *link, PilotTarget initial, bool reply_stderr);
 
 bool pilot_is_open(const Pilot *p);
 
-/* Call once per emulated frame: drains pending commands and applies the held
- * velocity / button state to the machine. Cheap no-op when closed. */
-void pilot_tick(Pilot *p, CPC *cpc);
+/* Pre-frame pass: drain pending commands and apply input state for the next
+ * emulated frame. */
+void pilot_tick(Pilot *p, CPC *cpc, Display *d, Paste *paste);
+
+/* Post-frame pass: refresh diagnostics state from the completed frame and
+ * complete any pending waits. frame_count is the just-finished frame. */
+void pilot_post_frame(Pilot *p, CPC *cpc, Display *d, int frame_count);


### PR DESCRIPTION
## Summary
- extend `--pilot` into a command/reply diagnostics protocol with waits, state queries, key input, snapshot control, and targeted crop capture
- add framebuffer hash and changed-rectangle helpers in the display layer and wire the pilot into pre-frame/post-frame passes
- make crop replies truthful and keep changed/crop in the same visible-framebuffer coordinate space

## Verification
- rebuilt `1984` in distrobox after the changes
- ran `python3 debug/ai_diag.py --smoke -- --config=/dev/null --exit-after=200`
- verified invalid crop paths now return `err crop ...`
- verified a `changed` rectangle can be fed back into `crop` and produces the expected-sized PPM artifact
