### PR TITLE
Fix macOS Apple Silicon source builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,12 +97,20 @@ jobs:
           path: dist/
 
   macos:
-    name: macOS (Apple Silicon)
-    runs-on: macos-latest
+    name: macOS (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            arch: arm64
+          - runner: macos-15-intel
+            arch: x86_64
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       - name: Install build deps
-        run: brew install autoconf automake pkg-config sdl3 cairo
+        run: brew install autoconf automake pkg-config sdl3 cairo dylibbundler
       - name: Configure
         run: |
           autoreconf -iv
@@ -111,6 +119,20 @@ jobs:
         run: make -j$(sysctl -n hw.logicalcpu)
       - name: Test
         run: make -C tests check
+      - name: Package app bundle
+        run: |
+          version="$(sed -n 's/^PACKAGE_VERSION = //p' Makefile)"
+          sh packaging/macos/package.sh ./1984 dist/1984.app "$version"
+          SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy \
+            dist/1984.app/Contents/MacOS/1984 \
+            --config=/dev/null --exit-after=100
+          ditto -c -k --sequesterRsrc --keepParent \
+            dist/1984.app "dist/1984-macos-${{ matrix.arch }}.zip"
+      - name: Upload app bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: 1984-macos-${{ matrix.arch }}
+          path: dist/1984-macos-${{ matrix.arch }}.zip
 
   flatpak:
     name: Flatpak (x86_64)
@@ -168,6 +190,12 @@ jobs:
 
           # Windows: zip the full bundle (exe + DLLs + roms)
           (cd artifacts/1984-windows-x86_64 && zip -r "../../assets/1984-${tag}-windows-x86_64.zip" .)
+
+          # macOS: self-contained app bundles for Apple Silicon and Intel.
+          cp artifacts/1984-macos-arm64/1984-macos-arm64.zip \
+             "assets/1984-${tag}-macos-arm64.zip"
+          cp artifacts/1984-macos-x86_64/1984-macos-x86_64.zip \
+             "assets/1984-${tag}-macos-x86_64.zip"
 
           # Flatpak: single-file bundle, installable with `flatpak install`
           cp artifacts/1984-flatpak-x86_64/1984.flatpak "assets/1984-${tag}-x86_64.flatpak"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,22 @@ jobs:
           name: 1984-windows-x86_64
           path: dist/
 
+  macos:
+    name: macOS (Apple Silicon)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build deps
+        run: brew install autoconf automake pkg-config sdl3 cairo
+      - name: Configure
+        run: |
+          autoreconf -iv
+          ./configure
+      - name: Build
+        run: make -j$(sysctl -n hw.logicalcpu)
+      - name: Test
+        run: make -C tests check
+
   flatpak:
     name: Flatpak (x86_64)
     # Slow (~15 min); skip on PRs (the manifest builds branch:main, so a PR
@@ -126,7 +142,7 @@ jobs:
 
   release:
     name: Publish GitHub Release
-    needs: [linux, windows, flatpak]
+    needs: [linux, windows, macos, flatpak]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -197,11 +197,14 @@ Cairo is optional (`./configure --without-cairo` disables PDF capture), and
 `ffmpeg` is optional for WebM recording. The required CPC firmware, M4ROM, and
 Amstrad Diagnostics ROMs are bundled in `roms/`.
 
-Tagged releases publish a Linux x86_64 binary, Fedora RPM, Windows x86_64 zip,
-and Flatpak bundle on the
+Tagged releases publish a Linux x86_64 binary, Fedora RPM, Windows x86_64 ZIP,
+macOS application bundles for Apple Silicon and Intel, and a Flatpak bundle on the
 [GitHub Releases page](https://github.com/salvogendut/1984/releases). Pushes to
-`main` also produce workflow artifacts. Linux and Windows are built in CI;
-source builds are maintained for macOS, FreeBSD, NetBSD, OpenBSD, and Haiku.
+`main` also produce workflow artifacts. Linux, Windows, and macOS are built in
+CI; source builds are maintained for FreeBSD, NetBSD, OpenBSD, and Haiku.
+The macOS bundles are currently ad-hoc signed rather than Developer ID
+notarized, so the first launch may require right-clicking the app and selecting
+**Open**.
 See [INSTALL.md](INSTALL.md) and [docs/FLATPAK.md](docs/FLATPAK.md).
 
 ## Keyboard shortcuts

--- a/packaging/macos/package.sh
+++ b/packaging/macos/package.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 3 ]; then
+    echo "usage: $0 BINARY APP_DIR VERSION" >&2
+    exit 2
+fi
+
+binary=$1
+app=$2
+version=$3
+root=$(CDPATH= cd "$(dirname "$0")/../.." && pwd)
+contents="$app/Contents"
+macos="$contents/MacOS"
+resources="$contents/Resources"
+frameworks="$contents/Frameworks"
+plist="$contents/Info.plist"
+iconset="$resources/1984.iconset"
+plistbuddy=/usr/libexec/PlistBuddy
+
+if [ -e "$app" ]; then
+    echo "macOS bundle output already exists: $app" >&2
+    exit 1
+fi
+
+mkdir -p "$macos" "$resources" "$frameworks" "$iconset"
+install -m 0755 "$binary" "$macos/1984"
+cp -R "$root/roms" "$resources/roms"
+cp "$root/LICENSE" "$resources/LICENSE.txt"
+
+cp "$root/icons/16x16/apps/io.github.salvogendut.Emulator1984.png" \
+    "$iconset/icon_16x16.png"
+cp "$root/icons/32x32/apps/io.github.salvogendut.Emulator1984.png" \
+    "$iconset/icon_16x16@2x.png"
+cp "$root/icons/32x32/apps/io.github.salvogendut.Emulator1984.png" \
+    "$iconset/icon_32x32.png"
+cp "$root/icons/64x64/apps/io.github.salvogendut.Emulator1984.png" \
+    "$iconset/icon_32x32@2x.png"
+cp "$root/icons/128x128/apps/io.github.salvogendut.Emulator1984.png" \
+    "$iconset/icon_128x128.png"
+cp "$root/icons/256x256/apps/io.github.salvogendut.Emulator1984.png" \
+    "$iconset/icon_128x128@2x.png"
+cp "$root/icons/256x256/apps/io.github.salvogendut.Emulator1984.png" \
+    "$iconset/icon_256x256.png"
+cp "$root/icons/512x512/apps/io.github.salvogendut.Emulator1984.png" \
+    "$iconset/icon_256x256@2x.png"
+cp "$root/icons/512x512/apps/io.github.salvogendut.Emulator1984.png" \
+    "$iconset/icon_512x512.png"
+sips -z 1024 1024 \
+    "$root/icons/512x512/apps/io.github.salvogendut.Emulator1984.png" \
+    --out "$iconset/icon_512x512@2x.png" >/dev/null
+iconutil -c icns "$iconset" -o "$resources/1984.icns"
+rm -rf "$iconset"
+
+plutil -create xml1 "$plist"
+"$plistbuddy" -c "Add :CFBundleDevelopmentRegion string en" "$plist"
+"$plistbuddy" -c "Add :CFBundleDisplayName string 1984" "$plist"
+"$plistbuddy" -c "Add :CFBundleExecutable string 1984" "$plist"
+"$plistbuddy" -c "Add :CFBundleIconFile string 1984.icns" "$plist"
+"$plistbuddy" -c "Add :CFBundleIdentifier string io.github.salvogendut.Emulator1984" "$plist"
+"$plistbuddy" -c "Add :CFBundleInfoDictionaryVersion string 6.0" "$plist"
+"$plistbuddy" -c "Add :CFBundleName string 1984" "$plist"
+"$plistbuddy" -c "Add :CFBundlePackageType string APPL" "$plist"
+"$plistbuddy" -c "Add :CFBundleShortVersionString string $version" "$plist"
+"$plistbuddy" -c "Add :CFBundleVersion string $version" "$plist"
+"$plistbuddy" -c "Add :LSApplicationCategoryType string public.app-category.entertainment" "$plist"
+"$plistbuddy" -c "Add :LSMinimumSystemVersion string 15.0" "$plist"
+"$plistbuddy" -c "Add :NSHighResolutionCapable bool true" "$plist"
+"$plistbuddy" -c \
+    "Add :NSMicrophoneUsageDescription string 1984 uses audio input for the Real Cassette System Audio source." \
+    "$plist"
+
+brew_prefix=$(brew --prefix)
+dylibbundler -od -b \
+    -x "$macos/1984" \
+    -d "$frameworks" \
+    -p "@executable_path/../Frameworks/" \
+    -s "$brew_prefix/lib" \
+    -s "$(brew --prefix sdl3)/lib" \
+    -s "$(brew --prefix cairo)/lib"
+
+if find "$macos" "$frameworks" -type f -print0 |
+        xargs -0 otool -L |
+        grep -F "$brew_prefix/"; then
+    echo "macOS bundle still contains Homebrew library references" >&2
+    exit 1
+fi
+
+codesign --force --deep --sign - "$app"
+codesign --verify --deep --strict --verbose=2 "$app"

--- a/src/config.c
+++ b/src/config.c
@@ -1,5 +1,6 @@
 #include "config.h"
 #include "m4.h"
+#include <SDL3/SDL_filesystem.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -106,12 +107,13 @@ int config_websvc_dir(char *out, size_t sz) {
  * Priority:
  *   1. ~/.config/1984/roms/<file>      — user override
  *   2. $(pkgdatadir)/roms/<file>       — system install (from autotools)
- *   3. ./roms/<file>                   — dev tree / cwd fallback
+ *   3. <application base>/roms/<file>  — app bundle / executable directory
+ *   4. ./roms/<file>                   — dev tree / cwd fallback
  * The first path that exists is returned; otherwise the user-config path
  * (so a "file not found" error names the location the user is expected
  * to populate). */
 static void rom_cfg_path(const char *file, char *out, size_t size) {
-    char user[512], system_[512];
+    char user[512], system_[512], app_[512];
     char cdir[CONFIG_PATH_MAX];
 
     user[0] = '\0';
@@ -131,6 +133,14 @@ static void rom_cfg_path(const char *file, char *out, size_t size) {
 #else
     (void)system_;
 #endif
+    const char *base = SDL_GetBasePath();
+    if (base && base[0]) {
+        snprintf(app_, sizeof(app_), "%sroms/%s", base, file);
+        if (access(app_, R_OK) == 0) {
+            snprintf(out, size, "%s", app_);
+            return;
+        }
+    }
     if (access("roms", R_OK) == 0) {
         char dev_[512];
         snprintf(dev_, sizeof(dev_), "roms/%s", file);

--- a/src/kbd_pty.c
+++ b/src/kbd_pty.c
@@ -6,6 +6,11 @@
  * #129 investigation harness so external scripts can drive the
  * machine end-to-end without xdotool/Xvfb. */
 
+/* _XOPEN_SOURCE hides Darwin's BSD interfaces unless this is requested. */
+#if defined(__APPLE__)
+#define _DARWIN_C_SOURCE 1
+#endif
+
 #define _XOPEN_SOURCE 600
 /* See usifac.c / issue #203: the BSDs hide the Bxxxx baud constants behind
  * __BSD_VISIBLE, which _XOPEN_SOURCE turns off. */

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -1,4 +1,8 @@
 #ifndef _WIN32
+/* _XOPEN_SOURCE hides Darwin's BSD interfaces unless this is requested. */
+#if defined(__APPLE__)
+#define _DARWIN_C_SOURCE 1
+#endif
 #define _XOPEN_SOURCE 600   /* posix_openpt, grantpt, unlockpt, ptsname */
 /* See usifac.c / issue #203: the BSDs hide the Bxxxx baud constants behind
  * __BSD_VISIBLE, which _XOPEN_SOURCE turns off. */

--- a/src/pilot.c
+++ b/src/pilot.c
@@ -4,6 +4,11 @@
 #define _NETBSD_SOURCE 1
 #endif
 
+/* _XOPEN_SOURCE hides Darwin's BSD interfaces unless this is requested. */
+#if defined(__APPLE__)
+#define _DARWIN_C_SOURCE 1
+#endif
+
 #define _XOPEN_SOURCE 600   /* posix_openpt, grantpt, unlockpt, ptsname */
 #define _DEFAULT_SOURCE     /* cfmakeraw */
 /* See usifac.c / issue #203: the BSDs hide cfmakeraw behind __BSD_VISIBLE,

--- a/src/usifac.c
+++ b/src/usifac.c
@@ -4,6 +4,11 @@
 #define _NETBSD_SOURCE 1
 #endif
 
+/* _XOPEN_SOURCE hides Darwin's BSD interfaces unless this is requested. */
+#if defined(__APPLE__)
+#define _DARWIN_C_SOURCE 1
+#endif
+
 #define _XOPEN_SOURCE 600   /* posix_openpt, grantpt, unlockpt, ptsname */
 #define _DEFAULT_SOURCE     /* cfmakeraw */
 /* On the BSDs, defining _XOPEN_SOURCE/_POSIX_C_SOURCE turns __BSD_VISIBLE


### PR DESCRIPTION
## Root cause
`_XOPEN_SOURCE=600` enables strict POSIX visibility on Darwin. Unlike glibc, macOS does not interpret `_DEFAULT_SOURCE`, so Apple hides `cfmakeraw`, `B115200`, and `INADDR_LOOPBACK` unless `_DARWIN_C_SOURCE` is defined. The build therefore stopped in `usifac.c`, with the same latent failure in the other PTY translation units.

## Changes
- request Darwin BSD interfaces before system headers in all four PTY translation units
- build and test on GitHub-hosted Apple Silicon and Intel macOS runners
- package a self-contained `1984.app` with ROMs, icon, license, SDL, Cairo, and transitive Homebrew libraries
- use executable-relative resource lookup so bundled ROMs are found regardless of the launch directory
- ad-hoc sign and verify each app bundle
- publish `1984-<tag>-macos-arm64.zip` and `1984-<tag>-macos-x86_64.zip` for future tags
- require both macOS checks to pass before a tagged release is published

## Verification
- distrobox build and full test suite
- executable-relative ROM lookup smoke test from `/tmp`
- packaged-app headless smoke tests on both macOS architectures
- bundle dependency audit confirms no Homebrew paths remain
- code-sign verification on both bundles
- downloaded both Actions artifacts and passed `unzip -t`
- `git diff --check`

## Distribution note
The bundles are ad-hoc signed because the project does not currently provide Apple Developer ID credentials. They are usable through Finder's **Open** action, but warning-free Gatekeeper distribution will require Developer ID signing and notarization.

Fixes #238