### PR TITLE
Bring the Flatpak machinery into main; retire the flatpak branch (#199)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
     tags:     ['v*']
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   linux:
@@ -73,9 +74,37 @@ jobs:
           name: 1984-windows-x86_64
           path: dist/
 
+  flatpak:
+    name: Flatpak (x86_64)
+    # Slow (~15 min); skip on PRs (the manifest builds branch:main, so a PR
+    # build wouldn't reflect the PR anyway). Runs on main, tags, and manual
+    # dispatch. The Linux job already covers PR compile breakage.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' &&
+       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:freedesktop-24.08
+      options: --privileged
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Flatpak bundle
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: 1984.flatpak
+          manifest-path: io.github.salvogendut.Emulator1984.yml
+          cache-key: flatpak-builder-${{ github.sha }}
+          upload-artifact: false
+      - name: Upload bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: 1984-flatpak-x86_64
+          path: 1984.flatpak
+
   release:
     name: Publish GitHub Release
-    needs: [linux, windows]
+    needs: [linux, windows, flatpak]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
@@ -98,6 +127,9 @@ jobs:
 
           # Windows: zip the full bundle (exe + DLLs + roms)
           (cd artifacts/1984-windows-x86_64 && zip -r "../../assets/1984-${tag}-windows-x86_64.zip" .)
+
+          # Flatpak: single-file bundle, installable with `flatpak install`
+          cp artifacts/1984-flatpak-x86_64/1984.flatpak "assets/1984-${tag}-x86_64.flatpak"
 
           ls -la assets/
       - name: Create release

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,14 @@ roms/*
 # dist tarballs produced by `make dist`
 /1984-*.tar.gz
 
+# flatpak-builder artifacts and bundles
+/.flatpak-builder/
+/flatpak-repo/
+/fp-build/
+/build-dir/
+/flatpak-build.log
+/1984*.flatpak
+
 # Windows build output dirs (CI artifacts cover these now)
 /dist-win*/
 

--- a/Development.md
+++ b/Development.md
@@ -801,8 +801,9 @@ under Wine on Linux). Four points worth knowing:
 
 ## Continuous integration
 
-`.github/workflows/build.yml` defines two jobs that run on every push
-to `main`/`windows-port` and on every PR to `main`:
+`.github/workflows/build.yml` defines the build, package, and release jobs.
+Linux and Windows run on every push to `main`/`windows-port` and every PR to
+`main`; the Flatpak job runs on `main`, tags, and manual dispatch (not PRs).
 
 - **Linux** — runs inside a `fedora:41` container, installs the standard
   build deps (`gcc make autoconf automake pkgconf SDL3-devel`), runs
@@ -814,6 +815,13 @@ to `main`/`windows-port` and on every PR to `main`:
   into the `1984-windows-x86_64` artifact. `cache: true` keeps the
   pacman package cache between runs so subsequent setups drop from ~8
   minutes to ~30 seconds.
+- **Flatpak** — builds `io.github.salvogendut.Emulator1984.yml` in the
+  `freedesktop-24.08` container via the `flatpak/flatpak-github-actions`
+  action and uploads the `1984.flatpak` bundle. Skipped on PRs because the
+  manifest builds `branch: main` (the Linux job already covers PR compile
+  breakage). See [docs/FLATPAK.md](docs/FLATPAK.md).
 
-No release pipeline yet — artifacts are downloadable from the Actions
-tab but not attached to GitHub Releases.
+On a `v*` tag the **release** job (`needs: [linux, windows, flatpak]`)
+packages all three artifacts and publishes them to a GitHub Release —
+`1984-<tag>-linux-x86_64`, `1984-<tag>-windows-x86_64.zip`, and
+`1984-<tag>-x86_64.flatpak`.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Pre-built Linux and Windows binaries are attached to each [GitHub Release](https
 - **[INSTALL.md](INSTALL.md)** — installing pre-built binaries, building from source on each supported platform, ROM file requirements
 - **[USAGE.md](USAGE.md)** — command-line options, keyboard shortcuts, joystick mapping, options overlay (F9), memory monitor (F8), F10 host-side card browse, config file format
 - **[Development.md](Development.md)** — architecture, render pipeline, hardware emulation details, CI, port-specific notes (Haiku / NetBSD / Windows)
+- **[docs/FLATPAK.md](docs/FLATPAK.md)** — building and distributing the Flatpak from `main`; manifest layout, local bundle build, CI auto-build on tags
 
 Per-expansion guides:
 

--- a/docs/FLATPAK.md
+++ b/docs/FLATPAK.md
@@ -1,0 +1,69 @@
+# Building and distributing the Flatpak
+
+The Flatpak manifest, `io.github.salvogendut.Emulator1984.yml`, lives in the
+repository root on `main`. There is **no separate `flatpak` branch** — the
+manifest builds the emulator straight from `main`, so everything needed to
+produce a Flatpak ships with the code it packages.
+
+## Manifest at a glance
+
+- **Runtime:** `org.freedesktop.Platform // 24.08` (SDK `org.freedesktop.Sdk//24.08`).
+- **Modules:**
+  1. `sdl3` — SDL `release-3.4.10` built from source (the freedesktop runtime
+     has no SDL3), shared library only, tests/examples stripped.
+  2. `emulator-1984` — `autoreconf -fi && ./configure --prefix=/app && make &&
+     make install`, sourced via `type: git` from this repository's `main`
+     branch.
+- **`command: '1984'`** — quoted on purpose. Unquoted, YAML parses `1984` as an
+  integer and flatpak-builder rejects it.
+- **Permissions** (`finish-args`): Wayland + X11 fallback, PulseAudio, DRI,
+  network, `--device=all` (gamepads), and `--filesystem=home` (disk/ROM/SD
+  images the user points at).
+
+Because the `emulator-1984` module pulls `branch: main` over git, a Flatpak
+build always packages the latest pushed `main`. Push your changes first, then
+build.
+
+## Build a local bundle
+
+Requires `flatpak` and `flatpak-builder`, plus the freedesktop 24.08 runtime/SDK:
+
+```bash
+flatpak install -y flathub org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08
+
+# Build + install into the user installation in one step:
+flatpak-builder --user --install --force-clean build-dir \
+    io.github.salvogendut.Emulator1984.yml
+flatpak run io.github.salvogendut.Emulator1984
+```
+
+To produce a single-file, shareable bundle instead:
+
+```bash
+flatpak-builder --force-clean --repo=flatpak-repo build-dir \
+    io.github.salvogendut.Emulator1984.yml
+flatpak build-bundle flatpak-repo 1984.flatpak io.github.salvogendut.Emulator1984
+# Install it anywhere with:
+flatpak install --user 1984.flatpak
+```
+
+All of `build-dir/`, `flatpak-repo/`, `.flatpak-builder/`, and `*.flatpak` are
+git-ignored.
+
+## CI
+
+`.github/workflows/build.yml` has a `flatpak` job that builds the bundle in the
+`bilelmoussaoui/flatpak-github-actions:freedesktop-24.08` container via the
+`flatpak/flatpak-github-actions/flatpak-builder` action. It runs on:
+
+- pushes to `main`,
+- version tags (`v*`),
+- manual **workflow_dispatch** (Actions tab → *build* → *Run workflow*).
+
+It is **skipped on pull requests** — the manifest builds `branch: main`, so a PR
+build wouldn't reflect the PR's own changes, and the `Linux (Fedora)` job
+already catches compile breakage. To validate a manifest change before merging,
+trigger the workflow manually from your branch via workflow_dispatch.
+
+On a `v*` tag the `release` job attaches the bundle to the GitHub Release as
+`1984-<tag>-x86_64.flatpak`, alongside the Linux and Windows assets.

--- a/io.github.salvogendut.Emulator1984.yml
+++ b/io.github.salvogendut.Emulator1984.yml
@@ -2,7 +2,8 @@ app-id: io.github.salvogendut.Emulator1984
 runtime: org.freedesktop.Platform
 runtime-version: '24.08'
 sdk: org.freedesktop.Sdk//24.08
-command: 1984
+# Quoted so flatpak-builder parses it as a string, not the integer 1984.
+command: '1984'
 
 finish-args:
   - --socket=wayland


### PR DESCRIPTION
Fixes #199.

## The problem
Producing a Flatpak meant keeping a separate `flatpak` branch in sync with `main` via periodic `git merge main` — impractical per release.

## Why it's actually trivial
The `flatpak` branch carried **no unique code**: its manifest's `emulator-1984` module already sources `type: git … branch: main`, so the Flatpak always built from `main` regardless. The branch only held:
1. a corrected manifest (`command: '1984'`), and
2. `.gitignore` patterns for build artifacts.

The metainfo and everything else were already in sync. So unification = fold those two bits into `main`.

## Changes
- **Manifest**: quote `command: '1984'`. Unquoted, YAML parses it as the integer `1984` and flatpak-builder rejects it — the one real fix the branch carried.
- **.gitignore**: flatpak-builder artifact/bundle patterns (`.flatpak-builder/`, `flatpak-repo/`, `build-dir/`, `*.flatpak`, …).
- **CI** (`build.yml`): new `flatpak` job builds the bundle in the `freedesktop-24.08` container via `flatpak/flatpak-github-actions`. Runs on `main`, `v*` tags, and manual **workflow_dispatch**; **skipped on PRs** (the manifest builds `branch:main`, and the Linux job already covers PR compile breakage). The `release` job now also attaches `1984-<tag>-x86_64.flatpak` to the GitHub Release.
- **Docs**: new `docs/FLATPAK.md` (local build + CI); refreshed the stale CI section in `Development.md` (it still said "two jobs" / "no release pipeline yet") and added the README doc-index entry.

## Verification
- Both YAML files parse (`build.yml` → jobs `linux, windows, flatpak, release`; `release.needs = [linux, windows, flatpak]`; manifest `command` is the string `'1984'`).
- No source code touched.
- The CI flatpak build itself is verified-by-construction (standard `flatpak-github-actions` action + matching `freedesktop-24.08` image) — it'll first run live on merge to `main`.

## After merge
The `flatpak` branch can be deleted — no more per-release branch merges. (I can delete it once this lands.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)