### PR TITLE
Persist floppy writes and track formatting

### DIFF
--- a/src/cpc.c
+++ b/src/cpc.c
@@ -1144,6 +1144,7 @@ static void cpc_advance_bus(CPC *cpc, int cycles) {
     /* Tape (no-op when no tape loaded / motor off) */
     tape_step(&cpc->tape, cycles);
     ppi_set_tape_level(&cpc->ppi, tape_level(&cpc->tape));
+    fdc_tick(&cpc->fdc, cycles);
     /* Audio sampling at 44.1 kHz. PSG rendering lives here rather than at
      * frame end so AY register writes take effect at their CPU-cycle time;
      * this is required for volume-register sample playback. */

--- a/src/disk.c
+++ b/src/disk.c
@@ -16,7 +16,7 @@ void disk_eject(Disk *d) {
     d->cur_track = cur_track;   /* preserve head position across eject */
 }
 
-static int load_track(DiskTrack *tr, FILE *f, int track_size) {
+static int load_track(DiskTrack *tr, FILE *f, int track_size, long track_file_offset) {
     if (track_size < 256) return 0;
 
     uint8_t hdr[256];
@@ -30,6 +30,7 @@ static int load_track(DiskTrack *tr, FILE *f, int track_size) {
     tr->sector_count = spt;
 
     /* Sector data follows the 256-byte header */
+    long data_file_offset = track_file_offset + 256;
     int data_size = track_size - 256;
     if (data_size > 0) {
         tr->data = malloc(data_size);
@@ -52,13 +53,19 @@ static int load_track(DiskTrack *tr, FILE *f, int track_size) {
         if (sz == 0) sz = 128 << sec->N;
         sec->size   = sz;
         sec->offset = offset;
+        sec->file_offset = data_file_offset + offset;
         offset += sz;
     }
     return 0;
 }
 
 int disk_load(Disk *d, const char *path) {
-    FILE *f = fopen(path, "rb");
+    bool write_protected = false;
+    FILE *f = fopen(path, "r+b");
+    if (!f) {
+        f = fopen(path, "rb");
+        write_protected = true;
+    }
     if (!f) { fprintf(stderr, "disk: cannot open %s\n", path); return -1; }
 
     uint8_t hdr[256];
@@ -84,6 +91,8 @@ int disk_load(Disk *d, const char *path) {
     d->track_count = tracks;
     d->sides       = sides;
     d->inserted    = true;
+    snprintf(d->path, sizeof(d->path), "%s", path);
+    d->write_protected = write_protected;
 
     /* Normal DSK: fixed track size for all tracks */
     int fixed_track_size = 0;
@@ -100,7 +109,9 @@ int disk_load(Disk *d, const char *path) {
 
             if (ts == 0) continue;  /* missing track in extended DSK */
 
-            if (load_track(&d->track[t][s], f, ts) < 0) {
+            long track_file_offset = ftell(f);
+            if (track_file_offset < 0 ||
+                load_track(&d->track[t][s], f, ts, track_file_offset) < 0) {
                 fprintf(stderr, "disk: error reading track %d side %d\n", t, s);
                 fclose(f);
                 return -1;
@@ -187,4 +198,29 @@ DiskSector *disk_find_sector(Disk *d, int side, uint8_t C, uint8_t H,
             return s;
     }
     return NULL;
+}
+
+int disk_write_sector(Disk *d, DiskSector *sec, const uint8_t *data, int len) {
+    if (!d || !sec || !data || !d->inserted || d->write_protected ||
+        !d->path[0] || sec->file_offset < 0 || len < 0)
+        return -1;
+
+    if (len > sec->size) len = sec->size;
+
+    FILE *f = fopen(d->path, "r+b");
+    if (!f) {
+        d->write_protected = true;
+        return -1;
+    }
+
+    int rc = 0;
+    if (fseek(f, sec->file_offset, SEEK_SET) != 0 ||
+        fwrite(data, 1, (size_t)len, f) != (size_t)len ||
+        fflush(f) != 0) {
+        rc = -1;
+        d->write_protected = true;
+    }
+
+    fclose(f);
+    return rc;
 }

--- a/src/disk.c
+++ b/src/disk.c
@@ -18,6 +18,7 @@ void disk_eject(Disk *d) {
 
 static int load_track(DiskTrack *tr, FILE *f, int track_size, long track_file_offset) {
     if (track_size < 256) return 0;
+    tr->file_offset = track_file_offset;
 
     uint8_t hdr[256];
     if (fread(hdr, 1, 256, f) != 256) return -1;
@@ -222,5 +223,92 @@ int disk_write_sector(Disk *d, DiskSector *sec, const uint8_t *data, int len) {
     }
 
     fclose(f);
+    return rc;
+}
+
+int disk_format_track(Disk *d, int side, const uint8_t *chrn, int count,
+                      uint8_t default_N, uint8_t gap3, uint8_t filler) {
+    if (!d || !chrn || !d->inserted || d->write_protected || !d->path[0] ||
+        side < 0 || side >= d->sides || d->cur_track >= d->track_count ||
+        count <= 0 || count > DISK_MAX_SECTORS)
+        return -1;
+
+    DiskTrack *tr = &d->track[d->cur_track][side];
+    if (!tr->data || tr->data_size <= 0 || tr->file_offset < 0)
+        return -1;
+
+    DiskSector sectors[DISK_MAX_SECTORS];
+    memset(sectors, 0, sizeof(sectors));
+
+    int offset = 0;
+    for (int i = 0; i < count; i++) {
+        uint8_t N = chrn[i * 4 + 3];
+        if (N > 7) return -1;
+        int size = 128 << N;
+        if (offset + size > tr->data_size) return -1;
+
+        DiskSector *sec = &sectors[i];
+        sec->C = chrn[i * 4 + 0];
+        sec->H = chrn[i * 4 + 1];
+        sec->R = chrn[i * 4 + 2];
+        sec->N = N;
+        sec->st1 = 0;
+        sec->st2 = 0;
+        sec->offset = offset;
+        sec->file_offset = tr->file_offset + 256 + offset;
+        sec->size = size;
+        offset += size;
+    }
+
+    uint8_t hdr[256];
+    memset(hdr, 0, sizeof(hdr));
+    memcpy(hdr, "Track-Info\r\n", 12);
+    hdr[0x10] = (uint8_t)d->cur_track;
+    hdr[0x11] = (uint8_t)side;
+    hdr[0x14] = default_N;
+    hdr[0x15] = (uint8_t)count;
+    hdr[0x16] = gap3;
+    hdr[0x17] = filler;
+    for (int i = 0; i < count; i++) {
+        uint8_t *si = hdr + 0x18 + i * 8;
+        const DiskSector *sec = &sectors[i];
+        si[0] = sec->C;
+        si[1] = sec->H;
+        si[2] = sec->R;
+        si[3] = sec->N;
+        si[4] = sec->st1;
+        si[5] = sec->st2;
+        si[6] = (uint8_t)(sec->size & 0xFF);
+        si[7] = (uint8_t)(sec->size >> 8);
+    }
+
+    uint8_t *data = malloc((size_t)tr->data_size);
+    if (!data) return -1;
+    memset(data, filler, (size_t)tr->data_size);
+
+    FILE *f = fopen(d->path, "r+b");
+    if (!f) {
+        d->write_protected = true;
+        free(data);
+        return -1;
+    }
+
+    int rc = 0;
+    if (fseek(f, tr->file_offset, SEEK_SET) != 0 ||
+        fwrite(hdr, 1, sizeof(hdr), f) != sizeof(hdr) ||
+        fwrite(data, 1, (size_t)tr->data_size, f) != (size_t)tr->data_size ||
+        fflush(f) != 0) {
+        rc = -1;
+        d->write_protected = true;
+    }
+    fclose(f);
+
+    if (rc == 0) {
+        memcpy(tr->data, data, (size_t)tr->data_size);
+        memcpy(tr->sectors, sectors, sizeof(sectors));
+        tr->sector_count = count;
+    }
+
+    free(data);
     return rc;
 }

--- a/src/disk.h
+++ b/src/disk.h
@@ -20,6 +20,7 @@ typedef struct {
     DiskSector sectors[DISK_MAX_SECTORS];
     uint8_t   *data;        /* raw sector data (heap-allocated) */
     int        data_size;
+    long       file_offset;  /* absolute byte offset of track header in .dsk */
 } DiskTrack;
 
 typedef struct {
@@ -50,3 +51,8 @@ DiskSector *disk_find_sector(Disk *d, int side, uint8_t C, uint8_t H,
 
 /* Persist an already-committed sector write back into the mounted .dsk image. */
 int disk_write_sector(Disk *d, DiskSector *sec, const uint8_t *data, int len);
+
+/* Reformat the current track on `side` using `count` CHRN records (4 bytes
+ * each: C,H,R,N), filling all sector data with `filler`. */
+int disk_format_track(Disk *d, int side, const uint8_t *chrn, int count,
+                      uint8_t default_N, uint8_t gap3, uint8_t filler);

--- a/src/disk.h
+++ b/src/disk.h
@@ -5,11 +5,13 @@
 #define DISK_MAX_TRACKS   84
 #define DISK_MAX_SIDES     2
 #define DISK_MAX_SECTORS  29
+#define DISK_PATH_MAX    4096
 
 typedef struct {
     uint8_t C, H, R, N;    /* CHRN — cylinder, head, record, size code */
     uint8_t st1, st2;       /* pre-set status flags from DSK file */
     int     offset;         /* byte offset within track data[] */
+    long    file_offset;    /* absolute byte offset of sector data in .dsk */
     int     size;           /* actual data bytes (128 << N, or per extended header) */
 } DiskSector;
 
@@ -23,6 +25,7 @@ typedef struct {
 typedef struct {
     bool      inserted;
     bool      write_protected;
+    char      path[DISK_PATH_MAX];
     int       track_count;
     int       sides;
     DiskTrack track[DISK_MAX_TRACKS][DISK_MAX_SIDES];
@@ -44,3 +47,6 @@ int  disk_create_blank(const char *path);
 /* Find a sector by CHRN on the current track. Returns NULL if not found. */
 DiskSector *disk_find_sector(Disk *d, int side, uint8_t C, uint8_t H,
                              uint8_t R, uint8_t N);
+
+/* Persist an already-committed sector write back into the mounted .dsk image. */
+int disk_write_sector(Disk *d, DiskSector *sec, const uint8_t *data, int len);

--- a/src/fdc.c
+++ b/src/fdc.c
@@ -345,8 +345,14 @@ static void commit_write(FDC *fdc) {
         DiskTrack *tr = &d->track[d->cur_track][side];
         int copy = sec->size;
         if (buf_off + copy > fdc->exec_len) copy = fdc->exec_len - buf_off;
-        if (tr->data && sec->offset + copy <= tr->data_size)
+        if (tr->data && sec->offset + copy <= tr->data_size) {
+            if (disk_write_sector(d, sec, fdc->exec_buf + buf_off, copy) < 0) {
+                set_result(fdc, FDC_ST0_IC_AT | (uint8_t)drv, FDC_ST1_NW, 0,
+                           C, H, cur_R, N);
+                return;
+            }
             memcpy(tr->data + sec->offset, fdc->exec_buf + buf_off, copy);
+        }
         buf_off += copy;
         cur_R++;
     }

--- a/src/fdc.c
+++ b/src/fdc.c
@@ -2,6 +2,8 @@
 #include "leds.h"
 #include <string.h>
 
+#define FDC_FORMAT_TRACK_DELAY_CYCLES 800000  /* 200 ms at 4 MHz */
+
 /* Command byte counts (total bytes including the command byte itself).
  * Index = command code & 0x1F. 0 = unknown/invalid. */
 static const int cmd_len[32] = {
@@ -44,6 +46,8 @@ uint8_t fdc_read_status(FDC *fdc) {
         else                    /* CPU → FDC */
             return FDC_MSR_RQM | FDC_MSR_NDM | FDC_MSR_BUSY;
     case FDC_PHASE_RESULT:
+        if (fdc->result_delay_cycles > 0)
+            return FDC_MSR_BUSY;
         return FDC_MSR_RQM | FDC_MSR_DIO | FDC_MSR_BUSY;
     }
     return FDC_MSR_RQM;
@@ -291,15 +295,33 @@ static void exec_cmd(FDC *fdc) {
 
     /* FORMAT TRACK */
     case 0x0D: {
-        /* Accept the CPU's format data then produce a dummy result */
-        int drv = fdc->cmd[1] & 0x01;
-        uint8_t N   = fdc->cmd[2];
-        uint8_t sc  = fdc->cmd[3];   /* sectors per track */
-        int total = (128 << N) * sc;
-        fdc->exec_len   = total > FDC_EXEC_BUF ? FDC_EXEC_BUF : total;
+        int drv  = fdc->cmd[1] & 0x01;
+        int side = (fdc->cmd[1] >> 2) & 0x01;
+        uint8_t sc = fdc->cmd[3];   /* sectors per track */
+        Disk *d = fdc->drive[drv];
+
+        leds_ping(drv ? LED_FDC_B : LED_FDC_A);
+        if (!d || !d->inserted) {
+            set_result(fdc, FDC_ST0_IC_AT | FDC_ST0_NR | (uint8_t)drv,
+                       0, 0, 0, (uint8_t)side, 0, fdc->cmd[2]);
+            break;
+        }
+        if (d->write_protected) {
+            set_result(fdc, FDC_ST0_IC_AT | (uint8_t)drv, FDC_ST1_NW, 0,
+                       0, (uint8_t)side, 0, fdc->cmd[2]);
+            break;
+        }
+        if (sc == 0 || sc > DISK_MAX_SECTORS || (int)sc * 4 > FDC_EXEC_BUF) {
+            set_result(fdc, FDC_ST0_IC_AT | (uint8_t)drv, FDC_ST1_OR, 0,
+                       0, (uint8_t)side, 0, fdc->cmd[2]);
+            break;
+        }
+
+        fdc->exec_len   = sc * 4;    /* CHRN records, not sector payload */
         fdc->exec_pos   = 0;
         fdc->exec_write = true;
         fdc->result[0] = (uint8_t)drv;
+        fdc->result[1] = (uint8_t)side;
         fdc->result_len = 7;
         fdc->result_pos = 0;
         fdc->phase = FDC_PHASE_EXEC;
@@ -316,12 +338,37 @@ static void exec_cmd(FDC *fdc) {
 
 static void commit_write(FDC *fdc) {
     uint8_t code = fdc->cmd[0] & 0x1F;
-    if (code != 0x05 && code != 0x09) {
-        /* FORMAT or unknown — just return OK result */
+    if (code == 0x0D) {
         int drv = fdc->result[0] & 0x01;
-        uint8_t C = fdc->cmd[2], H = fdc->cmd[3];
-        uint8_t R = fdc->cmd[4], N = fdc->cmd[5];
-        set_result(fdc, (uint8_t)(FDC_ST0_IC_OK | drv), 0, 0, C, H, R, N);
+        int side = fdc->result[1] & 0x01;
+        uint8_t N = fdc->cmd[2];
+        uint8_t sc = fdc->cmd[3];
+        uint8_t gap3 = fdc->cmd[4];
+        uint8_t filler = fdc->cmd[5];
+        Disk *d = fdc->drive[drv];
+        uint8_t C = sc ? fdc->exec_buf[(sc - 1) * 4 + 0] : 0;
+        uint8_t H = sc ? fdc->exec_buf[(sc - 1) * 4 + 1] : (uint8_t)side;
+        uint8_t R = sc ? fdc->exec_buf[(sc - 1) * 4 + 2] : 0;
+        uint8_t idN = sc ? fdc->exec_buf[(sc - 1) * 4 + 3] : N;
+
+        if (!d || !d->inserted) {
+            set_result(fdc, FDC_ST0_IC_AT | FDC_ST0_NR | (uint8_t)drv,
+                       0, 0, C, H, R, idN);
+            return;
+        }
+        if (disk_format_track(d, side, fdc->exec_buf, sc, N, gap3, filler) < 0) {
+            set_result(fdc, FDC_ST0_IC_AT | (uint8_t)drv, FDC_ST1_NW, 0,
+                       C, H, R, idN);
+            return;
+        }
+
+        set_result(fdc, (uint8_t)(FDC_ST0_IC_OK | drv), 0, 0, C, H, R, idN);
+        fdc->result_delay_cycles = FDC_FORMAT_TRACK_DELAY_CYCLES;
+        return;
+    }
+
+    if (code != 0x05 && code != 0x09) {
+        set_invalid(fdc);
         return;
     }
 
@@ -373,6 +420,8 @@ uint8_t fdc_read_data(FDC *fdc) {
         return val;
     }
     if (fdc->phase == FDC_PHASE_RESULT) {
+        if (fdc->result_delay_cycles > 0)
+            return 0xFF;
         uint8_t val = (fdc->result_pos < fdc->result_len)
                     ? fdc->result[fdc->result_pos++]
                     : 0xFF;
@@ -412,4 +461,13 @@ void fdc_write_data(FDC *fdc, uint8_t val) {
 
 void fdc_motor_write(FDC *fdc, uint8_t val) {
     fdc->motor = (val & 0x01) != 0;
+}
+
+void fdc_tick(FDC *fdc, int cycles) {
+    if (!fdc || cycles <= 0 || fdc->result_delay_cycles <= 0)
+        return;
+    if (cycles >= fdc->result_delay_cycles)
+        fdc->result_delay_cycles = 0;
+    else
+        fdc->result_delay_cycles -= cycles;
 }

--- a/src/fdc.h
+++ b/src/fdc.h
@@ -64,6 +64,7 @@ typedef struct {
 
     bool     motor;
     int      read_status_delay;  /* first status read after data-ready returns BUSY (matches Caprice32) */
+    int      result_delay_cycles; /* post-operation busy time before result bytes are ready */
 
     Disk    *drive[2];      /* drive[0]=A, drive[1]=B */
 } FDC;
@@ -75,3 +76,4 @@ uint8_t fdc_read_status(FDC *fdc);
 uint8_t fdc_read_data(FDC *fdc);
 void    fdc_write_data(FDC *fdc, uint8_t val);
 void    fdc_motor_write(FDC *fdc, uint8_t val);
+void    fdc_tick(FDC *fdc, int cycles);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@ CC ?= cc
 CFLAGS ?= -O2
 CPPFLAGS ?=
 
-TESTS = test-gate-array test-crtc test-z80 test-psg test-mem
+TESTS = test-gate-array test-crtc test-z80 test-psg test-mem test-disk
 
 .PHONY: all check clean
 
@@ -28,12 +28,17 @@ test-mem: test_mem.c ../src/mem.c ../src/mem.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -std=c11 -Wall -Wextra -I../src \
 		test_mem.c ../src/mem.c -o $@
 
+test-disk: test_disk.c ../src/disk.c ../src/disk.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) -std=c11 -Wall -Wextra -I../src \
+		test_disk.c ../src/disk.c -o $@
+
 check: $(TESTS)
 	./test-gate-array
 	./test-crtc
 	./test-z80
 	./test-psg
 	./test-mem
+	./test-disk
 
 clean:
 	rm -f $(TESTS)

--- a/tests/test_disk.c
+++ b/tests/test_disk.c
@@ -1,0 +1,48 @@
+#include "disk.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static void test_sector_write_persists_after_reload(void) {
+    const char *path = "/tmp/1984-test-disk-writeback.dsk";
+    uint8_t pattern[512];
+
+    for (int i = 0; i < (int)sizeof(pattern); i++)
+        pattern[i] = (uint8_t)(i ^ 0x5A);
+
+    unlink(path);
+    assert(disk_create_blank(path) == 0);
+
+    Disk disk;
+    disk_init(&disk);
+    assert(disk_load(&disk, path) == 0);
+    assert(disk.inserted);
+    assert(!disk.write_protected);
+
+    DiskSector *sec = disk_find_sector(&disk, 0, 0, 0, 0xC1, 2);
+    assert(sec);
+    assert(sec->size == (int)sizeof(pattern));
+    assert(disk_write_sector(&disk, sec, pattern, sec->size) == 0);
+    disk_eject(&disk);
+
+    disk_init(&disk);
+    assert(disk_load(&disk, path) == 0);
+    sec = disk_find_sector(&disk, 0, 0, 0, 0xC1, 2);
+    assert(sec);
+
+    DiskTrack *tr = &disk.track[disk.cur_track][0];
+    assert(tr->data);
+    assert(sec->offset + sec->size <= tr->data_size);
+    assert(memcmp(tr->data + sec->offset, pattern, sizeof(pattern)) == 0);
+
+    disk_eject(&disk);
+    unlink(path);
+}
+
+int main(void) {
+    test_sector_write_persists_after_reload();
+    return 0;
+}

--- a/tests/test_disk.c
+++ b/tests/test_disk.c
@@ -42,7 +42,52 @@ static void test_sector_write_persists_after_reload(void) {
     unlink(path);
 }
 
+static void test_format_track_persists_after_reload(void) {
+    const char *path = "/tmp/1984-test-disk-format.dsk";
+    uint8_t ids[9 * 4];
+    uint8_t pattern[512];
+
+    for (int i = 0; i < 9; i++) {
+        ids[i * 4 + 0] = 0;
+        ids[i * 4 + 1] = 0;
+        ids[i * 4 + 2] = (uint8_t)(0x41 + i);
+        ids[i * 4 + 3] = 2;
+    }
+    memset(pattern, 0xA5, sizeof(pattern));
+
+    unlink(path);
+    assert(disk_create_blank(path) == 0);
+
+    Disk disk;
+    disk_init(&disk);
+    assert(disk_load(&disk, path) == 0);
+
+    DiskSector *sec = disk_find_sector(&disk, 0, 0, 0, 0xC1, 2);
+    assert(sec);
+    assert(disk_write_sector(&disk, sec, pattern, sec->size) == 0);
+    assert(disk_format_track(&disk, 0, ids, 9, 2, 0x4E, 0xE5) == 0);
+    disk_eject(&disk);
+
+    disk_init(&disk);
+    assert(disk_load(&disk, path) == 0);
+    assert(disk_find_sector(&disk, 0, 0, 0, 0xC1, 2) == NULL);
+
+    DiskTrack *tr = &disk.track[disk.cur_track][0];
+    assert(tr->sector_count == 9);
+    for (int i = 0; i < 9; i++) {
+        sec = disk_find_sector(&disk, 0, 0, 0, (uint8_t)(0x41 + i), 2);
+        assert(sec);
+        assert(sec->offset + sec->size <= tr->data_size);
+        for (int j = 0; j < sec->size; j++)
+            assert(tr->data[sec->offset + j] == 0xE5);
+    }
+
+    disk_eject(&disk);
+    unlink(path);
+}
+
 int main(void) {
     test_sector_write_persists_after_reload();
+    test_format_track_persists_after_reload();
     return 0;
 }


### PR DESCRIPTION
## Summary
- persist guest WRITE DATA sector updates back into mounted DSK images
- implement FORMAT TRACK using CHRN records, filler bytes, and on-disk track header/data rewrite
- add an emulated post-format FDC busy delay so formatting no longer completes instantly
- add disk regression coverage for sector writeback and format/reload persistence

## Tests
- make -C tests check
- distrobox enter my-distrobox -- make -j4

Closes #214