### PR TITLE
Release 0.4.13

### DIFF
--- a/1984.spec
+++ b/1984.spec
@@ -1,5 +1,5 @@
 Name:           1984
-Version:        0.4.12
+Version:        0.4.13
 Release:        1%{?dist}
 Summary:        Amstrad CPC 464/6128 emulator
 
@@ -83,6 +83,12 @@ appstream-util validate-relax --nonet %{buildroot}%{_datadir}/metainfo/io.github
 %{_datadir}/%{name}/roms/OS_6128.ROM
 
 %changelog
+* Wed Jul 02 2026 Salvatore Bognanni <salvogendut@gmail.com> - 0.4.13-1
+- New General -> Fallback Input toggle: switch the primary host input
+  between the USB joystick and an AMX mouse (joystick-port mouse, host
+  pointer captured; Ctrl+Enter releases). Mutually exclusive with the
+  SYMBiFACE/Albireo pointer mice (#211).
+
 * Tue Jun 30 2026 Salvatore Bognanni <salvogendut@gmail.com> - 0.4.12-1
 - M4 no longer needs the ROM Board and now coexists with the RTC,
   SYMBiFACE mouse/IDE and Net4CPC; only Albireo stays mutually exclusive.

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([1984], [0.4.12], [], [1984])
+AC_INIT([1984], [0.4.13], [], [1984])
 AC_CONFIG_SRCDIR([src/main.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])

--- a/io.github.salvogendut.Emulator1984.metainfo.xml
+++ b/io.github.salvogendut.Emulator1984.metainfo.xml
@@ -30,6 +30,11 @@
   <url type="bugtracker">https://github.com/salvogendut/1984/issues</url>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="0.4.13" date="2026-07-02">
+      <description>
+        <p>New General -&gt; Fallback Input toggle switches the primary host input between the USB joystick and an AMX mouse — a joystick-port mouse that captures the host pointer (Ctrl+Enter releases). It is mutually exclusive with the SYMBiFACE and Albireo pointer mice.</p>
+      </description>
+    </release>
     <release version="0.4.12" date="2026-06-30">
       <description>
         <p>M4 no longer requires the ROM Board and now coexists with the RTC, SYMBiFACE mouse/IDE and Net4CPC — only Albireo stays mutually exclusive — and each MX4 card maps its own onboard ROM. M4 SD-card image files can be erased from the overlay. New --pilot host-PTY auto-pilot drives the mouse pointer or CPC joystick from a script or AI via polar-coordinate commands. FreeBSD build fixed. Flatpak now builds from main and ships as a release asset.</p>


### PR DESCRIPTION
Cuts v0.4.13. Since v0.4.12 (a CI-only re-tag) main gained the AMX mouse **Fallback Input** feature (#211), so this bump publishes fresh Linux/RPM/Windows/Flatpak binaries with it.

- configure.ac, 1984.spec (Version + %changelog), metainfo.xml release entry -> 0.4.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)