### PR TITLE
Fix new-disk suffix and F10 hint

### DIFF
--- a/src/disk.c
+++ b/src/disk.c
@@ -132,6 +132,30 @@ int disk_load(Disk *d, const char *path) {
 #define BLANK_SECTOR_SZ  512
 #define BLANK_TRACK_SZ  (256 + BLANK_SPT * BLANK_SECTOR_SZ)   /* 4864 */
 
+bool disk_ensure_dsk_extension(char *path, size_t capacity) {
+    static const char suffix[] = ".dsk";
+    size_t len;
+
+    if (!path || capacity == 0 || path[0] == '\0')
+        return false;
+
+    len = strlen(path);
+    if (len >= sizeof(suffix) - 1) {
+        const char *tail = path + len - (sizeof(suffix) - 1);
+        if (tail[0] == '.' &&
+            (tail[1] == 'd' || tail[1] == 'D') &&
+            (tail[2] == 's' || tail[2] == 'S') &&
+            (tail[3] == 'k' || tail[3] == 'K'))
+            return true;
+    }
+
+    if (len >= capacity || capacity - len < sizeof(suffix))
+        return false;
+
+    memcpy(path + len, suffix, sizeof(suffix));
+    return true;
+}
+
 int disk_create_blank(const char *path) {
     const int TRACKS     = BLANK_TRACKS;
     const int SPT        = BLANK_SPT;

--- a/src/disk.h
+++ b/src/disk.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #define DISK_MAX_TRACKS   84
@@ -44,6 +45,10 @@ int  disk_load(Disk *d, const char *path);
  * single-sided, 9 × 512-byte sectors, sector IDs 0xC1..0xC9, 0xE5 fill
  * — empty AMSDOS directory). Returns 0 on success, -1 on I/O error. */
 int  disk_create_blank(const char *path);
+
+/* Ensure a newly created disk path ends in .dsk (case-insensitive).
+ * Returns false if path is empty or the suffix would not fit. */
+bool disk_ensure_dsk_extension(char *path, size_t capacity);
 
 /* Find a sector by CHRN on the current track. Returns NULL if not found. */
 DiskSector *disk_find_sector(Disk *d, int side, uint8_t C, uint8_t H,

--- a/src/main.c
+++ b/src/main.c
@@ -774,6 +774,7 @@ int main(int argc, char *argv[]) {
     SD_LOG("overlay_init OK");
 
     HostMount host_mount = {0};   /* F10 toggle state; see host_mount.c */
+    const bool host_mount_available = host_mount_supported();
 
     Monitor *monitor = monitor_create(&cpc);
     if (monitor_pty) {
@@ -1112,7 +1113,7 @@ int main(int argc, char *argv[]) {
                         host_mount_close(&host_mount);
                         cpc.paused = false;
                         overlay.needs_cold_boot = true;
-                    } else if (host_mount_supported()) {
+                    } else if (host_mount_available) {
                         cpc.paused = true;
                         if (host_mount_open(&host_mount, &cfg)) {
                             host_mount.active = true;
@@ -1123,7 +1124,8 @@ int main(int argc, char *argv[]) {
                         }
                     } else {
                         fprintf(stderr,
-                            "F10: needs libguestfs (guestmount, guestunmount) and xdg-open\n");
+                            "F10: host card browsing requires Linux, xdg-open, "
+                            "and udisks2 or libguestfs\n");
                     }
                 } else if (ev.key.scancode == SDL_SCANCODE_F6) {
                     /* Toggle video capture. Auto-name in CWD when starting
@@ -1404,9 +1406,11 @@ int main(int argc, char *argv[]) {
             const char *model_str = "CPC 6128";
             if (cpc.model == MODEL_464) model_str = "CPC 464";
             else if (cpc.model == MODEL_664) model_str = "CPC 664";
-            const char *keys =
-                "  F4=screenshot  F5=reset  F6=capture  F8=monitor  "
-                "F9=options  F10=open image  F11=fullscreen  F12=quit";
+            const char *keys = host_mount_available
+                ? "  F4=screenshot  F5=reset  F6=capture  F8=monitor  "
+                  "F9=options  F10=cards  F11=fullscreen  F12=quit"
+                : "  F4=screenshot  F5=reset  F6=capture  F8=monitor  "
+                  "F9=options  F11=fullscreen  F12=quit";
 
             int hdr_ww, hdr_wh;
             SDL_GetWindowSize(cpc.display.window, &hdr_ww, &hdr_wh);

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -1846,7 +1846,11 @@ void overlay_tick(Overlay *ov) {
         int drv = ov->dialog_drive;
         ov->dialog_drive = -1;
         char *dest = (drv == 0) ? ov->cfg->disk_a : ov->cfg->disk_b;
-        if (disk_create_blank(ov->dialog_path) == 0) {
+        if (!disk_ensure_dsk_extension(ov->dialog_path,
+                                       sizeof(ov->dialog_path))) {
+            fprintf(stderr,
+                    "1984: cannot create disk: filename is empty or too long\n");
+        } else if (disk_create_blank(ov->dialog_path) == 0) {
             snprintf(dest, CONFIG_PATH_MAX, "%s", ov->dialog_path);
             if (ov->cpc) {
                 Disk *d = &ov->cpc->drive[drv];

--- a/tests/test_disk.c
+++ b/tests/test_disk.c
@@ -6,6 +6,42 @@
 #include <string.h>
 #include <unistd.h>
 
+static void test_new_disk_extension(void) {
+    char plain[64] = "blank";
+    char lower[64] = "blank.dsk";
+    char upper[64] = "blank.DSK";
+    char other[64] = "blank.img";
+    char dotted_dir[64] = "/tmp/archive.v1/blank";
+    char exact[9] = "disk";
+    char too_small[8] = "disk";
+    char empty[8] = "";
+
+    assert(disk_ensure_dsk_extension(plain, sizeof(plain)));
+    assert(strcmp(plain, "blank.dsk") == 0);
+
+    assert(disk_ensure_dsk_extension(lower, sizeof(lower)));
+    assert(strcmp(lower, "blank.dsk") == 0);
+
+    assert(disk_ensure_dsk_extension(upper, sizeof(upper)));
+    assert(strcmp(upper, "blank.DSK") == 0);
+
+    assert(disk_ensure_dsk_extension(other, sizeof(other)));
+    assert(strcmp(other, "blank.img.dsk") == 0);
+
+    assert(disk_ensure_dsk_extension(dotted_dir, sizeof(dotted_dir)));
+    assert(strcmp(dotted_dir, "/tmp/archive.v1/blank.dsk") == 0);
+
+    assert(disk_ensure_dsk_extension(exact, sizeof(exact)));
+    assert(strcmp(exact, "disk.dsk") == 0);
+
+    assert(!disk_ensure_dsk_extension(too_small, sizeof(too_small)));
+    assert(strcmp(too_small, "disk") == 0);
+
+    assert(!disk_ensure_dsk_extension(empty, sizeof(empty)));
+    assert(empty[0] == '\0');
+    assert(!disk_ensure_dsk_extension(NULL, 0));
+}
+
 static void test_sector_write_persists_after_reload(void) {
     const char *path = "/tmp/1984-test-disk-writeback.dsk";
     uint8_t pattern[512];
@@ -87,6 +123,7 @@ static void test_format_track_persists_after_reload(void) {
 }
 
 int main(void) {
+    test_new_disk_extension();
     test_sector_write_persists_after_reload();
     test_format_track_persists_after_reload();
     return 0;


### PR DESCRIPTION
## Summary
- append .dsk automatically when creating a blank disk
- make the F10 footer hint describe host card browsing
- hide the F10 hint when host card mounting is unavailable
- add focused filename-extension tests

## Validation
- autoreconf -iv
- ./configure
- make -j4
- make -C tests check
- headless boot smoke test
- make distcheck
- GitHub Linux, Windows, and Flatpak build workflow

Refs #234