### PR TITLE
Support M4 image file erase

### DIFF
--- a/src/fat.c
+++ b/src/fat.c
@@ -697,6 +697,34 @@ bool fat_seek(FatFile *f, u32 pos) {
 u32 fat_tell(FatFile *f)      { return f ? f->file_offset : 0; }
 u32 fat_file_size(FatFile *f) { return f ? f->file_size   : 0; }
 
+bool fat_delete(FatVol *v, const char *path) {
+    if (!v || !v->fp || !path) return false;
+
+    char leaf[256];
+    u32  parent;
+    if (!split_parent(v, path, &parent, leaf, sizeof(leaf))) return false;
+
+    u32 lba = 0;
+    u16 off = 0;
+    u8 slot[32];
+    if (!find_in_dir(v, parent, leaf, &lba, &off, slot)) return false;
+    if (slot[11] & 0x18) return false;  /* refuse directories and volume labels */
+
+    u32 c = ((u32)rd_u16(&slot[20]) << 16) | rd_u16(&slot[26]);
+    while (c >= 2 && !fat_is_eoc(v, c)) {
+        u32 n = fat_read_entry(v, c);
+        if (!fat_write_entry(v, c, 0)) return false;
+        c = n;
+    }
+
+    u8 sec[512];
+    if (!sec_read(v, lba, sec)) return false;
+    sec[off] = 0xE5;
+    if (!sec_write(v, lba, sec)) return false;
+    fat_flush_cache(v);
+    return true;
+}
+
 bool fat_write_dir_entry(FatVol *v, u32 sector, u16 byte_offset,
                          const u8 entry[32]) {
     if (!v || !v->fp || byte_offset + 32 > v->bytes_per_sector) return false;

--- a/src/fat.h
+++ b/src/fat.h
@@ -109,6 +109,9 @@ u32 fat_file_size(FatFile *f);
 /* Close (flushes the directory entry on writes). */
 void fat_close(FatFile *f);
 
+/* Delete a regular file and free its cluster chain. Directories are refused. */
+bool fat_delete(FatVol *v, const char *path);
+
 /* Overwrite a 32-byte FAT directory entry at (sector, byte_offset).
  * Used by Albireo's CH376 DIR_INFO_SAVE command, which is how UNIDOS
  * implements renames (it edits the name field of an existing entry).

--- a/src/m4.c
+++ b/src/m4.c
@@ -1176,11 +1176,23 @@ bool m4_ackport_write(M4 *m, Mem *mem) {
     }
 
     case C_ERASEFILE: {
-        if (!m->root[0] || plen < 1) { err = M4_ERR_IO; break; }
-        char hostpath[M4_PATH_MAX];
-        if (!resolve_path(m, (const char *)p, hostpath, sizeof(hostpath)))
-            { err = M4_ERR_NOFILE; break; }
-        err = (remove(hostpath) == 0) ? M4_OK : M4_ERR_IO;
+        u8 erase_err = M4_ERR_IO;
+        if (plen >= 1) {
+            if (m4_use_fat(m)) {
+                char abs[M4_PATH_MAX];
+                fat_abs_path(m, (const char *)p, abs, sizeof(abs));
+                erase_err = m->image_read_only ? M4_ERR_RDONLY :
+                    (fat_delete(&m->image_vol, abs) ? M4_OK : M4_ERR_NOFILE);
+            } else if (m->root[0]) {
+                char hostpath[M4_PATH_MAX];
+                if (resolve_path(m, (const char *)p, hostpath, sizeof(hostpath)))
+                    erase_err = (remove(hostpath) == 0) ? M4_OK : M4_ERR_IO;
+                else
+                    erase_err = M4_ERR_NOFILE;
+            }
+        }
+        resp_u8(m, &roff, erase_err);
+        err = M4_OK;
         break;
     }
 


### PR DESCRIPTION
Summary:\n- Add FAT image file deletion support.\n- Route M4 C_ERASEFILE through the FAT image backend when M4 uses an image.\n- Return an explicit M4 status byte and reject read-only images.\n\nNeeded so GEOBENCH Trash deletes are observable when testing M4 image mode with GEOBENCH.IMG.