### PR TITLE
Fix CPC Plus sprite clipping in the counter space

### DIFF
--- a/docs/CPC-Plus.md
+++ b/docs/CPC-Plus.md
@@ -25,7 +25,7 @@ The initial ASIC implementation includes:
 - the documented lock/unlock sequence and RMR2 mapping;
 - the 32-entry 12-bit palette;
 - sixteen 16x16 hardware sprites with magnification, priority, coordinate
-  wrapping, raster-time register updates, and outer monitor-window clipping;
+  wrapping, raster-time register updates, and clipping to the scanned screen;
 - horizontal and vertical soft scrolling;
 - CRTC-derived programmable raster interrupts and screen splits;
 - ASIC interrupt-mode-2 vectors and source acknowledgement;
@@ -38,9 +38,10 @@ The display records per-frame monitor-beam coverage and fills untouched output
 pixels with the current border colour before presentation. This avoids stale
 sprite or raster content outside the area scanned by a short Plus frame.
 Hardware sprites remain independent of CRTC display enable, as on the ASIC, so
-they can appear in the inner border. Their outer limits follow Caprice32's Plus
-monitor window, including the 16-pixel horizontal shift selected by SSCR's
-extend-border bit.
+they can appear in the inner border. Their horizontal range is clipped to the
+640-column screen in CRTC-counter space; vertically there is no clip beyond the
+scanlines the monitor beam actually draws, so overscan modes keep sprites at
+the bottom of the playfield.
 
 Caprice32 is the general behavioral reference, with Sugarbox used where its
 Plus behavior is more complete. The v4 system cartridge, 1942, Robocop 2,

--- a/src/asic.c
+++ b/src/asic.c
@@ -373,22 +373,16 @@ AsicVideoPosition asic_video_position(const Asic *asic, u16 crtc_ma,
 }
 
 void asic_draw_sprites_char(const Asic *asic, u16 hcc, u16 vcc, u16 vlc,
-                            u8 vertical_sync_pos, u32 *pixels) {
+                            u32 *pixels) {
     int sprite_row[ASIC_SPRITE_COUNT];
     unsigned beam_y = (((unsigned)vcc & 0x3F) << 3) | (vlc & 7);
-    int border_width = 64 + (asic->extend_border ? 16 : 0);
-    int border_height = 40 + 8 * (30 - (int)vertical_sync_pos);
 
-    /* Sprite coordinates ignore CRTC display enable, but the visible Plus
-     * monitor window still clips the outer coordinate range. These limits
-     * match Caprice32, including SSCR's 16-pixel horizontal displacement. */
-    if ((int)beam_y <= border_height ||
-            (int)beam_y >= border_height + 200)
-        return;
-
-    /* Sprite coordinates are compared directly with CRTC counters. This is
-     * deliberately done while the beam is drawing: Plus software can change
-     * sprite data and attributes several times within one frame. */
+    /* Sprite coordinates are compared directly with CRTC counters while the
+     * beam is drawing: Plus software can change sprite data and attributes
+     * several times within one frame. There is no vertical clip here — the
+     * caller only invokes this for scanlines the monitor beam actually draws,
+     * and CRTC-counter based sprites may legitimately sit in the bottom
+     * border on overscan screens (e.g. GNG's 248-line mode). */
     for (int id = 0; id < ASIC_SPRITE_COUNT; id++) {
         int mx = asic->sprite_mag_x[id];
         int my = asic->sprite_mag_y[id];
@@ -399,11 +393,13 @@ void asic_draw_sprites_char(const Asic *asic, u16 hcc, u16 vcc, u16 vlc,
 
     /* Sprite X coordinates use the 640-pixel (mode 2) clock. A CRTC
      * character therefore spans 16 coordinates in this output buffer.
-     * Sprite 0 has highest priority, so the first opaque sprite wins. */
+     * Caprice32 clips sprites to this same 640-column window after
+     * translating its frame border; do the equivalent in the counter space
+     * sprites draw in. Sprite 0 has highest priority, so the first opaque
+     * sprite wins. */
     unsigned beam_x = ((unsigned)hcc * 16) & 0x3FF;
     for (int x = 0; x < 16; x++, beam_x = (beam_x + 1) & 0x3FF) {
-        if ((int)beam_x <= border_width ||
-                (int)beam_x >= border_width + 640)
+        if ((int)beam_x <= 0 || (int)beam_x >= 640)
             continue;
         for (int id = 0; id < ASIC_SPRITE_COUNT; id++) {
             int mx = asic->sprite_mag_x[id];

--- a/src/asic.h
+++ b/src/asic.h
@@ -72,4 +72,4 @@ AsicVideoPosition asic_video_position(const Asic *asic, u16 crtc_ma,
                                       u8 crtc_raster, u8 max_raster,
                                       u8 chars_per_row);
 void asic_draw_sprites_char(const Asic *asic, u16 hcc, u16 vcc, u16 vlc,
-                            u8 vertical_sync_pos, u32 *pixels);
+                            u32 *pixels);

--- a/src/cpc.c
+++ b/src/cpc.c
@@ -1469,7 +1469,7 @@ static void cpc_advance_bus(CPC *cpc, int cycles) {
             if (cpc_model_is_plus(cpc->model))
                 asic_draw_sprites_char(&cpc->asic, cpc->crtc_pre_hcc,
                                        cpc->crtc_pre_vcc, cpc->crtc_pre_ra,
-                                       cpc->crtc.reg[7], row + px);
+                                       row + px);
             memset(cpc->display.touched + py * CPC_SCREEN_W + px, 1, 16);
         }
 

--- a/tests/test_asic.c
+++ b/tests/test_asic.c
@@ -301,7 +301,6 @@ static void test_dma_pause_cadence(void) {
 static void test_sprite_beam_composition(void) {
     Asic asic = {0};
     u32 pixels[16];
-    const u8 vertical_sync_pos = 30;
 
     for (int i = 0; i < 16; i++)
         pixels[i] = 0x010203;
@@ -314,7 +313,7 @@ static void test_sprite_beam_composition(void) {
     asic.sprite[0][0][0] = 1;
     asic.sprite[0][1][0] = 2;
 
-    asic_draw_sprites_char(&asic, 5, 6, 0, vertical_sync_pos, pixels);
+    asic_draw_sprites_char(&asic, 5, 6, 0, pixels);
     assert(pixels[0] == 0x112233);
     assert(pixels[1] == 0x445566);
     assert(pixels[2] == 0x010203);
@@ -326,7 +325,7 @@ static void test_sprite_beam_composition(void) {
     pixels[0] = pixels[1] = 0;
     asic.sprite_x[1] = 80;
     asic.sprite_y[1] = 48;
-    asic_draw_sprites_char(&asic, 5, 6, 0, vertical_sync_pos, pixels);
+    asic_draw_sprites_char(&asic, 5, 6, 0, pixels);
     assert(pixels[0] == 0x112233);
     assert(pixels[1] == 0x445566);
 
@@ -334,13 +333,13 @@ static void test_sprite_beam_composition(void) {
     asic.sprite_x[0] = 0x3FF;
     asic.sprite[0][1][0] = 1;
     pixels[0] = pixels[1] = 0;
-    asic_draw_sprites_char(&asic, 0, 6, 0, vertical_sync_pos, pixels);
+    asic_draw_sprites_char(&asic, 0, 6, 0, pixels);
     assert(pixels[0] == 0);
 
     /* Each CRTC character advances 16 sprite-coordinate pixels. */
     asic.sprite_x[0] = 96;
     pixels[0] = 0;
-    asic_draw_sprites_char(&asic, 6, 6, 0, vertical_sync_pos, pixels);
+    asic_draw_sprites_char(&asic, 6, 6, 0, pixels);
     assert(pixels[0] == 0x112233);
 
     /* Sprite Y comparison is nine-bit: (VCC[5:0] << 3) | VLC[2:0]. */
@@ -348,12 +347,14 @@ static void test_sprite_beam_composition(void) {
     asic.sprite_y[0] = 51;
     asic.sprite[0][0][0] = 1;
     pixels[0] = pixels[1] = 0;
-    asic_draw_sprites_char(&asic, 5, 6, 3, vertical_sync_pos, pixels);
+    asic_draw_sprites_char(&asic, 5, 6, 3, pixels);
     assert(pixels[0] == 0x112233);
 
+    /* There is no vertical clip: rows below the 200-line window draw as long
+     * as the beam reaches them (overscan modes such as GNG's 248-line one). */
     asic.sprite_y[0] = 259;
     pixels[0] = 0;
-    asic_draw_sprites_char(&asic, 5, 32, 3, 3, pixels);
+    asic_draw_sprites_char(&asic, 5, 32, 3, pixels);
     assert(pixels[0] == 0x112233);
 }
 
@@ -366,43 +367,43 @@ static void test_sprite_monitor_clipping(void) {
     asic.sprite_mag_y[0] = 1;
     asic.sprite[0][0][0] = 1;
 
-    /* With R7=30 the normal visible window is X=65..703, Y=41..239. */
+    /* Sprite coordinates are compared with the CRTC counters, so the
+     * visible window is the standard 200-line screen in counter space:
+     * X=1..639, Y=1..199. A sprite at X=64 lands fully inside. */
     asic.sprite_x[0] = 64;
     asic.sprite_y[0] = 48;
-    asic_draw_sprites_char(&asic, 4, 6, 0, 30, pixels);
-    assert(pixels[0] == 0);
+    asic_draw_sprites_char(&asic, 4, 6, 0, pixels);
+    assert(pixels[0] == 0x112233);
 
-    asic.sprite_x[0] = 65;
-    asic_draw_sprites_char(&asic, 4, 6, 0, 30, pixels);
+    /* The single beam_x=0 subpixel of column zero is the only clipped
+     * pixel at the left edge; the sprite still enters from X=1. */
+    asic.sprite_x[0] = 1;
+    memset(pixels, 0, sizeof(pixels));
+    asic_draw_sprites_char(&asic, 0, 6, 0, pixels);
     assert(pixels[0] == 0);
     assert(pixels[1] == 0x112233);
 
+    /* Beyond the 640-column window is clipped. */
+    asic.sprite_x[0] = 640;
     memset(pixels, 0, sizeof(pixels));
-    asic.sprite_x[0] = 704;
-    asic_draw_sprites_char(&asic, 44, 6, 0, 30, pixels);
+    asic_draw_sprites_char(&asic, 40, 6, 0, pixels);
     assert(pixels[0] == 0);
 
-    /* SSCR extend-border shifts both horizontal clip edges by 16 pixels. */
-    asic.extend_border = true;
-    asic.sprite_x[0] = 65;
-    asic_draw_sprites_char(&asic, 4, 6, 0, 30, pixels);
-    assert(pixels[1] == 0);
-
-    asic.extend_border = false;
-    asic.sprite_x[0] = 80;
-    asic.sprite_y[0] = 40;
+    /* Vertical extent is not clipped: sprites may draw in the lower border. */
+    asic.sprite_x[0] = 64;
+    asic.sprite_y[0] = 0;
     memset(pixels, 0, sizeof(pixels));
-    asic_draw_sprites_char(&asic, 5, 5, 0, 30, pixels);
-    assert(pixels[0] == 0);
-
-    asic.sprite_y[0] = 41;
-    asic_draw_sprites_char(&asic, 5, 5, 1, 30, pixels);
+    asic_draw_sprites_char(&asic, 4, 0, 0, pixels);
     assert(pixels[0] == 0x112233);
 
-    asic.sprite_y[0] = 240;
-    pixels[0] = 0;
-    asic_draw_sprites_char(&asic, 5, 30, 0, 30, pixels);
-    assert(pixels[0] == 0);
+    asic.sprite_y[0] = 199;
+    asic_draw_sprites_char(&asic, 4, 24, 7, pixels);
+    assert(pixels[0] == 0x112233);
+
+    asic.sprite_y[0] = 200;
+    memset(pixels, 0, sizeof(pixels));
+    asic_draw_sprites_char(&asic, 4, 25, 0, pixels);
+    assert(pixels[0] == 0x112233);
 }
 
 int main(void) {


### PR DESCRIPTION
## Summary

Fixes the Ghosts 'n Goblins side-border artifacts on CPC 6128 Plus (issue
#244): side borders were "permeable", with sprites appearing past the edge of
the visible playfield, and sprites entering from the left were cut off four
characters inside.

## Root cause

`asic_draw_sprites_char()` applied the sprite clip window
`[border_width, border_width+640] × [border_height, border_height+200]` to the
**raw CRTC counters** (`beam_x`/`beam_y`) that sprites actually compare against,
but those bounds were taken from **Caprice32's frame-pixel** clip, which shifts
sprite coordinates by `+borderWidth`/`+borderHeight` first. The window was
therefore offset by 64 px right and `borderHeight` down in counter space:

- sprites with X 0..63 (the playfield's first four columns) were wrongly hidden;
- sprites at X 640..704 were drawn in the far side border past GNG's R1=34
  playfield width.

## Change

- Clip horizontally to the 640-column screen **in counter space** (`X ∈ [0,640)`),
  matching Caprice32's effective sprite window.
- Drop the vertical clip entirely. The caller only invokes the sprite pass for
  scanlines the monitor beam actually draws, so the visible-screen bound is
  already enforced there. The previous vertical window clipped the bottom of
  tall sprites on overscan displays (GNG's 248-line mode); removing it
  restores them.
- `asic_draw_sprites_char()` no longer takes `vertical_sync_pos`; updated the
  call site, the ASIC unit tests for the new window semantics, and the CPC
  Plus docs.

## Verification

- All `tests/` binaries pass.
- System cartridge and Sonic GX boot cleanly.
- GNG: far-right border sprite pixels reduced, left-edge sprites restored, and
  bottom-half sprite content (zombies/knight) equal-or-greater than baseline
  across gameplay frames.

## Known remaining

Some inner-border sprite visibility around the game area remains; the ASIC
coordinates are CRTC-counter based and the clip deliberately does not follow
CRTC R1/R6 display enable. Fine to leave as-is for now per the issue.
