### PR TITLE
Release 0.4.12

### DIFF
--- a/1984.spec
+++ b/1984.spec
@@ -1,5 +1,5 @@
 Name:           1984
-Version:        0.4.11
+Version:        0.4.12
 Release:        1%{?dist}
 Summary:        Amstrad CPC 464/6128 emulator
 
@@ -83,6 +83,18 @@ appstream-util validate-relax --nonet %{buildroot}%{_datadir}/metainfo/io.github
 %{_datadir}/%{name}/roms/OS_6128.ROM
 
 %changelog
+* Tue Jun 30 2026 Salvatore Bognanni <salvogendut@gmail.com> - 0.4.12-1
+- M4 no longer needs the ROM Board and now coexists with the RTC,
+  SYMBiFACE mouse/IDE and Net4CPC; only Albireo stays mutually exclusive.
+  MX4 cards map their own onboard ROM independently (#205).
+- M4 SD-card image files can now be erased from the overlay (#206).
+- New --pilot host-PTY auto-pilot: drive the mouse pointer or CPC
+  joystick from a script or AI via polar-coordinate commands (#200).
+- Fix FreeBSD build: re-expose BSD extensions hidden by _XOPEN_SOURCE
+  (#203).
+- Flatpak now builds from main and ships as a release asset; the separate
+  flatpak branch was retired (#199).
+
 * Sun Jun 28 2026 Salvatore Bognanni <salvogendut@gmail.com> - 0.4.11-1
 - Display: new Real CRT post-process under Advanced with adjustable
   scanlines, brightness, contrast, and per-channel RGB gain (#81, #195).

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([1984], [0.4.11], [], [1984])
+AC_INIT([1984], [0.4.12], [], [1984])
 AC_CONFIG_SRCDIR([src/main.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])

--- a/io.github.salvogendut.Emulator1984.metainfo.xml
+++ b/io.github.salvogendut.Emulator1984.metainfo.xml
@@ -30,6 +30,11 @@
   <url type="bugtracker">https://github.com/salvogendut/1984/issues</url>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="0.4.12" date="2026-06-30">
+      <description>
+        <p>M4 no longer requires the ROM Board and now coexists with the RTC, SYMBiFACE mouse/IDE and Net4CPC — only Albireo stays mutually exclusive — and each MX4 card maps its own onboard ROM. M4 SD-card image files can be erased from the overlay. New --pilot host-PTY auto-pilot drives the mouse pointer or CPC joystick from a script or AI via polar-coordinate commands. FreeBSD build fixed. Flatpak now builds from main and ships as a release asset.</p>
+      </description>
+    </release>
     <release version="0.4.11" date="2026-06-28">
       <description>
         <p>Display and audio overhaul. New Real CRT post-process under Advanced — adjustable scanline opacity, brightness, contrast, and per-channel red/green/blue gain for white-point and tint correction (#81, #195). AY-3-8912 output is now interleaved stereo with Caprice32-style ABC channel panning (blendable from mono to full separation), a perceptual master volume control, and a DC blocker that kills the clicks register 7 used to make when toggling a channel mid-frame (#178); the envelope prescaler and sampled-audio playback are corrected so digi-tunes and effects sound right (#179, #186). On-screen toast notifications surface hardware events (USIfAC link-up, client connect/disconnect) in a fading bottom-left "smoked" panel, toggleable between screen / console / off, with a debug-gated stderr echo (#190); the activity LEDs gain hover labels (#191). The MC6845 CRTC gains overscan and hybrid screen-mode support — split-screen via mid-frame R-register reprogramming, R9 character-height changes, rupture-style raster tricks, and a modelled displayed-address pipeline — fixing raster timing in Bomb Jack, Batman Forever, and Xevious (#170, #181, #183, #105). CP/M Plus ROM probe fallback fixed (#108).</p>


### PR DESCRIPTION
Version bump for the 0.4.12 release. Tagging `v0.4.12` after merge triggers the build workflow, which publishes the Linux ELF, Windows zip, **and the new Flatpak bundle** to the GitHub Release.

Bumps `configure.ac`, `1984.spec` (+ changelog), and adds the metainfo `<release>` entry.

### Since 0.4.11
- **M4 untangled from the ROM Board** and now coexists with the RTC, SYMBiFACE mouse/IDE and Net4CPC (only Albireo stays mutually exclusive); each MX4 card maps its own onboard ROM. "experimental" label dropped (#205)
- M4 SD-card image file erase from the overlay (#206)
- New **`--pilot`** host-PTY auto-pilot for driving the mouse pointer / CPC joystick from a script or AI (#200, #202)
- FreeBSD build fix (#203)
- Flatpak builds from `main` and ships as a release asset; the separate flatpak branch was retired (#199)

Verified: metainfo passes `appstreamcli validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)