### PR TITLE
Add configurable GIF capture controls

### DIFF
--- a/1984.1
+++ b/1984.1
@@ -139,7 +139,8 @@ then exit.
 .BI --gif-out= PATH
 Record a GIF from boot to
 .IR PATH ,
-finalised on exit. Pairs with
+finalised on exit. The Advanced GIF resolution, frame-rate, and encoder
+profile applies. Pairs with
 .BR --exit-after .
 .TP
 .BI --exit-after= N
@@ -304,7 +305,8 @@ Save screenshot (.ppm).
 Warm reset.
 .TP
 .B F6
-Toggle video capture (.gif in the current directory).
+Toggle GIF capture in the current directory using the Advanced capture
+profile.
 .TP
 .B F8
 Open / close the memory monitor and disassembler.
@@ -348,7 +350,9 @@ the MX4 expansion bus).
 .TP
 .B Advanced
 Smoothing (linear vs nearest scaling), snapshot load/save, Net4CPC
-TAP toggle, debug machinery, video capture, USIfAC mode (PTY /
+TAP toggle, debug machinery, WebM video capture, GIF resolution
+(768x576 through 192x144), GIF frame rate (25/20/10/5), optional
+FFmpeg GIF optimization, USIfAC mode (PTY /
 TCP), USIfAC PTY link (stable host-side symlink alias for the
 randomised
 .IR /dev/pts/N

--- a/Makefile
+++ b/Makefile
@@ -134,14 +134,15 @@ am_1984_OBJECTS = src/1984-config.$(OBJEXT) src/1984-cpc.$(OBJEXT) \
 	src/1984-fat.$(OBJEXT) src/1984-ch376.$(OBJEXT) \
 	src/1984-usifac.$(OBJEXT) src/1984-perryfi.$(OBJEXT) \
 	src/1984-symbols.$(OBJEXT) src/1984-gifcap.$(OBJEXT) \
-	src/1984-webmcap.$(OBJEXT) src/1984-webgui.$(OBJEXT) \
-	src/1984-websvc.$(OBJEXT) src/1984-host_mount.$(OBJEXT) \
-	src/1984-leds.$(OBJEXT) src/1984-m4.$(OBJEXT) \
-	src/1984-symbnet.$(OBJEXT) src/1984-symbos_trace.$(OBJEXT) \
-	src/1984-mouse.$(OBJEXT) src/1984-n4c_stack.$(OBJEXT) \
-	src/1984-notify.$(OBJEXT) src/1984-pilot.$(OBJEXT) \
-	src/1984-snapshot.$(OBJEXT) src/1984-tap.$(OBJEXT) \
-	src/1984-tape.$(OBJEXT) src/1984-z80.$(OBJEXT)
+	src/1984-ffmpeg_gif.$(OBJEXT) src/1984-webmcap.$(OBJEXT) \
+	src/1984-webgui.$(OBJEXT) src/1984-websvc.$(OBJEXT) \
+	src/1984-host_mount.$(OBJEXT) src/1984-leds.$(OBJEXT) \
+	src/1984-m4.$(OBJEXT) src/1984-symbnet.$(OBJEXT) \
+	src/1984-symbos_trace.$(OBJEXT) src/1984-mouse.$(OBJEXT) \
+	src/1984-n4c_stack.$(OBJEXT) src/1984-notify.$(OBJEXT) \
+	src/1984-pilot.$(OBJEXT) src/1984-snapshot.$(OBJEXT) \
+	src/1984-tap.$(OBJEXT) src/1984-tape.$(OBJEXT) \
+	src/1984-z80.$(OBJEXT)
 1984_OBJECTS = $(am_1984_OBJECTS)
 am__DEPENDENCIES_1 =
 1984_LINK = $(CCLD) $(1984_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) \
@@ -166,6 +167,7 @@ am__depfiles_remade = src/$(DEPDIR)/1984-amx.Po \
 	src/$(DEPDIR)/1984-cpc.Po src/$(DEPDIR)/1984-crtc.Po \
 	src/$(DEPDIR)/1984-disk.Po src/$(DEPDIR)/1984-display.Po \
 	src/$(DEPDIR)/1984-fat.Po src/$(DEPDIR)/1984-fdc.Po \
+	src/$(DEPDIR)/1984-ffmpeg_gif.Po \
 	src/$(DEPDIR)/1984-gate_array.Po src/$(DEPDIR)/1984-gifcap.Po \
 	src/$(DEPDIR)/1984-host_mount.Po src/$(DEPDIR)/1984-ide.Po \
 	src/$(DEPDIR)/1984-joy.Po src/$(DEPDIR)/1984-kbd.Po \
@@ -340,7 +342,7 @@ PATH_SEPARATOR = :
 PKG_CONFIG = /usr/bin/pkg-config
 PKG_CONFIG_LIBDIR = 
 PKG_CONFIG_PATH = 
-PROG_GIT_COMMIT = 41d2cc6
+PROG_GIT_COMMIT = b803e3e
 SDL3_CFLAGS = 
 SDL3_LIBS = -lSDL3
 SET_MAKE = 
@@ -437,6 +439,7 @@ dist_man1_MANS = 1984.1
 	src/perryfi.c \
 	src/symbols.c \
 	src/gifcap.c \
+	src/ffmpeg_gif.c \
 	src/webmcap.c \
 	src/webgui.c \
 	src/websvc.c \
@@ -467,6 +470,7 @@ noinst_HEADERS = \
 	src/fdc.h \
 	src/gate_array.h \
 	src/gifcap.h \
+	src/ffmpeg_gif.h \
 	src/webmcap.h \
 	src/webgui.h \
 	src/webgui_page.h \
@@ -712,6 +716,8 @@ src/1984-symbols.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-gifcap.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
+src/1984-ffmpeg_gif.$(OBJEXT): src/$(am__dirstamp) \
+	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-webmcap.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-webgui.$(OBJEXT): src/$(am__dirstamp) \
@@ -765,6 +771,7 @@ include src/$(DEPDIR)/1984-disk.Po # am--include-marker
 include src/$(DEPDIR)/1984-display.Po # am--include-marker
 include src/$(DEPDIR)/1984-fat.Po # am--include-marker
 include src/$(DEPDIR)/1984-fdc.Po # am--include-marker
+include src/$(DEPDIR)/1984-ffmpeg_gif.Po # am--include-marker
 include src/$(DEPDIR)/1984-gate_array.Po # am--include-marker
 include src/$(DEPDIR)/1984-gifcap.Po # am--include-marker
 include src/$(DEPDIR)/1984-host_mount.Po # am--include-marker
@@ -1244,6 +1251,20 @@ src/1984-gifcap.obj: src/gifcap.c
 #	$(AM_V_CC)source='src/gifcap.c' object='src/1984-gifcap.obj' libtool=no \
 #	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) \
 #	$(AM_V_CC_no)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-gifcap.obj `if test -f 'src/gifcap.c'; then $(CYGPATH_W) 'src/gifcap.c'; else $(CYGPATH_W) '$(srcdir)/src/gifcap.c'; fi`
+
+src/1984-ffmpeg_gif.o: src/ffmpeg_gif.c
+	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-ffmpeg_gif.o -MD -MP -MF src/$(DEPDIR)/1984-ffmpeg_gif.Tpo -c -o src/1984-ffmpeg_gif.o `test -f 'src/ffmpeg_gif.c' || echo '$(srcdir)/'`src/ffmpeg_gif.c
+	$(AM_V_at)$(am__mv) src/$(DEPDIR)/1984-ffmpeg_gif.Tpo src/$(DEPDIR)/1984-ffmpeg_gif.Po
+#	$(AM_V_CC)source='src/ffmpeg_gif.c' object='src/1984-ffmpeg_gif.o' libtool=no \
+#	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) \
+#	$(AM_V_CC_no)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-ffmpeg_gif.o `test -f 'src/ffmpeg_gif.c' || echo '$(srcdir)/'`src/ffmpeg_gif.c
+
+src/1984-ffmpeg_gif.obj: src/ffmpeg_gif.c
+	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-ffmpeg_gif.obj -MD -MP -MF src/$(DEPDIR)/1984-ffmpeg_gif.Tpo -c -o src/1984-ffmpeg_gif.obj `if test -f 'src/ffmpeg_gif.c'; then $(CYGPATH_W) 'src/ffmpeg_gif.c'; else $(CYGPATH_W) '$(srcdir)/src/ffmpeg_gif.c'; fi`
+	$(AM_V_at)$(am__mv) src/$(DEPDIR)/1984-ffmpeg_gif.Tpo src/$(DEPDIR)/1984-ffmpeg_gif.Po
+#	$(AM_V_CC)source='src/ffmpeg_gif.c' object='src/1984-ffmpeg_gif.obj' libtool=no \
+#	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) \
+#	$(AM_V_CC_no)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-ffmpeg_gif.obj `if test -f 'src/ffmpeg_gif.c'; then $(CYGPATH_W) 'src/ffmpeg_gif.c'; else $(CYGPATH_W) '$(srcdir)/src/ffmpeg_gif.c'; fi`
 
 src/1984-webmcap.o: src/webmcap.c
 	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-webmcap.o -MD -MP -MF src/$(DEPDIR)/1984-webmcap.Tpo -c -o src/1984-webmcap.o `test -f 'src/webmcap.c' || echo '$(srcdir)/'`src/webmcap.c
@@ -2033,6 +2054,7 @@ distclean: distclean-am
 	-rm -f src/$(DEPDIR)/1984-display.Po
 	-rm -f src/$(DEPDIR)/1984-fat.Po
 	-rm -f src/$(DEPDIR)/1984-fdc.Po
+	-rm -f src/$(DEPDIR)/1984-ffmpeg_gif.Po
 	-rm -f src/$(DEPDIR)/1984-gate_array.Po
 	-rm -f src/$(DEPDIR)/1984-gifcap.Po
 	-rm -f src/$(DEPDIR)/1984-host_mount.Po
@@ -2131,6 +2153,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f src/$(DEPDIR)/1984-display.Po
 	-rm -f src/$(DEPDIR)/1984-fat.Po
 	-rm -f src/$(DEPDIR)/1984-fdc.Po
+	-rm -f src/$(DEPDIR)/1984-ffmpeg_gif.Po
 	-rm -f src/$(DEPDIR)/1984-gate_array.Po
 	-rm -f src/$(DEPDIR)/1984-gifcap.Po
 	-rm -f src/$(DEPDIR)/1984-host_mount.Po

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,6 +34,7 @@ dist_man1_MANS = 1984.1
 	src/perryfi.c \
 	src/symbols.c \
 	src/gifcap.c \
+	src/ffmpeg_gif.c \
 	src/webmcap.c \
 	src/webgui.c \
 	src/websvc.c \
@@ -64,6 +65,7 @@ noinst_HEADERS = \
 	src/fdc.h \
 	src/gate_array.h \
 	src/gifcap.h \
+	src/ffmpeg_gif.h \
 	src/webmcap.h \
 	src/webgui.h \
 	src/webgui_page.h \

--- a/Makefile.in
+++ b/Makefile.in
@@ -134,14 +134,15 @@ am_1984_OBJECTS = src/1984-config.$(OBJEXT) src/1984-cpc.$(OBJEXT) \
 	src/1984-fat.$(OBJEXT) src/1984-ch376.$(OBJEXT) \
 	src/1984-usifac.$(OBJEXT) src/1984-perryfi.$(OBJEXT) \
 	src/1984-symbols.$(OBJEXT) src/1984-gifcap.$(OBJEXT) \
-	src/1984-webmcap.$(OBJEXT) src/1984-webgui.$(OBJEXT) \
-	src/1984-websvc.$(OBJEXT) src/1984-host_mount.$(OBJEXT) \
-	src/1984-leds.$(OBJEXT) src/1984-m4.$(OBJEXT) \
-	src/1984-symbnet.$(OBJEXT) src/1984-symbos_trace.$(OBJEXT) \
-	src/1984-mouse.$(OBJEXT) src/1984-n4c_stack.$(OBJEXT) \
-	src/1984-notify.$(OBJEXT) src/1984-pilot.$(OBJEXT) \
-	src/1984-snapshot.$(OBJEXT) src/1984-tap.$(OBJEXT) \
-	src/1984-tape.$(OBJEXT) src/1984-z80.$(OBJEXT)
+	src/1984-ffmpeg_gif.$(OBJEXT) src/1984-webmcap.$(OBJEXT) \
+	src/1984-webgui.$(OBJEXT) src/1984-websvc.$(OBJEXT) \
+	src/1984-host_mount.$(OBJEXT) src/1984-leds.$(OBJEXT) \
+	src/1984-m4.$(OBJEXT) src/1984-symbnet.$(OBJEXT) \
+	src/1984-symbos_trace.$(OBJEXT) src/1984-mouse.$(OBJEXT) \
+	src/1984-n4c_stack.$(OBJEXT) src/1984-notify.$(OBJEXT) \
+	src/1984-pilot.$(OBJEXT) src/1984-snapshot.$(OBJEXT) \
+	src/1984-tap.$(OBJEXT) src/1984-tape.$(OBJEXT) \
+	src/1984-z80.$(OBJEXT)
 1984_OBJECTS = $(am_1984_OBJECTS)
 am__DEPENDENCIES_1 =
 1984_LINK = $(CCLD) $(1984_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) \
@@ -166,6 +167,7 @@ am__depfiles_remade = src/$(DEPDIR)/1984-amx.Po \
 	src/$(DEPDIR)/1984-cpc.Po src/$(DEPDIR)/1984-crtc.Po \
 	src/$(DEPDIR)/1984-disk.Po src/$(DEPDIR)/1984-display.Po \
 	src/$(DEPDIR)/1984-fat.Po src/$(DEPDIR)/1984-fdc.Po \
+	src/$(DEPDIR)/1984-ffmpeg_gif.Po \
 	src/$(DEPDIR)/1984-gate_array.Po src/$(DEPDIR)/1984-gifcap.Po \
 	src/$(DEPDIR)/1984-host_mount.Po src/$(DEPDIR)/1984-ide.Po \
 	src/$(DEPDIR)/1984-joy.Po src/$(DEPDIR)/1984-kbd.Po \
@@ -437,6 +439,7 @@ dist_man1_MANS = 1984.1
 	src/perryfi.c \
 	src/symbols.c \
 	src/gifcap.c \
+	src/ffmpeg_gif.c \
 	src/webmcap.c \
 	src/webgui.c \
 	src/websvc.c \
@@ -467,6 +470,7 @@ noinst_HEADERS = \
 	src/fdc.h \
 	src/gate_array.h \
 	src/gifcap.h \
+	src/ffmpeg_gif.h \
 	src/webmcap.h \
 	src/webgui.h \
 	src/webgui_page.h \
@@ -712,6 +716,8 @@ src/1984-symbols.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-gifcap.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
+src/1984-ffmpeg_gif.$(OBJEXT): src/$(am__dirstamp) \
+	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-webmcap.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/1984-webgui.$(OBJEXT): src/$(am__dirstamp) \
@@ -765,6 +771,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-display.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-fat.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-fdc.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-ffmpeg_gif.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-gate_array.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-gifcap.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/1984-host_mount.Po@am__quote@ # am--include-marker
@@ -1244,6 +1251,20 @@ src/1984-gifcap.obj: src/gifcap.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/gifcap.c' object='src/1984-gifcap.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-gifcap.obj `if test -f 'src/gifcap.c'; then $(CYGPATH_W) 'src/gifcap.c'; else $(CYGPATH_W) '$(srcdir)/src/gifcap.c'; fi`
+
+src/1984-ffmpeg_gif.o: src/ffmpeg_gif.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-ffmpeg_gif.o -MD -MP -MF src/$(DEPDIR)/1984-ffmpeg_gif.Tpo -c -o src/1984-ffmpeg_gif.o `test -f 'src/ffmpeg_gif.c' || echo '$(srcdir)/'`src/ffmpeg_gif.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/1984-ffmpeg_gif.Tpo src/$(DEPDIR)/1984-ffmpeg_gif.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/ffmpeg_gif.c' object='src/1984-ffmpeg_gif.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-ffmpeg_gif.o `test -f 'src/ffmpeg_gif.c' || echo '$(srcdir)/'`src/ffmpeg_gif.c
+
+src/1984-ffmpeg_gif.obj: src/ffmpeg_gif.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-ffmpeg_gif.obj -MD -MP -MF src/$(DEPDIR)/1984-ffmpeg_gif.Tpo -c -o src/1984-ffmpeg_gif.obj `if test -f 'src/ffmpeg_gif.c'; then $(CYGPATH_W) 'src/ffmpeg_gif.c'; else $(CYGPATH_W) '$(srcdir)/src/ffmpeg_gif.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/1984-ffmpeg_gif.Tpo src/$(DEPDIR)/1984-ffmpeg_gif.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/ffmpeg_gif.c' object='src/1984-ffmpeg_gif.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -c -o src/1984-ffmpeg_gif.obj `if test -f 'src/ffmpeg_gif.c'; then $(CYGPATH_W) 'src/ffmpeg_gif.c'; else $(CYGPATH_W) '$(srcdir)/src/ffmpeg_gif.c'; fi`
 
 src/1984-webmcap.o: src/webmcap.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(1984_CFLAGS) $(CFLAGS) -MT src/1984-webmcap.o -MD -MP -MF src/$(DEPDIR)/1984-webmcap.Tpo -c -o src/1984-webmcap.o `test -f 'src/webmcap.c' || echo '$(srcdir)/'`src/webmcap.c
@@ -2033,6 +2054,7 @@ distclean: distclean-am
 	-rm -f src/$(DEPDIR)/1984-display.Po
 	-rm -f src/$(DEPDIR)/1984-fat.Po
 	-rm -f src/$(DEPDIR)/1984-fdc.Po
+	-rm -f src/$(DEPDIR)/1984-ffmpeg_gif.Po
 	-rm -f src/$(DEPDIR)/1984-gate_array.Po
 	-rm -f src/$(DEPDIR)/1984-gifcap.Po
 	-rm -f src/$(DEPDIR)/1984-host_mount.Po
@@ -2131,6 +2153,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f src/$(DEPDIR)/1984-display.Po
 	-rm -f src/$(DEPDIR)/1984-fat.Po
 	-rm -f src/$(DEPDIR)/1984-fdc.Po
+	-rm -f src/$(DEPDIR)/1984-ffmpeg_gif.Po
 	-rm -f src/$(DEPDIR)/1984-gate_array.Po
 	-rm -f src/$(DEPDIR)/1984-gifcap.Po
 	-rm -f src/$(DEPDIR)/1984-host_mount.Po

--- a/README.md
+++ b/README.md
@@ -94,9 +94,11 @@ SYMBiFACE PS/2 and Albireo CH376-A mouse devices are available with their
 respective expansions. Click the emulator to capture a selected mouse and
 press **Ctrl+Enter** to release it.
 
-F4 saves a PPM screenshot. F6 records a dependency-free animated GIF, while
-Advanced > **Capture video** records WebM/VP9 when `ffmpeg` was found during
-configuration. Audio can also be recorded to WAV from the command line.
+F4 saves a PPM screenshot. F6 records an animated GIF using the resolution,
+frame-rate, and encoder profile under Advanced. The built-in path has no
+dependencies; optional FFmpeg optimization reduces captures when possible.
+Advanced > **Capture video** records WebM/VP9. Audio can also be recorded to
+WAV from the command line.
 
 ## Expansion hardware
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -128,9 +128,11 @@ Two paths, picked by what you want from the output.
 | **F6** | `.gif` (animated) | Quick share, no dependencies, ≤ few seconds of gameplay |
 | **F9 → Advanced → Capture video** | `.webm` (VP9) | Longer clips, YouTube uploads, anything where GIF size becomes painful |
 
-Both video paths capture the CPC framebuffer **before** the overlay draws, so the recording shows only the CPC screen. Output is scaled to 768×576 (correct 4:3 — the CPC framebuffer is 768×272 with non-square pixels).
+Both video paths capture the CPC framebuffer **before** the overlay draws, so the recording shows only the CPC screen. WebM is scaled to 768×576. GIF resolution is selectable as 768×576, 576×432, 384×288, 256×192, or 192×144. Every choice preserves the correct 4:3 display aspect (the CPC framebuffer is 768×272 with non-square pixels).
 
-**GIF (F6)** uses an in-tree GIF89a + LZW encoder — no codec libraries, no ffmpeg required. Captured at 25 fps. Lossless palette for the CPC's ≤27 simultaneous colours. Toggle F6 again to stop; the file is finalised on stop or on clean exit.
+**GIF (F6)** uses an in-tree GIF89a + LZW encoder — no codec libraries or FFmpeg required. Under Advanced, **GIF resolution** controls output dimensions and **GIF frame rate** selects 25, 20, 10, or 5 fps. These are the useful size controls: GIF has no dependable target-bitrate setting, and file size is content-dependent. The default remains 768×576 at 25 fps. Toggle F6 again to stop; the file is finalised on stop or on clean exit. The same profile applies to `--gif-out`.
+
+**GIF encoder** defaults to `built-in`. When `FFmpeg optimize` is selected, capture still uses the reliable in-tree encoder, then FFmpeg builds a global palette and inter-frame differences when recording stops. The original GIF is retained if conversion fails or does not produce a smaller file. Conversion can briefly pause the emulator after a long recording. Press Delete on any of the three GIF rows to restore its default. The corresponding `[advanced]` keys are `gif_resolution`, `gif_fps`, and `gif_ffmpeg`.
 
 **WebM (overlay)** spawns `ffmpeg` as a subprocess and pipes raw frames to it; `ffmpeg` does the VP9 encoding (50 fps, 2 Mbit/s) and Matroska muxing. `./configure` detects ffmpeg at build time; on systems where it was absent the overlay row shows `[needs ffmpeg — F6 still records .gif]`. The encoded bitstream is YouTube-ingestible without re-encoding.
 

--- a/configure
+++ b/configure
@@ -5297,10 +5297,10 @@ esac
 
 
 
-# ffmpeg — optional. Enables WebM/VP9 video capture from the overlay's
-# "Capture video" menu. The F6-triggered .gif capture works without it.
-# Detected at configure time so the overlay can gate the menu row; the
-# path is hardcoded into the binary as FFMPEG_PATH for popen().
+# ffmpeg - optional. Enables WebM/VP9 capture and the post-capture GIF
+# optimization pass. The F6-triggered built-in GIF encoder works without it.
+# Detected at configure time so the overlay can gate both options; the path is
+# hardcoded into the binary as FFMPEG_PATH for subprocess invocation.
 # Extract the first word of "ffmpeg", so it can be a program name with args.
 set dummy ffmpeg; ac_word=$2
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
@@ -5355,11 +5355,11 @@ printf "%s\n" "#define FFMPEG_PATH \"$FFMPEG\"" >>confdefs.h
 
 printf "%s\n" "#define HAVE_FFMPEG 1" >>confdefs.h
 
-       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: video capture: WebM enabled via $FFMPEG" >&5
-printf "%s\n" "$as_me: video capture: WebM enabled via $FFMPEG" >&6;}
+       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: video capture: WebM and GIF optimization enabled via $FFMPEG" >&5
+printf "%s\n" "$as_me: video capture: WebM and GIF optimization enabled via $FFMPEG" >&6;}
 else case e in #(
-  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: video capture: WebM disabled (no ffmpeg found)" >&5
-printf "%s\n" "$as_me: video capture: WebM disabled (no ffmpeg found)" >&6;} ;;
+  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: video capture: WebM and GIF optimization disabled (no ffmpeg found)" >&5
+printf "%s\n" "$as_me: video capture: WebM and GIF optimization disabled (no ffmpeg found)" >&6;} ;;
 esac
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -75,17 +75,17 @@ AC_SUBST([WIN_LIBS])
 AC_SUBST([WIN_RC_OBJ])
 AC_SUBST([WINDRES])
 
-# ffmpeg — optional. Enables WebM/VP9 video capture from the overlay's
-# "Capture video" menu. The F6-triggered .gif capture works without it.
-# Detected at configure time so the overlay can gate the menu row; the
-# path is hardcoded into the binary as FFMPEG_PATH for popen().
+# ffmpeg - optional. Enables WebM/VP9 capture and the post-capture GIF
+# optimization pass. The F6-triggered built-in GIF encoder works without it.
+# Detected at configure time so the overlay can gate both options; the path is
+# hardcoded into the binary as FFMPEG_PATH for subprocess invocation.
 AC_PATH_PROG([FFMPEG], [ffmpeg], [])
 AS_IF([test -n "$FFMPEG"],
       [AC_DEFINE_UNQUOTED([FFMPEG_PATH], ["$FFMPEG"],
-           [Path to ffmpeg binary for WebM video capture])
-       AC_DEFINE([HAVE_FFMPEG], [1], [ffmpeg available for WebM capture])
-       AC_MSG_NOTICE([video capture: WebM enabled via $FFMPEG])],
-      [AC_MSG_NOTICE([video capture: WebM disabled (no ffmpeg found)])])
+           [Path to ffmpeg binary for video capture])
+       AC_DEFINE([HAVE_FFMPEG], [1], [ffmpeg available for video capture])
+       AC_MSG_NOTICE([video capture: WebM and GIF optimization enabled via $FFMPEG])],
+      [AC_MSG_NOTICE([video capture: WebM and GIF optimization disabled (no ffmpeg found)])])
 
 # Short git commit shown in the Advanced overlay alongside PACKAGE_VERSION.
 # Resolved at configure time so non-git source trees (dist tarballs, flatpak

--- a/src/config.c
+++ b/src/config.c
@@ -160,6 +160,9 @@ void config_defaults(Config *cfg) {
     cfg->crt_blue = DISPLAY_CRT_RGB_DEFAULT;
     cfg->tinker    = false;
     cfg->debug     = false;
+    cfg->gif_width = GIF_CAPTURE_WIDTH_DEFAULT;
+    cfg->gif_fps   = GIF_CAPTURE_FPS_DEFAULT;
+    cfg->gif_ffmpeg = false;
     cfg->web_gui   = false;
     cfg->web_port  = 1984;
     snprintf(cfg->net4cpc_tap_host_ip,    sizeof(cfg->net4cpc_tap_host_ip),    "10.0.0.1");
@@ -363,6 +366,12 @@ static void config_create_default(const char *path) {
         "# text capture, etc.). Off by default; when off, none of the\n"
         "# debug machinery runs and ONE_K_* trace env vars are no-ops.\n"
         "debug=false\n"
+        "# Animated GIF profile used by F6 and --gif-out. Resolution must be\n"
+        "# 768x576, 576x432, 384x288, 256x192, or 192x144; fps must be\n"
+        "# 25, 20, 10, or 5. FFmpeg mode falls back to the built-in encoder.\n"
+        "gif_resolution=768x576\n"
+        "gif_fps=25\n"
+        "gif_ffmpeg=false\n"
         "# Web GUI: serve the emulator screen + controls over HTTP.\n"
         "# Binds 0.0.0.0 — anyone on your network can view and type. No auth.\n"
         "web_gui=false\n"
@@ -654,6 +663,27 @@ int config_load_from(Config *cfg, const char *path_override) {
                 bool b;
                 if (parse_bool(val, &b)) cfg->debug = b;
                 else { fprintf(stderr, "1984.conf:%d: debug must be true/false\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "gif_resolution")) {
+                int w = 0, h = 0;
+                char trailing = '\0';
+                bool allowed;
+                if (sscanf(val, "%dx%d%c", &w, &h, &trailing) != 2) {
+                    allowed = false;
+                } else {
+                    allowed = (w == 768 || w == 576 || w == 384 ||
+                               w == 256 || w == 192) && h == (w * 3) / 4;
+                }
+                if (allowed) cfg->gif_width = w;
+                else { fprintf(stderr, "1984.conf:%d: gif_resolution must be 768x576/576x432/384x288/256x192/192x144\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "gif_fps")) {
+                int fps = atoi(val);
+                if (fps == 25 || fps == 20 || fps == 10 || fps == 5)
+                    cfg->gif_fps = fps;
+                else { fprintf(stderr, "1984.conf:%d: gif_fps must be 25/20/10/5\n", lineno); rc = -1; }
+            } else if (!strcmp(key, "gif_ffmpeg")) {
+                bool b;
+                if (parse_bool(val, &b)) cfg->gif_ffmpeg = b;
+                else { fprintf(stderr, "1984.conf:%d: gif_ffmpeg must be true/false\n", lineno); rc = -1; }
             } else if (!strcmp(key, "web_gui")) {
                 bool b;
                 if (parse_bool(val, &b)) cfg->web_gui = b;
@@ -819,6 +849,9 @@ int config_save(const Config *cfg) {
         "[advanced]\n"
         "tinker=%s\n"
         "debug=%s\n"
+        "gif_resolution=%dx%d\n"
+        "gif_fps=%d\n"
+        "gif_ffmpeg=%s\n"
         "web_gui=%s\n"
         "web_port=%d\n"
         "notifications=%s\n"
@@ -871,6 +904,10 @@ int config_save(const Config *cfg) {
         cfg->audio_stereo_sep,
         cfg->tinker     ? "true" : "false",
         cfg->debug      ? "true" : "false",
+        cfg->gif_width,
+        (cfg->gif_width * 3) / 4,
+        cfg->gif_fps,
+        cfg->gif_ffmpeg ? "true" : "false",
         cfg->web_gui    ? "true" : "false",
         cfg->web_port,
         cfg->notifications == NOTIFY_MODE_SCREEN  ? "screen"  :

--- a/src/config.h
+++ b/src/config.h
@@ -15,6 +15,8 @@ typedef enum { PRINTER_SINK_PDF = 0, PRINTER_SINK_REAL_PRINTER } ConfigPrintSink
 typedef enum { FALLBACK_JOYSTICK = 0, FALLBACK_AMX_MOUSE } FallbackInput;
 
 #define CONFIG_PATH_MAX 512
+#define GIF_CAPTURE_WIDTH_DEFAULT 768
+#define GIF_CAPTURE_FPS_DEFAULT   25
 
 typedef struct {
     /* [machine] */
@@ -150,6 +152,9 @@ typedef struct {
 
     /* [advanced] */
     bool tinker;             /* enable Advanced overlay tab with low-level toggles */
+    int  gif_width;           /* animated GIF output width; height is width * 3 / 4 */
+    int  gif_fps;             /* animated GIF frame rate: 5, 10, 20, or 25 */
+    bool gif_ffmpeg;          /* use FFmpeg's optimized GIF encoder when available */
     bool web_gui;            /* embedded HTTP server serving the emulator to a
                               * browser. Binds 0.0.0.0 — LAN-visible, no auth. */
     int  web_port;           /* Web GUI TCP port; default 1984 */

--- a/src/cpc.h
+++ b/src/cpc.h
@@ -153,7 +153,8 @@ static inline const char *dbg_getenv(const char *name) {
 
 /* Video capture (GIF89a) — owned by main.c. Returns true if recording
  * is active, regardless of how the call resolved. */
-bool videocap_start(const char *path);   /* false on open failure */
+bool videocap_start(const char *path, int gif_width, int gif_fps,
+                    bool gif_ffmpeg);    /* false on open failure */
 void videocap_stop(void);
 bool videocap_active(void);
 int  videocap_frame_count(void);

--- a/src/ffmpeg_gif.c
+++ b/src/ffmpeg_gif.c
@@ -1,0 +1,96 @@
+/* ffmpeg_gif.c - optional global-palette GIF optimization through FFmpeg. */
+#include "ffmpeg_gif.h"
+
+#include <SDL3/SDL.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+bool ffmpeg_gif_optimize(const char *path) {
+#ifndef HAVE_FFMPEG
+    (void)path;
+    fprintf(stderr, "[ffmpeg-gif] not compiled with FFmpeg support\n");
+    return false;
+#else
+    if (!path || !path[0])
+        return false;
+
+    size_t temp_len = strlen(path) + sizeof(".ffmpeg.tmp.gif");
+    char *temp = malloc(temp_len);
+    if (!temp)
+        return false;
+    snprintf(temp, temp_len, "%s.ffmpeg.tmp.gif", path);
+    SDL_RemovePath(temp);  /* ignore a missing stale temporary file */
+
+    const char *args[] = {
+        FFMPEG_PATH,
+        "-y", "-loglevel", "error",
+        "-i", path,
+        "-filter_complex",
+        "[0:v]split[palette_src][pixel_src];"
+        "[palette_src]palettegen=max_colors=256:reserve_transparent=0[palette];"
+        "[pixel_src][palette]paletteuse=dither=none",
+        "-fps_mode", "passthrough",
+        "-gifflags", "+offsetting+transdiff",
+        "-loop", "0",
+        temp,
+        NULL
+    };
+
+    fprintf(stderr, "[ffmpeg-gif] optimizing %s\n", path);
+    SDL_Process *process = SDL_CreateProcess(args, false);
+    if (!process) {
+        fprintf(stderr, "[ffmpeg-gif] could not start '%s': %s\n",
+                FFMPEG_PATH, SDL_GetError());
+        free(temp);
+        return false;
+    }
+
+    int exit_code = -255;
+    bool exited = SDL_WaitProcess(process, true, &exit_code);
+    SDL_DestroyProcess(process);
+    if (!exited || exit_code != 0) {
+        fprintf(stderr, "[ffmpeg-gif] conversion failed (exit=%d)\n",
+                exit_code);
+        SDL_RemovePath(temp);
+        free(temp);
+        return false;
+    }
+
+    SDL_PathInfo original_info;
+    SDL_PathInfo optimized_info;
+    if (!SDL_GetPathInfo(path, &original_info) ||
+        !SDL_GetPathInfo(temp, &optimized_info)) {
+        fprintf(stderr, "[ffmpeg-gif] could not compare output sizes: %s\n",
+                SDL_GetError());
+        SDL_RemovePath(temp);
+        free(temp);
+        return false;
+    }
+
+    if (optimized_info.size == 0 ||
+        optimized_info.size >= original_info.size) {
+        fprintf(stderr,
+                "[ffmpeg-gif] kept built-in GIF (%llu bytes; FFmpeg %llu bytes)\n",
+                (unsigned long long)original_info.size,
+                (unsigned long long)optimized_info.size);
+        SDL_RemovePath(temp);
+        free(temp);
+        return true;
+    }
+
+    if (!SDL_RenamePath(temp, path)) {
+        fprintf(stderr, "[ffmpeg-gif] could not install optimized GIF: %s\n",
+                SDL_GetError());
+        SDL_RemovePath(temp);
+        free(temp);
+        return false;
+    }
+
+    fprintf(stderr, "[ffmpeg-gif] reduced %llu -> %llu bytes\n",
+            (unsigned long long)original_info.size,
+            (unsigned long long)optimized_info.size);
+    free(temp);
+    return true;
+#endif
+}

--- a/src/ffmpeg_gif.h
+++ b/src/ffmpeg_gif.h
@@ -1,0 +1,15 @@
+/* ffmpeg_gif.h - optional FFmpeg optimization pass for animated GIFs. */
+#pragma once
+
+#include <stdbool.h>
+
+/* Re-encode an existing GIF through a global palette and inter-frame
+ * differences. The original is replaced only when FFmpeg succeeds and its
+ * result is smaller. */
+bool ffmpeg_gif_optimize(const char *path);
+
+#ifdef HAVE_FFMPEG
+#  define FFMPEG_GIF_SUPPORTED 1
+#else
+#  define FFMPEG_GIF_SUPPORTED 0
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -30,17 +30,21 @@
 #include "compat_win.h"   /* net_compat_init() — WSAStartup on Windows */
 #include "startup_debug.h"   /* SD_INIT()/SD_LOG() — no-ops unless -DSTARTUP_DEBUG */
 #include "gifcap.h"
+#include "ffmpeg_gif.h"
 #include "webmcap.h"
 #include "webgui.h"
 #include "websvc.h"
 #include "symbos_trace.h"
 
-/* --- Video capture state. F6 → GIF (lean, no deps); overlay file
- * picker → WebM via ffmpeg when configure detected it. Dispatch is by
- * file extension. Output is scaled to 768x576 (4:3) in both paths. */
+/* --- Video capture state. F6 -> configurable GIF (built-in, with an
+ * optional FFmpeg optimization pass); the overlay picker records WebM. */
 static GifCap  *g_videocap_gif  = NULL;
 static WebmCap *g_videocap_webm = NULL;
-static int      g_videocap_skip = 0;   /* GIF-only: halve to 25 fps */
+static uint64_t g_videocap_gif_interval_ns = 0;
+static uint64_t g_videocap_gif_elapsed_ns = 0;
+static bool     g_videocap_gif_first = false;
+static bool     g_videocap_gif_optimize = false;
+static char    *g_videocap_gif_path = NULL;
 static FILE    *g_audiocap_wav  = NULL;
 static uint32_t g_audiocap_bytes = 0;
 
@@ -59,7 +63,17 @@ static bool path_ends_with(const char *p, const char *suffix) {
     return strcasecmp(p + lp - ls, suffix) == 0;
 }
 
-bool videocap_start(const char *path) {
+static bool gif_width_supported(int width) {
+    return width == 768 || width == 576 || width == 384 ||
+           width == 256 || width == 192;
+}
+
+static bool gif_fps_supported(int fps) {
+    return fps == 25 || fps == 20 || fps == 10 || fps == 5;
+}
+
+bool videocap_start(const char *path, int gif_width, int gif_fps,
+                    bool gif_ffmpeg) {
     if (!path || !path[0]) return false;
     if (videocap_active()) return true;
     if (path_ends_with(path, ".webm")) {
@@ -71,19 +85,34 @@ bool videocap_start(const char *path) {
             return false;
         }
     } else {
-        /* 4 cs = 25 fps; decimate 50 Hz input by writing every other frame.
-         * Output at WINDOW_H for the correct 4:3 aspect — the CPC
-         * framebuffer is 768x272 non-square pixels, displayed at
-         * 768x576. */
+        if (!gif_width_supported(gif_width))
+            gif_width = GIF_CAPTURE_WIDTH_DEFAULT;
+        if (!gif_fps_supported(gif_fps))
+            gif_fps = GIF_CAPTURE_FPS_DEFAULT;
+        int gif_height = (gif_width * 3) / 4;
+
+        int delay_cs = 100 / gif_fps;
         g_videocap_gif = gifcap_open(path,
                                      CPC_SCREEN_W, CPC_SCREEN_H,
-                                     CPC_SCREEN_W, WINDOW_H,
-                                     4);
+                                     gif_width, gif_height,
+                                     delay_cs);
         if (!g_videocap_gif) {
             fprintf(stderr, "[videocap] GIF open failed for '%s'\n", path);
             return false;
         }
-        g_videocap_skip = 0;
+
+        g_videocap_gif_optimize = gif_ffmpeg && FFMPEG_GIF_SUPPORTED;
+        if (g_videocap_gif_optimize) {
+            size_t path_len = strlen(path) + 1;
+            g_videocap_gif_path = malloc(path_len);
+            if (g_videocap_gif_path)
+                memcpy(g_videocap_gif_path, path, path_len);
+            else
+                g_videocap_gif_optimize = false;
+        }
+        g_videocap_gif_interval_ns = 1000000000ULL / (uint64_t)gif_fps;
+        g_videocap_gif_elapsed_ns = 0;
+        g_videocap_gif_first = true;
     }
     fprintf(stderr, "[videocap] recording to %s\n", path);
     return true;
@@ -94,11 +123,28 @@ void videocap_stop(void) {
         gifcap_close(g_videocap_gif);
         g_videocap_gif = NULL;
         fprintf(stderr, "[videocap] GIF stopped (%d frames)\n", n);
+        if (g_videocap_gif_optimize && g_videocap_gif_path)
+            ffmpeg_gif_optimize(g_videocap_gif_path);
     }
+    free(g_videocap_gif_path);
+    g_videocap_gif_path = NULL;
+    g_videocap_gif_optimize = false;
     if (g_videocap_webm) {
         webmcap_close(g_videocap_webm);
         g_videocap_webm = NULL;
     }
+}
+
+static bool videocap_gif_due(uint64_t emulated_frame_ns) {
+    if (g_videocap_gif_first) {
+        g_videocap_gif_first = false;
+        return true;
+    }
+    g_videocap_gif_elapsed_ns += emulated_frame_ns;
+    if (g_videocap_gif_elapsed_ns < g_videocap_gif_interval_ns)
+        return false;
+    g_videocap_gif_elapsed_ns %= g_videocap_gif_interval_ns;
+    return true;
 }
 
 static void wav_u16(FILE *f, uint16_t v) {
@@ -348,7 +394,8 @@ static void usage(const char *prog, int code) {
         "  --joy-script=SPEC   Scripted joystick (row 9). SPEC = comma-separated DIRS:FRAMES\n"
         "                      steps; DIRS = u d l r 1 2 (Fire1/2) or - (neutral).\n"
         "                      e.g. --joy-script=d:150,-:30,u:150 (down, rest, up)\n"
-        "  --gif-out=PATH      Record a GIF from boot (finalised on exit; pairs with --exit-after)\n"
+        "  --gif-out=PATH      Record a GIF from boot using the configured capture profile\n"
+        "                      (finalised on exit; pairs with --exit-after)\n"
         "  --audio-out=PATH    Record emulator audio to a WAV file from boot\n"
         "  --exit-after=N      Quit after frame N (deterministic headless capture)\n"
         "  --printer-pdf=DIR   Capture parallel-printer output to timestamped PDFs in DIR\n"
@@ -823,7 +870,8 @@ int main(int argc, char *argv[]) {
     int  frame_count = 0;
     bool running = true;
     if (gifout_arg)            /* --gif-out: record from boot (finalised on exit) */
-        videocap_start(gifout_arg);
+        videocap_start(gifout_arg, cfg.gif_width, cfg.gif_fps,
+                       cfg.gif_ffmpeg);
     if (audioout_arg)
         audiocap_start(audioout_arg);
     SD_LOG("entering main loop — startup complete");
@@ -1091,7 +1139,8 @@ int main(int argc, char *argv[]) {
                                      "1984-%Y%m%d-%H%M%S.gif", lt);
                         else
                             snprintf(path, sizeof(path), "1984-capture.gif");
-                        videocap_start(path);
+                        videocap_start(path, cfg.gif_width, cfg.gif_fps,
+                                       cfg.gif_ffmpeg);
                     }
                 } else if (ev.key.scancode == SDL_SCANCODE_V &&
                            (SDL_GetModState() & SDL_KMOD_CTRL)) {
@@ -1287,12 +1336,12 @@ int main(int argc, char *argv[]) {
                 }
             }
         }
-        /* Video capture: grab the CPC framebuffer before the overlay
-         * draws on top. GIF decimates to 25 fps; WebM takes every
-         * frame at 50 fps (VP9 compresses interframe deltas well). */
-        if (g_videocap_gif) {
-            if ((g_videocap_skip ^= 1) == 0)
-                gifcap_frame(g_videocap_gif, cpc.display.pixels);
+        /* Video capture: grab the CPC framebuffer before the overlay draws
+         * on top. GIF cadence follows emulated time and the selected profile;
+         * WebM retains its native-frame capture path. */
+        if (g_videocap_gif && videocap_gif_due(emulated_frame_ns)) {
+            if (!gifcap_frame(g_videocap_gif, cpc.display.pixels))
+                videocap_stop();
         }
         if (g_videocap_webm) {
             if (!webmcap_frame(g_videocap_webm, cpc.display.pixels))

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -7,6 +7,7 @@
 #include "mem.h"
 #include "snapshot.h"
 #include "webmcap.h"   /* WEBMCAP_SUPPORTED */
+#include "ffmpeg_gif.h" /* FFMPEG_GIF_SUPPORTED */
 #include "webgui.h"
 #include "leds.h"
 #include "notify.h"
@@ -47,7 +48,7 @@ static const int sec_x[OV_SEC_COUNT] = { 8, 80, 160, 248 };
  * "External Tape" toggle, only meaningful on the 6128 since the 464 has
  * the cassette deck built in). Other sections are fixed.
  * The Advanced tab (OV_TINKER) is hidden unless cfg->tinker is enabled. */
-static const int sec_row_count[OV_SEC_COUNT] = { 8, 3, 14, 17 };
+static const int sec_row_count[OV_SEC_COUNT] = { 8, 3, 14, 20 };
 
 static int ov_section_rows(const Overlay *ov, OvSection s) {
     if (s == OV_GENERAL && ov->cfg->model != MODEL_464) return 9;
@@ -84,7 +85,26 @@ static int cycle_crt_percent(int v, int lo, int hi) {
     return v;
 }
 
-static bool reset_tinker_crt_item(Overlay *ov) {
+static int cycle_gif_width(int width) {
+    switch (width) {
+    case 768: return 576;
+    case 576: return 384;
+    case 384: return 256;
+    case 256: return 192;
+    default:  return 768;
+    }
+}
+
+static int cycle_gif_fps(int fps) {
+    switch (fps) {
+    case 25: return 20;
+    case 20: return 10;
+    case 10: return 5;
+    default: return 25;
+    }
+}
+
+static bool reset_tinker_item(Overlay *ov) {
     if (ov->section != OV_TINKER)
         return false;
 
@@ -95,6 +115,9 @@ static bool reset_tinker_crt_item(Overlay *ov) {
     int old_red = ov->cfg->crt_red;
     int old_green = ov->cfg->crt_green;
     int old_blue = ov->cfg->crt_blue;
+    int old_gif_width = ov->cfg->gif_width;
+    int old_gif_fps = ov->cfg->gif_fps;
+    bool old_gif_ffmpeg = ov->cfg->gif_ffmpeg;
 
     switch (tinker_logical_row(ov, ov->row)) {
     case -6:
@@ -124,18 +147,32 @@ static bool reset_tinker_crt_item(Overlay *ov) {
         ov->cfg->crt_green = DISPLAY_CRT_RGB_DEFAULT;
         ov->cfg->crt_blue = DISPLAY_CRT_RGB_DEFAULT;
         break;
+    case 8:
+        ov->cfg->gif_width = GIF_CAPTURE_WIDTH_DEFAULT;
+        break;
+    case 9:
+        ov->cfg->gif_fps = GIF_CAPTURE_FPS_DEFAULT;
+        break;
+    case 10:
+        ov->cfg->gif_ffmpeg = false;
+        break;
     default:
         return false;
     }
 
-    if (old_real_crt != ov->cfg->real_crt ||
-        old_scanlines != ov->cfg->crt_scanlines ||
-        old_brightness != ov->cfg->crt_brightness ||
-        old_contrast != ov->cfg->crt_contrast ||
-        old_red != ov->cfg->crt_red ||
-        old_green != ov->cfg->crt_green ||
-        old_blue != ov->cfg->crt_blue) {
-        overlay_apply_crt(ov);
+    bool crt_changed = old_real_crt != ov->cfg->real_crt ||
+                       old_scanlines != ov->cfg->crt_scanlines ||
+                       old_brightness != ov->cfg->crt_brightness ||
+                       old_contrast != ov->cfg->crt_contrast ||
+                       old_red != ov->cfg->crt_red ||
+                       old_green != ov->cfg->crt_green ||
+                       old_blue != ov->cfg->crt_blue;
+    bool changed = crt_changed || old_gif_width != ov->cfg->gif_width ||
+                   old_gif_fps != ov->cfg->gif_fps ||
+                   old_gif_ffmpeg != ov->cfg->gif_ffmpeg;
+    if (changed) {
+        if (crt_changed)
+            overlay_apply_crt(ov);
         ov->dirty = true;
     }
     return true;
@@ -862,6 +899,25 @@ static void item_text(const Overlay *ov, int row,
             *readonly = true;
             break;
         case 8:
+            snprintf(lbl, lsz, "GIF resolution");
+            snprintf(val, vsz, "%dx%d", ov->cfg->gif_width,
+                     (ov->cfg->gif_width * 3) / 4);
+            break;
+        case 9:
+            snprintf(lbl, lsz, "GIF frame rate");
+            snprintf(val, vsz, "%d fps", ov->cfg->gif_fps);
+            break;
+        case 10:
+            snprintf(lbl, lsz, "GIF encoder");
+            if (!FFMPEG_GIF_SUPPORTED) {
+                snprintf(val, vsz, "built-in [ffmpeg unavailable]");
+                *readonly = true;
+            } else {
+                snprintf(val, vsz, "%s",
+                         ov->cfg->gif_ffmpeg ? "FFmpeg optimize" : "built-in");
+            }
+            break;
+        case 11:
             snprintf(lbl, lsz, "USIfAC mode");
             if (!ov->cfg->usifac) {
                 snprintf(val, vsz, "[USIfAC RS232 disabled]");
@@ -872,7 +928,7 @@ static void item_text(const Overlay *ov, int row,
                 snprintf(val, vsz, "PTY");
             }
             break;
-        case 9:
+        case 12:
             snprintf(lbl, lsz, "USIfAC PTY link");
             if (!ov->cfg->usifac) {
                 snprintf(val, vsz, "[USIfAC RS232 disabled]");
@@ -887,7 +943,7 @@ static void item_text(const Overlay *ov, int row,
                 *readonly = true;
             }
             break;
-        case 10:
+        case 13:
             snprintf(lbl, lsz, "Monochrome");
             switch (ov->cfg->monochrome) {
                 case MONO_GREEN: snprintf(val, vsz, "green"); break;
@@ -896,7 +952,7 @@ static void item_text(const Overlay *ov, int row,
                 default:         snprintf(val, vsz, "off");   break;
             }
             break;
-        case 11:
+        case 14:
             snprintf(lbl, lsz, "Printer mode");
             if (!ov->cfg->mx4) {
                 snprintf(val, vsz, "[needs MX4]");
@@ -907,11 +963,11 @@ static void item_text(const Overlay *ov, int row,
                              ? "Real printer (CUPS lp)" : "PDF file");
             }
             break;
-        case 12:
+        case 15:
             snprintf(lbl, lsz, "Volume");
             snprintf(val, vsz, "%d%%", ov->cfg->audio_volume);
             break;
-        case 13:
+        case 16:
             snprintf(lbl, lsz, "Stereo");
             if (ov->cfg->audio_stereo_sep == 0)
                 snprintf(val, vsz, "mono");
@@ -920,20 +976,20 @@ static void item_text(const Overlay *ov, int row,
             else
                 snprintf(val, vsz, "ABC %d/255", ov->cfg->audio_stereo_sep);
             break;
-        case 14:
+        case 17:
             snprintf(lbl, lsz, "Notifications");
             snprintf(val, vsz, "%s",
                      ov->cfg->notifications == NOTIFY_MODE_SCREEN  ? "screen"  :
                      ov->cfg->notifications == NOTIFY_MODE_CONSOLE ? "console" : "off");
             break;
-        case 15:
+        case 18:
             snprintf(lbl, lsz, "Web GUI");
             if (webgui_active())
                 snprintf(val, vsz, "on - 0.0.0.0:%d", webgui_port());
             else
                 snprintf(val, vsz, "off (port %d)", ov->cfg->web_port);
             break;
-        case 16:
+        case 19:
             snprintf(lbl, lsz, "Version");
             snprintf(val, vsz, "%s (commit %s)", PACKAGE_VERSION, PROG_GIT_COMMIT);
             *readonly = true;
@@ -1547,6 +1603,19 @@ static void activate_item(Overlay *ov, SDL_Keymod mods) {
             }
             break;
         case 8:
+            ov->cfg->gif_width = cycle_gif_width(ov->cfg->gif_width);
+            ov->dirty = true;
+            break;
+        case 9:
+            ov->cfg->gif_fps = cycle_gif_fps(ov->cfg->gif_fps);
+            ov->dirty = true;
+            break;
+        case 10:
+            if (!FFMPEG_GIF_SUPPORTED) break;
+            ov->cfg->gif_ffmpeg = !ov->cfg->gif_ffmpeg;
+            ov->dirty = true;
+            break;
+        case 11:
             if (!ov->cfg->usifac) break;
             /* Flip pty ↔ tcp; re-init the device on the new backend. */
             if (!strcmp(ov->cfg->usifac_backend, "tcp"))
@@ -1563,7 +1632,7 @@ static void activate_item(Overlay *ov, SDL_Keymod mods) {
             }
             ov->dirty = true;
             break;
-        case 9:
+        case 12:
             /* USIfAC PTY link: Enter starts an inline text editor seeded
              * with the current value (empty if none). Commit applies the
              * new path and re-inits USIfAC; clearing the field and
@@ -1576,7 +1645,7 @@ static void activate_item(Overlay *ov, SDL_Keymod mods) {
             if (ov->cpc && ov->cpc->display.window)
                 SDL_StartTextInput(ov->cpc->display.window);
             break;
-        case 10: {
+        case 13: {
             MonoMode next;
             switch (ov->cfg->monochrome) {
                 case MONO_OFF:   next = MONO_GREEN; break;
@@ -1589,7 +1658,7 @@ static void activate_item(Overlay *ov, SDL_Keymod mods) {
             ov->dirty = true;
             break;
         }
-        case 11:
+        case 14:
             if (!ov->cfg->mx4) break;
             ov->cfg->print_sink = (ov->cfg->print_sink == PRINTER_SINK_PDF)
                                   ? PRINTER_SINK_REAL_PRINTER : PRINTER_SINK_PDF;
@@ -1599,7 +1668,7 @@ static void activate_item(Overlay *ov, SDL_Keymod mods) {
                                      ? PRINT_SINK_REAL : PRINT_SINK_PDF);
             ov->dirty = true;
             break;
-        case 12:
+        case 15:
             /* Volume: step 5% per Enter, wrap 0→100. Use Left/Right for
              * finer control (handled in handle_event). */
             ov->cfg->audio_volume += 5;
@@ -1607,7 +1676,7 @@ static void activate_item(Overlay *ov, SDL_Keymod mods) {
             if (ov->cpc) psg_set_volume(&ov->cpc->psg, ov->cfg->audio_volume);
             ov->dirty = true;
             break;
-        case 13:
+        case 16:
             /* Stereo separation: cycle mono → half → full. */
             ov->cfg->audio_stereo_sep =
                 ov->cfg->audio_stereo_sep == 0     ? 128 :
@@ -1615,14 +1684,14 @@ static void activate_item(Overlay *ov, SDL_Keymod mods) {
             if (ov->cpc) psg_set_stereo(&ov->cpc->psg, ov->cfg->audio_stereo_sep);
             ov->dirty = true;
             break;
-        case 14:
+        case 17:
             /* Notifications: cycle screen -> console -> off. */
             ov->cfg->notifications =
                 (NotifyMode)((ov->cfg->notifications + 1) % 3);
             notify_set_mode(ov->cfg->notifications);
             ov->dirty = true;
             break;
-        case 15:
+        case 18:
             /* Web GUI: live start/stop, no reboot. On start failure the
              * flag stays off (webgui_start posted the toast). */
             if (webgui_active()) {
@@ -1863,7 +1932,8 @@ void overlay_tick(Overlay *ov) {
             char *slash = strrchr(path, '/');
             if (!dot || (slash && dot < slash))
                 strncat(path, ".webm", sizeof(path) - strlen(path) - 1);
-            videocap_start(path);
+            videocap_start(path, ov->cfg->gif_width, ov->cfg->gif_fps,
+                           ov->cfg->gif_ffmpeg);
         }
     } else if (ov->dialog_kind == DIALOG_M4_IMAGE) {
         /* User picked an SD card image — enable M4, load its ROM, and seed
@@ -2254,7 +2324,7 @@ bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
         break;
     case SDL_SCANCODE_DELETE:
     case SDL_SCANCODE_BACKSPACE:
-        if (reset_tinker_crt_item(ov))
+        if (reset_tinker_item(ov))
             break;
 
         /* Del on Drive A / Drive B / Tape ejects the image and clears
@@ -2555,7 +2625,7 @@ void overlay_render(const Overlay *ov, SDL_Renderer *r) {
 
         float ty = iy + (ITEM_H - FONT_H) / 2.0f;
         draw_text(r, DROP_PAD, ty, lbl, 220, 220, 240);
-        if (ov->section == OV_TINKER && logical == 9 && ov->pty_link_editing) {
+        if (ov->section == OV_TINKER && logical == 12 && ov->pty_link_editing) {
             /* Inline editor: show the live buffer with a blinking-style
              * trailing underscore cursor. Bright green to signal that
              * keystrokes are being captured. */
@@ -2564,7 +2634,7 @@ void overlay_render(const Overlay *ov, SDL_Renderer *r) {
             draw_text(r, VAL_X, ty, shown, 120, 255, 120);
         } else if (readonly) {
             draw_text(r, VAL_X, ty, val, 90, 90, 110);
-        } else if (ov->section == OV_TINKER && logical == 10
+        } else if (ov->section == OV_TINKER && logical == 13
                    && ov->cfg->monochrome != MONO_OFF) {
             /* Render the tint name in its own phosphor colour so the
              * choice is recognisable at a glance. Bright values picked

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@ CC ?= cc
 CFLAGS ?= -O2
 CPPFLAGS ?=
 
-TESTS = test-gate-array test-crtc test-z80 test-psg test-mem test-disk
+TESTS = test-gate-array test-crtc test-z80 test-psg test-mem test-disk test-gifcap
 
 .PHONY: all check clean
 
@@ -32,6 +32,10 @@ test-disk: test_disk.c ../src/disk.c ../src/disk.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -std=c11 -Wall -Wextra -I../src \
 		test_disk.c ../src/disk.c -o $@
 
+test-gifcap: test_gifcap.c ../src/gifcap.c ../src/gifcap.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) -std=c11 -Wall -Wextra -I../src \
+		test_gifcap.c ../src/gifcap.c -o $@
+
 check: $(TESTS)
 	./test-gate-array
 	./test-crtc
@@ -39,6 +43,7 @@ check: $(TESTS)
 	./test-psg
 	./test-mem
 	./test-disk
+	./test-gifcap
 
 clean:
 	rm -f $(TESTS)

--- a/tests/test_gifcap.c
+++ b/tests/test_gifcap.c
@@ -1,0 +1,49 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "gifcap.h"
+
+static uint16_t read_le16(const uint8_t *p) {
+    return (uint16_t)p[0] | ((uint16_t)p[1] << 8);
+}
+
+static const uint8_t *find_gce(const uint8_t *data, size_t len) {
+    static const uint8_t marker[] = { 0x21, 0xF9, 0x04 };
+    for (size_t i = 0; i + 8 <= len; i++) {
+        if (memcmp(data + i, marker, sizeof(marker)) == 0)
+            return data + i;
+    }
+    return NULL;
+}
+
+int main(void) {
+    const int out_w = 192;
+    const int out_h = 144;
+    const int delay_cs = 20;
+    uint32_t pixels[8] = {
+        0x00000000, 0x00FFFFFF, 0x00000000, 0x00FFFFFF,
+        0x00FFFFFF, 0x00000000, 0x00FFFFFF, 0x00000000,
+    };
+
+    GifCap *cap = gifcap_open_mem(4, 2, out_w, out_h, delay_cs);
+    assert(cap != NULL);
+
+    size_t len = 0;
+    const uint8_t *gif = gifcap_encode_single(cap, pixels, &len);
+    assert(gif != NULL);
+    assert(len > 16);
+    assert(memcmp(gif, "GIF89a", 6) == 0);
+    assert(read_le16(gif + 6) == out_w);
+    assert(read_le16(gif + 8) == out_h);
+
+    const uint8_t *gce = find_gce(gif, len);
+    assert(gce != NULL);
+    assert(read_le16(gce + 4) == delay_cs);
+    assert(gifcap_frame_count(cap) == 1);
+
+    gifcap_close(cap);
+    puts("gifcap tests passed");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add persistent GIF resolution and frame-rate controls under Advanced
- add optional FFmpeg post-capture optimization with safe built-in fallback
- apply the profile to F6 and --gif-out, with Delete-to-default behavior
- document and test GIF profile output

## Testing
- make -C tests check
- make distcheck
- headless built-in and FFmpeg captures at 384x288/10 fps
- decoded frame hashes match before and after FFmpeg optimization
- no-FFmpeg fallback compilation

Closes #232