### PR TITLE
Add AMX mouse "Fallback Input" toggle (joystick port) — #211

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,6 +11,7 @@ dist_man1_MANS = 1984.1
 	src/z80dis.c \
 	src/crtc.c \
 	src/disk.c \
+	src/amx.c \
 	src/display.c \
 	src/fdc.c \
 	src/gate_array.c \
@@ -49,6 +50,7 @@ dist_man1_MANS = 1984.1
 	src/z80.c
 
 noinst_HEADERS = \
+	src/amx.h \
 	src/ch376.h \
 	src/compat_win.h \
 	src/config.h \

--- a/Makefile.in
+++ b/Makefile.in
@@ -121,25 +121,25 @@ am__dirstamp = $(am__leading_dot)dirstamp
 am_1984_OBJECTS = src/1984-config.$(OBJEXT) src/1984-cpc.$(OBJEXT) \
 	src/1984-monitor.$(OBJEXT) src/1984-net4cpc.$(OBJEXT) \
 	src/1984-z80dis.$(OBJEXT) src/1984-crtc.$(OBJEXT) \
-	src/1984-disk.$(OBJEXT) src/1984-display.$(OBJEXT) \
-	src/1984-fdc.$(OBJEXT) src/1984-gate_array.$(OBJEXT) \
-	src/1984-joy.$(OBJEXT) src/1984-kbd.$(OBJEXT) \
-	src/1984-main.$(OBJEXT) src/1984-mem.$(OBJEXT) \
-	src/1984-overlay.$(OBJEXT) src/1984-paste.$(OBJEXT) \
-	src/1984-kbd_pty.$(OBJEXT) src/1984-printer.$(OBJEXT) \
-	src/1984-screen_text.$(OBJEXT) src/1984-ppi.$(OBJEXT) \
-	src/1984-psg.$(OBJEXT) src/1984-rtc.$(OBJEXT) \
-	src/1984-ide.$(OBJEXT) src/1984-fat.$(OBJEXT) \
-	src/1984-ch376.$(OBJEXT) src/1984-usifac.$(OBJEXT) \
-	src/1984-perryfi.$(OBJEXT) src/1984-symbols.$(OBJEXT) \
-	src/1984-gifcap.$(OBJEXT) src/1984-webmcap.$(OBJEXT) \
-	src/1984-host_mount.$(OBJEXT) src/1984-leds.$(OBJEXT) \
-	src/1984-m4.$(OBJEXT) src/1984-symbnet.$(OBJEXT) \
-	src/1984-symbos_trace.$(OBJEXT) src/1984-mouse.$(OBJEXT) \
-	src/1984-n4c_stack.$(OBJEXT) src/1984-notify.$(OBJEXT) \
-	src/1984-pilot.$(OBJEXT) src/1984-snapshot.$(OBJEXT) \
-	src/1984-tap.$(OBJEXT) src/1984-tape.$(OBJEXT) \
-	src/1984-z80.$(OBJEXT)
+	src/1984-disk.$(OBJEXT) src/1984-amx.$(OBJEXT) \
+	src/1984-display.$(OBJEXT) src/1984-fdc.$(OBJEXT) \
+	src/1984-gate_array.$(OBJEXT) src/1984-joy.$(OBJEXT) \
+	src/1984-kbd.$(OBJEXT) src/1984-main.$(OBJEXT) \
+	src/1984-mem.$(OBJEXT) src/1984-overlay.$(OBJEXT) \
+	src/1984-paste.$(OBJEXT) src/1984-kbd_pty.$(OBJEXT) \
+	src/1984-printer.$(OBJEXT) src/1984-screen_text.$(OBJEXT) \
+	src/1984-ppi.$(OBJEXT) src/1984-psg.$(OBJEXT) \
+	src/1984-rtc.$(OBJEXT) src/1984-ide.$(OBJEXT) \
+	src/1984-fat.$(OBJEXT) src/1984-ch376.$(OBJEXT) \
+	src/1984-usifac.$(OBJEXT) src/1984-perryfi.$(OBJEXT) \
+	src/1984-symbols.$(OBJEXT) src/1984-gifcap.$(OBJEXT) \
+	src/1984-webmcap.$(OBJEXT) src/1984-host_mount.$(OBJEXT) \
+	src/1984-leds.$(OBJEXT) src/1984-m4.$(OBJEXT) \
+	src/1984-symbnet.$(OBJEXT) src/1984-symbos_trace.$(OBJEXT) \
+	src/1984-mouse.$(OBJEXT) src/1984-n4c_stack.$(OBJEXT) \
+	src/1984-notify.$(OBJEXT) src/1984-pilot.$(OBJEXT) \
+	src/1984-snapshot.$(OBJEXT) src/1984-tap.$(OBJEXT) \
+	src/1984-tape.$(OBJEXT) src/1984-z80.$(OBJEXT)
 1984_OBJECTS = $(am_1984_OBJECTS)
 am__DEPENDENCIES_1 =
 1984_LINK = $(CCLD) $(1984_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) \
@@ -159,23 +159,24 @@ am__v_at_1 =
 DEFAULT_INCLUDES = -I.@am__isrc@
 depcomp = $(SHELL) $(top_srcdir)/build-aux/depcomp
 am__maybe_remake_depfiles = depfiles
-am__depfiles_remade = src/$(DEPDIR)/1984-ch376.Po \
-	src/$(DEPDIR)/1984-config.Po src/$(DEPDIR)/1984-cpc.Po \
-	src/$(DEPDIR)/1984-crtc.Po src/$(DEPDIR)/1984-disk.Po \
-	src/$(DEPDIR)/1984-display.Po src/$(DEPDIR)/1984-fat.Po \
-	src/$(DEPDIR)/1984-fdc.Po src/$(DEPDIR)/1984-gate_array.Po \
-	src/$(DEPDIR)/1984-gifcap.Po src/$(DEPDIR)/1984-host_mount.Po \
-	src/$(DEPDIR)/1984-ide.Po src/$(DEPDIR)/1984-joy.Po \
-	src/$(DEPDIR)/1984-kbd.Po src/$(DEPDIR)/1984-kbd_pty.Po \
-	src/$(DEPDIR)/1984-leds.Po src/$(DEPDIR)/1984-m4.Po \
-	src/$(DEPDIR)/1984-main.Po src/$(DEPDIR)/1984-mem.Po \
-	src/$(DEPDIR)/1984-monitor.Po src/$(DEPDIR)/1984-mouse.Po \
-	src/$(DEPDIR)/1984-n4c_stack.Po src/$(DEPDIR)/1984-net4cpc.Po \
-	src/$(DEPDIR)/1984-notify.Po src/$(DEPDIR)/1984-overlay.Po \
-	src/$(DEPDIR)/1984-paste.Po src/$(DEPDIR)/1984-perryfi.Po \
-	src/$(DEPDIR)/1984-pilot.Po src/$(DEPDIR)/1984-ppi.Po \
-	src/$(DEPDIR)/1984-printer.Po src/$(DEPDIR)/1984-psg.Po \
-	src/$(DEPDIR)/1984-rtc.Po src/$(DEPDIR)/1984-screen_text.Po \
+am__depfiles_remade = src/$(DEPDIR)/1984-amx.Po \
+	src/$(DEPDIR)/1984-ch376.Po src/$(DEPDIR)/1984-config.Po \
+	src/$(DEPDIR)/1984-cpc.Po src/$(DEPDIR)/1984-crtc.Po \
+	src/$(DEPDIR)/1984-disk.Po src/$(DEPDIR)/1984-display.Po \
+	src/$(DEPDIR)/1984-fat.Po src/$(DEPDIR)/1984-fdc.Po \
+	src/$(DEPDIR)/1984-gate_array.Po src/$(DEPDIR)/1984-gifcap.Po \
+	src/$(DEPDIR)/1984-host_mount.Po src/$(DEPDIR)/1984-ide.Po \
+	src/$(DEPDIR)/1984-joy.Po src/$(DEPDIR)/1984-kbd.Po \
+	src/$(DEPDIR)/1984-kbd_pty.Po src/$(DEPDIR)/1984-leds.Po \
+	src/$(DEPDIR)/1984-m4.Po src/$(DEPDIR)/1984-main.Po \
+	src/$(DEPDIR)/1984-mem.Po src/$(DEPDIR)/1984-monitor.Po \
+	src/$(DEPDIR)/1984-mouse.Po src/$(DEPDIR)/1984-n4c_stack.Po \
+	src/$(DEPDIR)/1984-net4cpc.Po src/$(DEPDIR)/1984-notify.Po \
+	src/$(DEPDIR)/1984-overlay.Po src/$(DEPDIR)/1984-paste.Po \
+	src/$(DEPDIR)/1984-perryfi.Po src/$(DEPDIR)/1984-pilot.Po \
+	src/$(DEPDIR)/1984-ppi.Po src/$(DEPDIR)/1984-printer.Po \
+	src/$(DEPDIR)/1984-psg.Po src/$(DEPDIR)/1984-rtc.Po \
+	src/$(DEPDIR)/1984-screen_text.Po \
 	src/$(DEPDIR)/1984-snapshot.Po src/$(DEPDIR)/1984-symbnet.Po \
 	src/$(DEPDIR)/1984-symbols.Po \
 	src/$(DEPDIR)/1984-symbos_trace.Po src/$(DEPDIR)/1984-tap.Po \
@@ -410,6 +411,7 @@ dist_man1_MANS = 1984.1
 	src/z80dis.c \
 	src/crtc.c \
 	src/disk.c \
+	src/amx.c \
 	src/display.c \
 	src/fdc.c \
 	src/gate_array.c \
@@ -448,6 +450,7 @@ dist_man1_MANS = 1984.1
 	src/z80.c
 
 noinst_HEADERS = \
+	src/amx.h \
 	src/ch376.h \
 	src/compat_win.h \
 	src/config.h \
@@ -645,6 +648,8 @@ src/1984-crtc.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-disk.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
+src/1984-amx.$(OBJEXT): src/$(am__dirstamp) \
+	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-display.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-fdc.$(OBJEXT): src/$(am__dirstamp) \
@@ -729,6 +734,7 @@ mostlyclean-compile:
 distclean-compile:
 	-rm -f *.tab.c
 
+@AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-amx.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-ch376.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-config.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-cpc.Po@am__quote@ # am--include-marker
@@ -892,6 +898,20 @@ src/1984-disk.obj: src/disk.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/disk.c' object='src/1984-disk.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-disk.obj `if test -f 'src/disk.c'; then $(CYGPATH_W) 'src/disk.c'; else $(CYGPATH_W) '$(srcdir)/src/disk.c'; fi`
+
+src/1984-amx.o: src/amx.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-amx.o -MD -MP -MF src/$(DEPDIR)/1984-amx.Tpo -c -o src/1984-amx.o `test -f 'src/amx.c' || echo '$(srcdir)/'`src/amx.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/1984-amx.Tpo src/$(DEPDIR)/1984-amx.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/amx.c' object='src/1984-amx.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-amx.o `test -f 'src/amx.c' || echo '$(srcdir)/'`src/amx.c
+
+src/1984-amx.obj: src/amx.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-amx.obj -MD -MP -MF src/$(DEPDIR)/1984-amx.Tpo -c -o src/1984-amx.obj `if test -f 'src/amx.c'; then $(CYGPATH_W) 'src/amx.c'; else $(CYGPATH_W) '$(srcdir)/src/amx.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/1984-amx.Tpo src/$(DEPDIR)/1984-amx.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/amx.c' object='src/1984-amx.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-amx.obj `if test -f 'src/amx.c'; then $(CYGPATH_W) 'src/amx.c'; else $(CYGPATH_W) '$(srcdir)/src/amx.c'; fi`
 
 src/1984-display.o: src/display.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-display.o -MD -MP -MF src/$(DEPDIR)/1984-display.Tpo -c -o src/1984-display.o `test -f 'src/display.c' || echo '$(srcdir)/'`src/display.c
@@ -1931,6 +1951,7 @@ clean-am: clean-binPROGRAMS clean-generic mostlyclean-am
 
 distclean: distclean-am
 	-rm -f $(am__CONFIG_DISTCLEAN_FILES)
+	-rm -f src/$(DEPDIR)/1984-amx.Po
 	-rm -f src/$(DEPDIR)/1984-ch376.Po
 	-rm -f src/$(DEPDIR)/1984-config.Po
 	-rm -f src/$(DEPDIR)/1984-cpc.Po
@@ -2025,6 +2046,7 @@ installcheck-am:
 maintainer-clean: maintainer-clean-am
 	-rm -f $(am__CONFIG_DISTCLEAN_FILES)
 	-rm -rf $(top_srcdir)/autom4te.cache
+	-rm -f src/$(DEPDIR)/1984-amx.Po
 	-rm -f src/$(DEPDIR)/1984-ch376.Po
 	-rm -f src/$(DEPDIR)/1984-config.Po
 	-rm -f src/$(DEPDIR)/1984-cpc.Po

--- a/src/amx.c
+++ b/src/amx.c
@@ -1,0 +1,71 @@
+#include "amx.h"
+#include <string.h>
+
+/* Host pixels per emulated mickey. Relative-mode SDL deltas are much larger
+ * than a real mouse's mickey rate, so we divide down. Tunable by feel against
+ * real AMX software (AMX Art / Pagemaker). */
+#define AMX_DIV 2.0f
+
+void amx_init(Amx *a) {
+    memset(a, 0, sizeof(*a));
+    a->prev_row = 0xFF;
+}
+
+void amx_reset(Amx *a, Keyboard *k) {
+    for (int c = AMX_UP; c <= AMX_FIRE2; c++)
+        kbd_key_up(k, AMX_ROW, c);
+    a->acc_x = a->acc_y = 0.0f;
+    a->pulsed_mask = 0;
+    a->prev_row = 0xFF;
+    for (int i = 0; i < 4; i++) a->pending[i] = 0;
+}
+
+static void enqueue(int *slot, int n) {
+    *slot += n;
+    if (*slot > AMX_PENDING_CAP) *slot = AMX_PENDING_CAP;
+}
+
+void amx_move(Amx *a, int dx, int dy) {
+    a->acc_x += dx / AMX_DIV;
+    a->acc_y += dy / AMX_DIV;
+    int mx = (int)a->acc_x;
+    int my = (int)a->acc_y;
+    a->acc_x -= mx;
+    a->acc_y -= my;
+    /* SDL y+ is downward, which maps to the CPC joystick DOWN line. */
+    if (mx > 0)      enqueue(&a->pending[AMX_RIGHT],  mx);
+    else if (mx < 0) enqueue(&a->pending[AMX_LEFT],  -mx);
+    if (my > 0)      enqueue(&a->pending[AMX_DOWN],   my);
+    else if (my < 0) enqueue(&a->pending[AMX_UP],    -my);
+}
+
+void amx_button(Amx *a, Keyboard *k, int btn, bool down) {
+    (void)a;
+    int col = (btn == 0) ? AMX_FIRE1 : (btn == 1) ? AMX_FIRE2 : -1;
+    if (col < 0) return;   /* middle/other buttons unused */
+    if (down) kbd_key_down(k, AMX_ROW, col);
+    else      kbd_key_up(k, AMX_ROW, col);
+}
+
+void amx_pre_read(Amx *a, Keyboard *k, u8 row) {
+    if (a->prev_row == AMX_ROW && row != AMX_ROW) {
+        /* Deselect: pulsed direction lines return HIGH. */
+        for (int d = 0; d < 4; d++)
+            if (a->pulsed_mask & (1 << d)) kbd_key_up(k, AMX_ROW, d);
+        a->pulsed_mask = 0;
+    } else if (row == AMX_ROW && a->prev_row != AMX_ROW) {
+        /* Fresh select-edge: clear any stale pulse, then emit one mickey per
+         * pending direction (one pulse per select, per hardware). */
+        for (int d = 0; d < 4; d++)
+            if (a->pulsed_mask & (1 << d)) kbd_key_up(k, AMX_ROW, d);
+        a->pulsed_mask = 0;
+        for (int d = 0; d < 4; d++) {
+            if (a->pending[d] > 0) {
+                kbd_key_down(k, AMX_ROW, d);
+                a->pending[d]--;
+                a->pulsed_mask |= (1 << d);
+            }
+        }
+    }
+    a->prev_row = row;
+}

--- a/src/amx.h
+++ b/src/amx.h
@@ -1,0 +1,43 @@
+#pragma once
+#include "types.h"
+#include "kbd.h"
+#include <stdbool.h>
+
+/*
+ * AMX mouse — presents on the CPC joystick-1 port (keyboard matrix row 9),
+ * NOT an I/O-port device like the SYMBiFACE/Albireo mice.
+ *
+ * The real AMX interface converts mouse motion into active-LOW pulses on the
+ * row-9 direction lines: one pulse per "mickey" of movement. The /joystick1
+ * row-select line clocks the pulse generator, so software selects row 9,
+ * reads it, then deselects before the next pulse can appear. We reproduce that
+ * by delivering exactly one mickey per fresh select-edge to row 9 (see
+ * amx_pre_read). Buttons are level-held on the two fire lines.
+ *
+ * Row 9 bit map (matches src/joy.c):
+ *   bit0 UP  bit1 DOWN  bit2 LEFT  bit3 RIGHT  bit4 FIRE1  bit5 FIRE2
+ *   bit7 = DEL key — never touched here.
+ */
+
+#define AMX_ROW    9
+#define AMX_UP     0
+#define AMX_DOWN   1
+#define AMX_LEFT   2
+#define AMX_RIGHT  3
+#define AMX_FIRE1  4
+#define AMX_FIRE2  5
+
+#define AMX_PENDING_CAP 16   /* cap queued mickeys per direction to bound lag */
+
+typedef struct {
+    float acc_x, acc_y;      /* sub-mickey host-pixel remainder */
+    int   pending[4];        /* queued mickeys: UP, DOWN, LEFT, RIGHT */
+    u8    pulsed_mask;       /* direction bits currently driven low */
+    u8    prev_row;          /* last row read — select-edge detection */
+} Amx;
+
+void amx_init(Amx *a);
+void amx_reset(Amx *a, Keyboard *k);            /* drop pulses + fire bits on row 9 */
+void amx_move(Amx *a, int dx, int dy);          /* host pixels -> queued mickeys */
+void amx_button(Amx *a, Keyboard *k, int btn, bool down);
+void amx_pre_read(Amx *a, Keyboard *k, u8 row); /* select-edge pulse machine */

--- a/src/config.c
+++ b/src/config.c
@@ -190,6 +190,16 @@ static bool parse_mono(const char *val, MonoMode *out) {
     return false;
 }
 
+static const char *fallback_to_str(FallbackInput f) {
+    return f == FALLBACK_AMX_MOUSE ? "amx_mouse" : "joystick";
+}
+
+static bool parse_fallback(const char *val, FallbackInput *out) {
+    if (!strcasecmp(val, "joystick"))  { *out = FALLBACK_JOYSTICK;  return true; }
+    if (!strcasecmp(val, "amx_mouse")) { *out = FALLBACK_AMX_MOUSE; return true; }
+    return false;
+}
+
 static bool parse_bool(const char *val, bool *out) {
     if (!strcmp(val, "true") || !strcmp(val, "1") || !strcmp(val, "yes")) {
         *out = true; return true;
@@ -229,6 +239,8 @@ static void config_create_default(const char *path) {
         "model=6128\n"
         "# RAM size in KB: 64 (CPC 464/664) or 128+ (CPC 6128)\n"
         "memory=128\n"
+        "# Primary host input: joystick or amx_mouse\n"
+        "fallback_input=joystick\n"
         "\n"
         "[roms]\n"
         "# Paths to ROM images. ~ is expanded to your home directory.\n"
@@ -401,6 +413,10 @@ int config_load_from(Config *cfg, const char *path_override) {
                         || kb == 768 || kb == 1024)
                     cfg->memory_kb = kb;
                 else { fprintf(stderr, "1984.conf:%d: invalid memory '%s', using default (%d KB)\n", lineno, val, cfg->memory_kb); }
+            } else if (!strcmp(key, "fallback_input")) {
+                FallbackInput fi;
+                if (parse_fallback(val, &fi)) cfg->fallback_input = fi;
+                else { fprintf(stderr, "1984.conf:%d: fallback_input must be joystick/amx_mouse\n", lineno); rc = -1; }
             }
         } else if (!strcmp(section, "roms")) {
             if (!strcmp(key, "os"))
@@ -664,7 +680,8 @@ int config_save(const Config *cfg) {
         "# 1984 CPC Emulator — configuration file\n\n"
         "[machine]\n"
         "model=%s\n"
-        "memory=%d\n\n"
+        "memory=%d\n"
+        "fallback_input=%s\n\n"
         "[roms]\n"
         "os=%s\n"
         "basic=%s\n"
@@ -672,6 +689,7 @@ int config_save(const Config *cfg) {
         cfg->model == MODEL_464 ? "464" :
             (cfg->model == MODEL_664 ? "664" : "6128"),
         cfg->memory_kb,
+        fallback_to_str(cfg->fallback_input),
         cfg->rom_os,
         cfg->rom_basic,
         cfg->rom_amsdos);

--- a/src/config.h
+++ b/src/config.h
@@ -7,12 +7,20 @@
  * and we want config.h to stay narrow. PrintSink: see src/printer.h. */
 typedef enum { PRINTER_SINK_PDF = 0, PRINTER_SINK_REAL_PRINTER } ConfigPrintSink;
 
+/* Primary host input device, selectable from the overlay's General tab.
+ * Joystick (default) routes the host gamepad to CPC joystick 1; AMX Mouse
+ * captures the host pointer and drives the same joystick port as an AMX mouse.
+ * Mutually exclusive with the MX4 pointer mice (symbiface_mouse/albireo_mouse),
+ * which all contend for the host pointer. */
+typedef enum { FALLBACK_JOYSTICK = 0, FALLBACK_AMX_MOUSE } FallbackInput;
+
 #define CONFIG_PATH_MAX 512
 
 typedef struct {
     /* [machine] */
     CpcModel model;
     int      memory_kb;     /* 64, 128, 256, 512, or 576 */
+    FallbackInput fallback_input;   /* primary host input: joystick | amx_mouse */
 
     /* [roms] */
     char rom_os[CONFIG_PATH_MAX];

--- a/src/cpc.c
+++ b/src/cpc.c
@@ -565,6 +565,11 @@ static void bus_io_write(void *ctx, u16 port, u8 val) {
             psg_write(&cpc->psg, cpc->ppi.port_a);
         }
         else if (psg_ctrl == 0x01) {
+            /* AMX mouse (Fallback Input) delivers one row-9 pulse per fresh
+             * select-edge; run it on the value being read so it's robust to
+             * both PPI row-select write paths. */
+            if (cpc->amx_mouse)
+                amx_pre_read(&cpc->amx, &cpc->kbd, cpc->ppi.kbd_row);
             psg_set_kbd_row(&cpc->psg, kbd_read_row(&cpc->kbd, cpc->ppi.kbd_row));
             /* PSG read mode on CPC always reads I/O port A (reg 14 = keyboard matrix).
              * Bypass psg_read() to avoid depending on psg->selected being 14. */
@@ -809,6 +814,7 @@ int cpc_init(CPC *cpc, CpcModel model, const char *rom_os, const char *rom_basic
     rtc_init(&cpc->rtc_chip);
     ide_init(&cpc->ide_chip);
     mouse_init(&cpc->mouse);
+    amx_init(&cpc->amx);
     m4_init(&cpc->m4_card, "");
     symbnet_init(&cpc->symbnet_card, &cpc->m4_card);
     ch376_init(&cpc->ch376);
@@ -861,6 +867,7 @@ void cpc_reset(CPC *cpc) {
     rtc_init(&cpc->rtc_chip);
     ide_reset(&cpc->ide_chip);  /* keeps image file open across warm reset */
     mouse_init(&cpc->mouse);    /* clear accumulated deltas; capture state managed by main */
+    amx_reset(&cpc->amx, &cpc->kbd);
     m4_reset(&cpc->m4_card);
     ch376_reset(&cpc->ch376);
     ch376_reset(&cpc->ch376_b);

--- a/src/cpc.h
+++ b/src/cpc.h
@@ -15,6 +15,7 @@
 #include "rtc.h"
 #include "ide.h"
 #include "mouse.h"
+#include "amx.h"
 #include "m4.h"
 #include "symbnet.h"
 #include "ch376.h"
@@ -51,6 +52,8 @@ typedef struct {
     IDE        ide_chip;
     bool       symbiface_mouse; /* SYMBiFACE II / Cyboard PS/2 mouse present */
     Mouse      mouse;
+    bool       amx_mouse;      /* AMX mouse on the joystick port (Fallback Input) */
+    Amx        amx;
     bool       m4;             /* M4 board hardware present */
     M4         m4_card;
     bool       symbnet;        /* 1984 emulator synthetic SymbOS network port */

--- a/src/joy.c
+++ b/src/joy.c
@@ -96,6 +96,7 @@ void joy_destroy(Joy *j) {
 }
 
 static void axis_update(Keyboard *k, int neg_col, int pos_col, int val) {
+    if (!k) return;   /* row-9 writes suppressed (AMX mouse owns the port) */
     if (val < -AXIS_DEAD) {
         kbd_key_down(k, JOY_ROW, neg_col);
         kbd_key_up  (k, JOY_ROW, pos_col);
@@ -108,6 +109,10 @@ static void axis_update(Keyboard *k, int neg_col, int pos_col, int val) {
     }
 }
 
+/* Handle an SDL gamepad/joystick event. Device add/remove is always processed
+ * so the pad list stays in sync; when `k` is NULL the row-9 matrix writes are
+ * suppressed (used when the AMX mouse owns the joystick port) — the pad still
+ * opens/closes, it just doesn't drive CPC joystick 1. */
 bool joy_handle_event(Joy *j, const SDL_Event *ev, Keyboard *k) {
     switch (ev->type) {
 
@@ -133,8 +138,9 @@ bool joy_handle_event(Joy *j, const SDL_Event *ev, Keyboard *k) {
                 break;
             }
         }
-        for (int c = 0; c <= JOY_FIRE2; c++)
-            kbd_key_up(k, JOY_ROW, c);
+        if (k)
+            for (int c = 0; c <= JOY_FIRE2; c++)
+                kbd_key_up(k, JOY_ROW, c);
         return true;
     }
 
@@ -157,8 +163,10 @@ bool joy_handle_event(Joy *j, const SDL_Event *ev, Keyboard *k) {
         default: break;
         }
         if (col >= 0) {
-            if (pressed) kbd_key_down(k, JOY_ROW, col);
-            else         kbd_key_up  (k, JOY_ROW, col);
+            if (k) {
+                if (pressed) kbd_key_down(k, JOY_ROW, col);
+                else         kbd_key_up  (k, JOY_ROW, col);
+            }
             return true;
         }
         break;
@@ -201,8 +209,9 @@ bool joy_handle_event(Joy *j, const SDL_Event *ev, Keyboard *k) {
                 break;
             }
         }
-        for (int c = 0; c <= JOY_FIRE2; c++)
-            kbd_key_up(k, JOY_ROW, c);
+        if (k)
+            for (int c = 0; c <= JOY_FIRE2; c++)
+                kbd_key_up(k, JOY_ROW, c);
         return true;
     }
 
@@ -224,8 +233,10 @@ bool joy_handle_event(Joy *j, const SDL_Event *ev, Keyboard *k) {
         default: break;
         }
         if (col >= 0) {
-            if (pressed) kbd_key_down(k, JOY_ROW, col);
-            else         kbd_key_up  (k, JOY_ROW, col);
+            if (k) {
+                if (pressed) kbd_key_down(k, JOY_ROW, col);
+                else         kbd_key_up  (k, JOY_ROW, col);
+            }
             return true;
         }
         break;
@@ -259,6 +270,7 @@ bool joy_handle_event(Joy *j, const SDL_Event *ev, Keyboard *k) {
             }
         }
         if (!is_raw) break;
+        if (!k) return true;   /* row-9 writes suppressed (AMX mouse owns port) */
         Uint8 hat = ev->jhat.value;
         if (hat & SDL_HAT_UP)    kbd_key_down(k, JOY_ROW, JOY_UP);
         else                     kbd_key_up  (k, JOY_ROW, JOY_UP);

--- a/src/main.c
+++ b/src/main.c
@@ -1032,9 +1032,12 @@ int main(int argc, char *argv[]) {
                 continue;
             }
 
-            /* Joystick/gamepad events — suppressed while the AMX mouse owns
-             * the joystick port (row 9), so the two don't fight over it. */
-            if (!cpc.amx_mouse && joy_handle_event(&joy, &ev, &cpc.kbd))
+            /* Joystick/gamepad events. Always processed so pads open/close and
+             * stay in sync; while the AMX mouse owns the joystick port (row 9)
+             * we pass NULL so the pad doesn't drive CPC joystick 1 — otherwise
+             * a pad hotplugged during AMX mode would never open and stay dead
+             * after switching back to Joystick. */
+            if (joy_handle_event(&joy, &ev, cpc.amx_mouse ? NULL : &cpc.kbd))
                 continue;
             /* Monitor window gets its own events */
             if (monitor_handle_event(monitor, &ev))

--- a/src/main.c
+++ b/src/main.c
@@ -655,6 +655,7 @@ int main(int argc, char *argv[]) {
      * Their ROMs map independently below (see the slot-load loop). */
     cpc.symbiface_ide   = cfg.symbiface_ide   && cfg.mx4;
     cpc.symbiface_mouse = cfg.symbiface_mouse && cfg.mx4;
+    cpc.amx_mouse       = (cfg.fallback_input == FALLBACK_AMX_MOUSE); /* joystick port, no MX4 gate */
     cpc.m4              = cfg.m4              && cfg.mx4;
     cpc.symbnet         = cfg.symbnet;
     if (cfg.m4 && cfg.m4_path[0])
@@ -969,6 +970,8 @@ int main(int argc, char *argv[]) {
                         mouse_move(&cpc.mouse, (int)ev.motion.xrel, (int)ev.motion.yrel);
                     if (cpc.albireo_mouse)
                         ch376_mouse_move(&cpc.ch376, (int)ev.motion.xrel, (int)ev.motion.yrel);
+                    if (cpc.amx_mouse)
+                        amx_move(&cpc.amx, (int)ev.motion.xrel, (int)ev.motion.yrel);
                     continue;
                 }
                 if (ev.type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
@@ -982,6 +985,8 @@ int main(int argc, char *argv[]) {
                             mouse_button(&cpc.mouse, btn, pressed);
                         if (cpc.albireo_mouse)
                             ch376_mouse_button(&cpc.ch376, btn, pressed);
+                        if (cpc.amx_mouse)
+                            amx_button(&cpc.amx, &cpc.kbd, btn, pressed);
                     }
                     continue;
                 }
@@ -996,14 +1001,17 @@ int main(int argc, char *argv[]) {
                     (SDL_GetModState() & SDL_KMOD_CTRL)) {
                     set_mouse_capture(cpc.display.window, false,
                                       &mouse_captured, cpc.model);
+                    if (cpc.amx_mouse)   /* drop any held fire/pulse bits on row 9 */
+                        amx_reset(&cpc.amx, &cpc.kbd);
                     continue;
                 }
             }
 
-            /* Click in emulator window captures mouse when either the
-             * SYMBiFACE II PS/2 mouse or the Albireo USB HID mouse is
-             * enabled. Ctrl+Enter releases capture. */
-            if (!mouse_captured && (cpc.symbiface_mouse || cpc.albireo_mouse) &&
+            /* Click in emulator window captures mouse when a pointer device is
+             * active: the SYMBiFACE II PS/2 mouse, the Albireo USB HID mouse,
+             * or the AMX joystick-port mouse. Ctrl+Enter releases capture. */
+            if (!mouse_captured &&
+                (cpc.symbiface_mouse || cpc.albireo_mouse || cpc.amx_mouse) &&
                 !overlay.visible &&
                 ev.type == SDL_EVENT_MOUSE_BUTTON_DOWN &&
                 ev.button.windowID == SDL_GetWindowID(cpc.display.window)) {
@@ -1018,12 +1026,15 @@ int main(int argc, char *argv[]) {
                         mouse_button(&cpc.mouse, btn, true);
                     if (cpc.albireo_mouse)
                         ch376_mouse_button(&cpc.ch376, btn, true);
+                    if (cpc.amx_mouse)
+                        amx_button(&cpc.amx, &cpc.kbd, btn, true);
                 }
                 continue;
             }
 
-            /* Joystick/gamepad events */
-            if (joy_handle_event(&joy, &ev, &cpc.kbd))
+            /* Joystick/gamepad events — suppressed while the AMX mouse owns
+             * the joystick port (row 9), so the two don't fight over it. */
+            if (!cpc.amx_mouse && joy_handle_event(&joy, &ev, &cpc.kbd))
                 continue;
             /* Monitor window gets its own events */
             if (monitor_handle_event(monitor, &ev))
@@ -1215,6 +1226,7 @@ int main(int argc, char *argv[]) {
             /* See boot-time comment: these MX4 cards gate on the bus alone. */
             cpc.symbiface_ide    = cfg.symbiface_ide   && cfg.mx4;
             cpc.symbiface_mouse  = cfg.symbiface_mouse && cfg.mx4;
+            cpc.amx_mouse        = (cfg.fallback_input == FALLBACK_AMX_MOUSE);
             cpc.m4               = cfg.m4              && cfg.mx4;
             cpc.symbnet          = cfg.symbnet;
             if (cpc.m4 && cfg.m4_path[0])

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -1,5 +1,6 @@
 #include "overlay.h"
 #include "cpc.h"
+#include "amx.h"
 #include "tap.h"     /* TAP_SUPPORTED */
 #include "m4.h"
 #include "disk.h"
@@ -32,14 +33,14 @@ static const char *const sec_labels[OV_SEC_COUNT] = {
     "General", "Media", "Extensions", "Advanced"
 };
 static const int sec_x[OV_SEC_COUNT] = { 8, 80, 160, 248 };
-/* General has 7 rows on CPC 464, 8 on 6128 (the extra one is the
+/* General has 8 rows on CPC 464, 9 on 6128 (the extra one is the
  * "External Tape" toggle, only meaningful on the 6128 since the 464 has
  * the cassette deck built in). Other sections are fixed.
  * The Advanced tab (OV_TINKER) is hidden unless cfg->tinker is enabled. */
-static const int sec_row_count[OV_SEC_COUNT] = { 7, 3, 14, 16 };
+static const int sec_row_count[OV_SEC_COUNT] = { 8, 3, 14, 16 };
 
 static int ov_section_rows(const Overlay *ov, OvSection s) {
-    if (s == OV_GENERAL && ov->cfg->model != MODEL_464) return 8;
+    if (s == OV_GENERAL && ov->cfg->model != MODEL_464) return 9;
     if (s == OV_TINKER && ov->cfg->real_crt) return sec_row_count[s] + 6;
     return sec_row_count[s];
 }
@@ -228,6 +229,11 @@ static void item_text(const Overlay *ov, int row,
         case 7:
             snprintf(lbl, lsz, "Tinker");
             snprintf(val, vsz, "%s", ov->cfg->tinker ? "enabled" : "disabled");
+            break;
+        case 8:
+            snprintf(lbl, lsz, "Fallback Input");
+            snprintf(val, vsz, "%s",
+                ov->cfg->fallback_input == FALLBACK_AMX_MOUSE ? "AMX Mouse" : "Joystick");
             break;
         }
         break;
@@ -612,6 +618,43 @@ static void item_text(const Overlay *ov, int row,
 
 /* ---- Value cycling — marks dirty, does NOT save ---- */
 
+/* Turn off the AMX fallback mouse (General tab). Used when an MX4 pointer
+ * mouse is enabled in Extensions — the two contend for the host pointer, so
+ * only one can be active. Pure input routing, no cold boot needed. */
+static void amx_release_pointer(Overlay *ov) {
+    if (ov->cfg->fallback_input != FALLBACK_AMX_MOUSE) return;
+    ov->cfg->fallback_input = FALLBACK_JOYSTICK;
+    if (ov->cpc) {
+        ov->cpc->amx_mouse = false;
+        amx_reset(&ov->cpc->amx, &ov->cpc->kbd);
+    }
+}
+
+/* Turn off both MX4 pointer mice (SymbIface PS/2 + Albireo HID). Used when the
+ * AMX fallback mouse is selected — mirrors the SymbIface<->Albireo exclusion.
+ * These are MX4 hardware, so disabling them requires a cold boot. */
+static void amx_take_pointer(Overlay *ov) {
+    bool changed = false;
+    if (ov->cfg->symbiface_mouse) {
+        ov->cfg->symbiface_mouse = false;
+        if (ov->cpc) ov->cpc->symbiface_mouse = false;
+        changed = true;
+    }
+    if (ov->cfg->albireo_mouse) {
+        ov->cfg->albireo_mouse = false;
+        if (ov->cpc) {
+            ov->cpc->albireo_mouse = false;
+            ov->cpc->ch376.has_mouse = false;
+            ch376_close(&ov->cpc->ch376);
+            ch376_close(&ov->cpc->ch376_b);
+            if (ov->cfg->albireo_image[0])
+                ch376_open(&ov->cpc->ch376, ov->cfg->albireo_image);
+        }
+        changed = true;
+    }
+    if (changed) ov->needs_cold_boot = true;
+}
+
 static void activate_item(Overlay *ov) {
     switch (ov->section) {
 
@@ -695,6 +738,24 @@ static void activate_item(Overlay *ov) {
             if (!ov->cfg->tinker && ov->section == OV_TINKER) {
                 ov->section = OV_GENERAL;
                 ov->row = 0;
+            }
+            ov->dirty = true;
+            break;
+        case 8:
+            /* Fallback Input: Joystick <-> AMX Mouse. Pure input routing —
+             * mirror the flag live, no cold boot. */
+            ov->cfg->fallback_input =
+                (ov->cfg->fallback_input == FALLBACK_JOYSTICK)
+                    ? FALLBACK_AMX_MOUSE : FALLBACK_JOYSTICK;
+            if (ov->cfg->fallback_input == FALLBACK_AMX_MOUSE)
+                amx_take_pointer(ov);   /* AMX and the MX4 mice can't coexist */
+            if (ov->cpc) {
+                ov->cpc->amx_mouse =
+                    (ov->cfg->fallback_input == FALLBACK_AMX_MOUSE);
+                /* Hand off row 9: drop any lingering joystick/AMX bits. */
+                for (int col = AMX_UP; col <= AMX_FIRE2; col++)
+                    kbd_key_up(&ov->cpc->kbd, AMX_ROW, col);
+                amx_reset(&ov->cpc->amx, &ov->cpc->kbd);
             }
             ov->dirty = true;
             break;
@@ -888,8 +949,9 @@ static void activate_item(Overlay *ov) {
             break;
         case 8:
             ov->cfg->symbiface_mouse = !ov->cfg->symbiface_mouse;
-            /* SymbIface Mouse and Albireo Mouse both drive the host
-             * pointer — only one can own it at a time. */
+            /* SymbIface Mouse, Albireo Mouse and the AMX fallback mouse all
+             * drive the host pointer — only one can own it at a time. */
+            if (ov->cfg->symbiface_mouse) amx_release_pointer(ov);
             if (ov->cfg->symbiface_mouse && ov->cfg->albireo_mouse) {
                 ov->cfg->albireo_mouse = false;
                 if (ov->cpc) {
@@ -911,6 +973,7 @@ static void activate_item(Overlay *ov) {
              * PS/2 mouse. */
             if (!ov->cfg->mx4 || !ov->cfg->albireo) break;
             ov->cfg->albireo_mouse = !ov->cfg->albireo_mouse;
+            if (ov->cfg->albireo_mouse) amx_release_pointer(ov);
             if (ov->cfg->albireo_mouse && ov->cfg->symbiface_mouse) {
                 ov->cfg->symbiface_mouse = false;
                 if (ov->cpc) ov->cpc->symbiface_mouse = false;


### PR DESCRIPTION
Closes #211.

Adds a **Fallback Input** entry to the overlay **General** tab that switches the primary host input between **Joystick** (default, unchanged) and **AMX Mouse**.

## What the AMX mouse is
Unlike the SYMBiFACE/Albireo mice (I/O-port devices), the AMX mouse is a **joystick-port** device. It presents on keyboard-matrix **row 9** as active-LOW **pulses on the direction lines** — one pulse per mickey — clocked by the row-9 select edge (software deselects between reads), with the two fire lines as buttons. Confirmed against CPCWiki + emulator docs.

## How it works here
- **`src/amx.{c,h}`** (new): queues host motion into per-direction mickey counters (capped to bound lag), delivers **one pulse per fresh row-9 select-edge** (`amx_pre_read`), buttons level-held on FIRE1/FIRE2. DEL (bit7) never touched.
- **`src/cpc.c`**: `amx_pre_read` runs on the row-9 read (robust to both PPI row-select write paths); `amx_init`/`amx_reset` beside the mouse.
- **`src/main.c`**: captured host pointer routed to the AMX mouse; click-to-capture + Ctrl+Enter release extended; **gamepad suppressed** while AMX owns row 9 (no MX4 gate — joystick port).
- **`src/overlay.c`**: General-tab enum-cycler; toggles live, **no cold boot**. **Mutual exclusion** with the MX4 pointer mice — enabling SYMBiFACE/Albireo mouse turns AMX off, and selecting AMX turns those mice off.
- **`src/config.{c,h}`**: `FallbackInput` enum persisted as `joystick|amx_mouse`.

## Verification
- Build clean (amx.c no warnings).
- Standalone unit test of the pulse machine: pulses land on the right bits, exactly one per select-edge, held-stable while selected, DEL preserved, buttons held/released, queue capped — all pass.
- Config round-trips (`joystick` default, `amx_mouse` persists, bad value rejected); boots clean in AMX mode.

## Still to confirm (why this is not merged yet)
Pulse-decode fidelity against **real AMX software** (AMX Art / Pagemaker) — the one thing only real software can confirm. Mouse feel is tunable via `AMX_DIV` in `src/amx.c`. Left unmerged for interactive testing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)