### PR TITLE
Fix CPC punctuation key order

### DIFF
--- a/src/kbd.c
+++ b/src/kbd.c
@@ -71,8 +71,8 @@ static const KeyMap keymap[] = {
     { SDL_SCANCODE_MINUS,     3, 1 },
     { SDL_SCANCODE_GRAVE,     3, 2 }, /* @ on CPC */
     { SDL_SCANCODE_P,         3, 3 },
-    { SDL_SCANCODE_SEMICOLON, 3, 4 },
-    { SDL_SCANCODE_APOSTROPHE,3, 5 }, /* : on CPC */
+    { SDL_SCANCODE_APOSTROPHE, 3, 4 }, /* ; on CPC */
+    { SDL_SCANCODE_SEMICOLON, 3, 5 }, /* : on CPC */
     { SDL_SCANCODE_SLASH,     3, 6 },
     { SDL_SCANCODE_PERIOD,    3, 7 },
     /* Row 4: 0 9 O I L K M , */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,7 +5,7 @@ CPPFLAGS ?=
 SDL3_CFLAGS ?= $(shell pkg-config --cflags sdl3)
 SDL3_LIBS ?= $(shell pkg-config --libs sdl3)
 
-TESTS = test-gate-array test-crtc test-z80 test-psg test-mem test-disk test-gifcap test-tape-signal test-real-tape
+TESTS = test-gate-array test-crtc test-z80 test-psg test-mem test-disk test-gifcap test-tape-signal test-real-tape test-kbd
 
 .PHONY: all check clean
 
@@ -47,6 +47,10 @@ test-real-tape: test_real_tape.c ../src/real_tape.c ../src/real_tape.h ../src/ta
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(SDL3_CFLAGS) -std=c11 -Wall -Wextra -I../src \
 		test_real_tape.c ../src/real_tape.c ../src/tape.c $(SDL3_LIBS) -o $@
 
+test-kbd: test_kbd.c ../src/kbd.c ../src/kbd.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(SDL3_CFLAGS) -std=c11 -Wall -Wextra -I../src \
+		test_kbd.c ../src/kbd.c -o $@
+
 check: $(TESTS)
 	./test-gate-array
 	./test-crtc
@@ -57,6 +61,7 @@ check: $(TESTS)
 	./test-gifcap
 	./test-tape-signal
 	./test-real-tape
+	./test-kbd
 
 clean:
 	rm -f $(TESTS)

--- a/tests/test_kbd.c
+++ b/tests/test_kbd.c
@@ -1,0 +1,30 @@
+#include "../src/kbd.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+static void test_punctuation_keys(void)
+{
+    Keyboard k;
+
+    kbd_init(&k);
+
+    /* The first physical key after L is colon on a UK CPC keyboard. */
+    assert(kbd_sdl_key(&k, SDL_SCANCODE_SEMICOLON, true));
+    assert(kbd_read_row(&k, 3) == 0xDF);
+    assert(kbd_sdl_key(&k, SDL_SCANCODE_SEMICOLON, false));
+    assert(kbd_read_row(&k, 3) == 0xFF);
+
+    /* The second physical key after L is semicolon on a UK CPC keyboard. */
+    assert(kbd_sdl_key(&k, SDL_SCANCODE_APOSTROPHE, true));
+    assert(kbd_read_row(&k, 3) == 0xEF);
+    assert(kbd_sdl_key(&k, SDL_SCANCODE_APOSTROPHE, false));
+    assert(kbd_read_row(&k, 3) == 0xFF);
+}
+
+int main(void)
+{
+    test_punctuation_keys();
+    puts("kbd tests passed");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- map the first physical key after `L` to the CPC colon matrix position
- map the second physical key after `L` to the CPC semicolon matrix position
- add regression coverage for pressing and releasing both SDL scancodes

This keeps the physical-scancode approach and lets the UK and French ROMs apply their own character layouts correctly.

## Verification
- full unit test suite
- 100-frame headless startup smoke test
- manually confirmed by @Yserra with both UK QWERTY and French AZERTY ROMs

Fixes #241