### PR TITLE
Fix FreeBSD build: re-expose BSD extensions hidden by _XOPEN_SOURCE (#203)

### DIFF
--- a/src/compat_win.h
+++ b/src/compat_win.h
@@ -133,6 +133,14 @@ static inline unsigned long long compat_fs_free_bytes(const char *path) {
 #include <unistd.h>
 #include <errno.h>
 
+/* MSG_NOSIGNAL is a Linux extension absent on macOS and older BSDs (and
+ * hidden on the BSDs unless __BSD_VISIBLE is on). 0 is a safe fallback —
+ * sockets here are non-blocking. Defined AFTER <sys/socket.h> so the
+ * system header wins first where it has the constant (issue #203). */
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
+
 #define sock_close(fd)      close(fd)
 
 static inline int sock_set_nonblocking(int fd) {

--- a/src/kbd_pty.c
+++ b/src/kbd_pty.c
@@ -7,6 +7,11 @@
  * machine end-to-end without xdotool/Xvfb. */
 
 #define _XOPEN_SOURCE 600
+/* See usifac.c / issue #203: the BSDs hide the Bxxxx baud constants behind
+ * __BSD_VISIBLE, which _XOPEN_SOURCE turns off. */
+#if defined(__FreeBSD__) || defined(__DragonFly__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#define __BSD_VISIBLE 1
+#endif
 #include "kbd_pty.h"
 
 #include <stdio.h>

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -1,5 +1,10 @@
 #ifndef _WIN32
 #define _XOPEN_SOURCE 600   /* posix_openpt, grantpt, unlockpt, ptsname */
+/* See usifac.c / issue #203: the BSDs hide the Bxxxx baud constants behind
+ * __BSD_VISIBLE, which _XOPEN_SOURCE turns off. */
+#if defined(__FreeBSD__) || defined(__DragonFly__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#define __BSD_VISIBLE 1
+#endif
 #endif
 #include "monitor.h"
 #include "z80dis.h"

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -2,6 +2,11 @@
 
 #define _XOPEN_SOURCE 600   /* posix_openpt, grantpt, unlockpt, ptsname */
 #define _DEFAULT_SOURCE     /* cfmakeraw */
+/* See usifac.c / issue #203: the BSDs hide cfmakeraw behind __BSD_VISIBLE,
+ * which _XOPEN_SOURCE turns off. */
+#if defined(__FreeBSD__) || defined(__DragonFly__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#define __BSD_VISIBLE 1
+#endif
 
 #include "pilot.h"
 #include "cpc.h"

--- a/src/usifac.c
+++ b/src/usifac.c
@@ -2,6 +2,12 @@
 
 #define _XOPEN_SOURCE 600   /* posix_openpt, grantpt, unlockpt, ptsname */
 #define _DEFAULT_SOURCE     /* cfmakeraw */
+/* On the BSDs, defining _XOPEN_SOURCE/_POSIX_C_SOURCE turns __BSD_VISIBLE
+ * off, hiding cfmakeraw, B115200, INADDR_LOOPBACK and MSG_NOSIGNAL. Force
+ * it back on (see issue #203). */
+#if defined(__FreeBSD__) || defined(__DragonFly__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#define __BSD_VISIBLE 1
+#endif
 
 #include "usifac.h"
 #include "perryfi.h"
@@ -22,6 +28,11 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
+/* MSG_NOSIGNAL is a Linux extension absent on macOS/older BSDs; 0 is a safe
+ * fallback. Defined AFTER <sys/socket.h> so the system header wins first. */
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
 #endif
 
 #define MASK (USIFAC_RING - 1)


### PR DESCRIPTION
Fixes #203.

## Problem
On the BSDs, defining `_XOPEN_SOURCE` / `_POSIX_C_SOURCE` turns `__BSD_VISIBLE` **off**, hiding BSD-extension symbols: `cfmakeraw`, the `Bxxxx` baud constants, `INADDR_LOOPBACK`, and `MSG_NOSIGNAL`. On glibc, `_DEFAULT_SOURCE` re-enables them; the BSDs have no equivalent, so the 0.4.11 build failed on FreeBSD 15.1 in `usifac.c` (same class of bug as 1985 issue #51).

## Fix
- Force `__BSD_VISIBLE 1` on FreeBSD/DragonFly/OpenBSD/NetBSD in the PTY/socket translation units that set a restrictive feature-test macro: `usifac.c`, `pilot.c`, `kbd_pty.c`, `monitor.c` — the same guard `perryfi.c` already carries.
- Add a `MSG_NOSIGNAL` fallback in `usifac.c` and centrally in `compat_win.h` (covers `m4.c`) so macOS / older BSDs without the constant still build.

All guards are platform-gated, so Linux/Windows are unaffected.

## Testing
- Clean Linux build confirmed (`EXIT=0`).
- FreeBSD build confirmed building by reporters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)