### PR TITLE
Fix CRTC-driven audio/video synchronization

### DIFF
--- a/src/cpc.c
+++ b/src/cpc.c
@@ -1376,8 +1376,15 @@ static void cpc_bus_tick(void *ctx, int cycles) {
     cpc->bus_ticked_in_step += cycles;
 }
 
-void cpc_frame(CPC *cpc) {
-    if (cpc->paused && !cpc->step_once) return;
+uint64_t cpc_cycles_to_ns(const CPC *cpc, int cycles) {
+    if (!cpc || cpc->cpu_clk_hz <= 0 || cycles <= 0)
+        return 20000000ULL;
+    return ((uint64_t)cycles * 1000000000ULL +
+            (uint64_t)cpc->cpu_clk_hz / 2) / (uint64_t)cpc->cpu_clk_hz;
+}
+
+int cpc_frame(CPC *cpc) {
+    if (cpc->paused && !cpc->step_once) return 0;
     bool was_stepping = cpc->step_once;
     cpc->step_once = false;
 
@@ -1884,6 +1891,7 @@ void cpc_frame(CPC *cpc) {
     cpc->audio_frame_pos = 0;
     if (stop_early)
         cpc->audio_sample_cycles = 0;
+    return done;
 }
 
 void cpc_key_event(CPC *cpc, SDL_Scancode sc, bool pressed) {

--- a/src/cpc.h
+++ b/src/cpc.h
@@ -167,5 +167,13 @@ int  cpc_init(CPC *cpc, CpcModel model, const char *rom_os, const char *rom_basi
 void cpc_reset(CPC *cpc);
 void cpc_destroy(CPC *cpc);
 void cpc_set_audio_sink(CPC *cpc, CpcAudioSink sink, void *userdata);
-void cpc_frame(CPC *cpc);        /* run one video frame (~20 ms) */
+/* Run until the monitor completes one video frame. Returns the number of
+ * emulated CPU cycles consumed, or zero while paused. CRTC programs can make
+ * a frame shorter or longer than the nominal 80,000 cycles, so frontends must
+ * pace from this value rather than assuming every frame lasts exactly 20 ms. */
+int cpc_frame(CPC *cpc);
+
+/* Convert emulated CPU cycles to host nanoseconds. Invalid/paused values use
+ * the nominal 50 Hz period so frontend event loops remain responsive. */
+uint64_t cpc_cycles_to_ns(const CPC *cpc, int cycles);
 void cpc_key_event(CPC *cpc, SDL_Scancode sc, bool pressed);

--- a/src/main.c
+++ b/src/main.c
@@ -810,8 +810,9 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    /* 50 Hz frame pacer — audio is pushed every 20 ms, matching the CPC's PAL rate.
-     * VSync is off; we sleep for any leftover time in each 20 ms budget. */
+    /* Host pacer. A normal CPC frame is 20 ms, but software can program a
+     * different CRTC frame length. Pace from the CPU cycles cpc_frame()
+     * actually consumed so video stays locked to the 4 MHz audio clock. */
 #define FRAME_NS 20000000ULL
     Uint64 next_frame = SDL_GetTicksNS();
 
@@ -1242,7 +1243,10 @@ int main(int argc, char *argv[]) {
         perryfi_poll(&cpc.perryfi);
         webgui_poll();
         printer_tick(&cpc.printer);
-        cpc_frame(&cpc);
+        int emulated_cycles = cpc_frame(&cpc);
+        Uint64 emulated_frame_ns = cpc_cycles_to_ns(&cpc, emulated_cycles);
+        if (cpc.paused)
+            emulated_frame_ns = FRAME_NS;
         pilot_post_frame(&pilot, &cpc, &cpc.display, frame_count + 1);
         /* Auto-open monitor on breakpoint hit */
         if (!was_paused && cpc.paused) {
@@ -1304,7 +1308,7 @@ int main(int argc, char *argv[]) {
         }
         prev_paused = cpc.paused;
         overlay_render(&overlay, cpc.display.renderer);
-        notify_tick(20);   /* 50 Hz frame => 20 ms per displayed frame */
+        notify_tick((int)((emulated_frame_ns + 500000ULL) / 1000000ULL));
         if (cpc.paused)
             display_draw_paused_label(&cpc.display);
         /* Debug-mode FPS overlay (bottom-left, just above the LED bar).
@@ -1457,12 +1461,14 @@ int main(int argc, char *argv[]) {
             }
         }
 
-        /* Sleep for whatever is left of the 20 ms frame budget */
-        next_frame += FRAME_NS;
+        /* Sleep until the amount of real time represented by this emulated
+         * frame has elapsed. This also prevents SDL's audio queue growing
+         * when a game uses a CRTC frame longer than the standard 80K cycles. */
+        next_frame += emulated_frame_ns;
         Uint64 now = SDL_GetTicksNS();
         if (now < next_frame) {
             SDL_DelayNS(next_frame - now);
-        } else if (now > next_frame + 3 * FRAME_NS) {
+        } else if (now > next_frame + 3 * emulated_frame_ns) {
             next_frame = now; /* reset if more than 3 frames behind */
         }
     }

--- a/src/websvc.c
+++ b/src/websvc.c
@@ -67,6 +67,7 @@ typedef struct Session {
     char      upload_dir[CONFIG_PATH_MAX];
     uint64_t  created_ms;
     uint64_t  last_attached_ms;   /* refreshed whenever a streaming client attaches */
+    uint64_t  next_frame_ns;      /* per-session CRTC/cycle-clock deadline */
     int       attached;           /* currently attached video/audio stream clients */
 } Session;
 
@@ -477,6 +478,7 @@ static bool session_build(Session *s, Config *cfg) {
     s->decim = 0;
     memset(s->joy_held, 0, sizeof(s->joy_held));
     memset(s->mbtn_held, 0, sizeof(s->mbtn_held));
+    s->next_frame_ns = SDL_GetTicksNS();
     return true;
 }
 
@@ -1151,20 +1153,33 @@ int websvc_run(int port) {
 
     for (int i = 0; i < WS_MAX_CLIENTS; i++) g_clients[i].fd = -1;
 
-    const uint64_t FRAME_NS = 20000000ULL;   /* 50 Hz, matches the classic loop */
-    uint64_t next_frame = SDL_GetTicksNS();
+    const uint64_t IDLE_POLL_NS = 5000000ULL;
     g_last_sweep_ms = SDL_GetTicks();
 
     while (g_running) {
         ws_poll();
 
+        uint64_t now_ns = SDL_GetTicksNS();
         uint64_t now_ms = SDL_GetTicks();
+        uint64_t wake_ns = now_ns + IDLE_POLL_NS;
         for (int i = 0; i < WS_MAX_SESSIONS; i++) {
             Session *s = &g_sessions[i];
             if (!s->in_use) continue;
+
+            if (now_ns < s->next_frame_ns) {
+                if (s->next_frame_ns < wake_ns) wake_ns = s->next_frame_ns;
+                continue;
+            }
+
             paste_tick(&s->paste, &s->cpc.kbd);
-            cpc_frame(&s->cpc);
+            int emulated_cycles = cpc_frame(&s->cpc);
             session_frame(s, now_ms);
+
+            uint64_t frame_ns = cpc_cycles_to_ns(&s->cpc, emulated_cycles);
+            s->next_frame_ns += frame_ns;
+            if (now_ns > s->next_frame_ns + 3 * frame_ns)
+                s->next_frame_ns = now_ns;
+            if (s->next_frame_ns < wake_ns) wake_ns = s->next_frame_ns;
         }
 
         if (now_ms - g_last_sweep_ms >= WS_SWEEP_INTERVAL_MS) {
@@ -1172,10 +1187,8 @@ int websvc_run(int port) {
             g_last_sweep_ms = now_ms;
         }
 
-        next_frame += FRAME_NS;
-        uint64_t now_ns = SDL_GetTicksNS();
-        if (now_ns < next_frame) SDL_DelayNS(next_frame - now_ns);
-        else if (now_ns > next_frame + 3 * FRAME_NS) next_frame = now_ns;
+        now_ns = SDL_GetTicksNS();
+        if (now_ns < wake_ns) SDL_DelayNS(wake_ns - now_ns);
     }
 
     wlog("shutting down");


### PR DESCRIPTION
## Summary

- pace the native frontend from the CPU cycles consumed by each completed CRTC frame
- keep Web GUI audio/video on the same cycle-derived clock
- schedule Web Service sessions independently so nonstandard CRTC frame lengths remain synchronized
- retain the nominal 20 ms period while paused or when no cycles are executed

Bomb Jack Extra Sugar uses frames that generate roughly 900-904 audio samples rather than the standard 882. The old fixed 20 ms frontend delay made video run ahead while SDL audio accumulated. With cycle-derived pacing, the queue remains bounded instead of growing continuously.

## Verification

- `autoreconf -iv`
- `./configure`
- `make -j4`
- `make -C tests check`
- Bomb Jack gameplay run with real AY output: SDL queue remains around 3.6-7.4 KB instead of exceeding 36 KB and continuing to grow
- standard 100-frame timing remains approximately 2.1 seconds
- Web Service `/audio` smoke test delivered approximately one second of 44.1 kHz stereo PCM in one second

Closes #226
