### PR TITLE
Clip CPC Plus sprites to the CRTC display width

### DIFF
--- a/docs/CPC-Plus.md
+++ b/docs/CPC-Plus.md
@@ -38,10 +38,10 @@ The display records per-frame monitor-beam coverage and fills untouched output
 pixels with the current border colour before presentation. This avoids stale
 sprite or raster content outside the area scanned by a short Plus frame.
 Hardware sprites remain independent of CRTC display enable, as on the ASIC, so
-they can appear in the inner border. Their horizontal range is clipped to the
-640-column screen in CRTC-counter space; vertically there is no clip beyond the
-scanlines the monitor beam actually draws, so overscan modes keep sprites at
-the bottom of the playfield.
+they can appear in the inner border vertically. Horizontally they are clipped
+to the CRTC display width (R1) in counter space, matching MAME: sprites enter
+and leave exactly at the playfield edges and never bleed into the side
+borders.
 
 Caprice32 is the general behavioral reference, with Sugarbox used where its
 Plus behavior is more complete. The v4 system cartridge, 1942, Robocop 2,

--- a/src/asic.c
+++ b/src/asic.c
@@ -373,7 +373,7 @@ AsicVideoPosition asic_video_position(const Asic *asic, u16 crtc_ma,
 }
 
 void asic_draw_sprites_char(const Asic *asic, u16 hcc, u16 vcc, u16 vlc,
-                            u32 *pixels) {
+                            u8 chars_per_row, u32 *pixels) {
     int sprite_row[ASIC_SPRITE_COUNT];
     unsigned beam_y = (((unsigned)vcc & 0x3F) << 3) | (vlc & 7);
 
@@ -391,15 +391,15 @@ void asic_draw_sprites_char(const Asic *asic, u16 hcc, u16 vcc, u16 vlc,
             ? (int)(rel_y / (unsigned)my) : -1;
     }
 
-    /* Sprite X coordinates use the 640-pixel (mode 2) clock. A CRTC
-     * character therefore spans 16 coordinates in this output buffer.
-     * Caprice32 clips sprites to this same 640-column window after
-     * translating its frame border; do the equivalent in the counter space
-     * sprites draw in. Sprite 0 has highest priority, so the first opaque
-     * sprite wins. */
+    /* Sprite X coordinates use the 640-pixel (mode 2) clock: a CRTC character
+     * spans 16 coordinates. The visible sprite window is the CRTC display
+     * width (R1) in counter space, matching MAME, which clips sprites to the
+     * display-enable area: sprites enter and leave exactly at the playfield
+     * edges and never bleed into the side borders. Sprite 0 has highest
+     * priority, so the first opaque sprite wins. */
     unsigned beam_x = ((unsigned)hcc * 16) & 0x3FF;
     for (int x = 0; x < 16; x++, beam_x = (beam_x + 1) & 0x3FF) {
-        if ((int)beam_x <= 0 || (int)beam_x >= 640)
+        if ((int)beam_x >= (int)chars_per_row * 16)
             continue;
         for (int id = 0; id < ASIC_SPRITE_COUNT; id++) {
             int mx = asic->sprite_mag_x[id];

--- a/src/asic.h
+++ b/src/asic.h
@@ -72,4 +72,4 @@ AsicVideoPosition asic_video_position(const Asic *asic, u16 crtc_ma,
                                       u8 crtc_raster, u8 max_raster,
                                       u8 chars_per_row);
 void asic_draw_sprites_char(const Asic *asic, u16 hcc, u16 vcc, u16 vlc,
-                            u32 *pixels);
+                            u8 chars_per_row, u32 *pixels);

--- a/src/cpc.c
+++ b/src/cpc.c
@@ -1469,7 +1469,7 @@ static void cpc_advance_bus(CPC *cpc, int cycles) {
             if (cpc_model_is_plus(cpc->model))
                 asic_draw_sprites_char(&cpc->asic, cpc->crtc_pre_hcc,
                                        cpc->crtc_pre_vcc, cpc->crtc_pre_ra,
-                                       row + px);
+                                       cpc->crtc.reg[1], row + px);
             memset(cpc->display.touched + py * CPC_SCREEN_W + px, 1, 16);
         }
 

--- a/tests/test_asic.c
+++ b/tests/test_asic.c
@@ -313,7 +313,7 @@ static void test_sprite_beam_composition(void) {
     asic.sprite[0][0][0] = 1;
     asic.sprite[0][1][0] = 2;
 
-    asic_draw_sprites_char(&asic, 5, 6, 0, pixels);
+    asic_draw_sprites_char(&asic, 5, 6, 0, 40, pixels);
     assert(pixels[0] == 0x112233);
     assert(pixels[1] == 0x445566);
     assert(pixels[2] == 0x010203);
@@ -325,21 +325,21 @@ static void test_sprite_beam_composition(void) {
     pixels[0] = pixels[1] = 0;
     asic.sprite_x[1] = 80;
     asic.sprite_y[1] = 48;
-    asic_draw_sprites_char(&asic, 5, 6, 0, pixels);
+    asic_draw_sprites_char(&asic, 5, 6, 0, 40, pixels);
     assert(pixels[0] == 0x112233);
     assert(pixels[1] == 0x445566);
 
-    /* Wrapped coordinates outside the visible Plus monitor are clipped. */
+    /* A wrapped negative X (0x3FF = -1) renders at the display left edge. */
     asic.sprite_x[0] = 0x3FF;
     asic.sprite[0][1][0] = 1;
     pixels[0] = pixels[1] = 0;
-    asic_draw_sprites_char(&asic, 0, 6, 0, pixels);
-    assert(pixels[0] == 0);
+    asic_draw_sprites_char(&asic, 0, 6, 0, 40, pixels);
+    assert(pixels[0] == 0x112233);
 
     /* Each CRTC character advances 16 sprite-coordinate pixels. */
     asic.sprite_x[0] = 96;
     pixels[0] = 0;
-    asic_draw_sprites_char(&asic, 6, 6, 0, pixels);
+    asic_draw_sprites_char(&asic, 6, 6, 0, 40, pixels);
     assert(pixels[0] == 0x112233);
 
     /* Sprite Y comparison is nine-bit: (VCC[5:0] << 3) | VLC[2:0]. */
@@ -347,14 +347,14 @@ static void test_sprite_beam_composition(void) {
     asic.sprite_y[0] = 51;
     asic.sprite[0][0][0] = 1;
     pixels[0] = pixels[1] = 0;
-    asic_draw_sprites_char(&asic, 5, 6, 3, pixels);
+    asic_draw_sprites_char(&asic, 5, 6, 3, 40, pixels);
     assert(pixels[0] == 0x112233);
 
     /* There is no vertical clip: rows below the 200-line window draw as long
      * as the beam reaches them (overscan modes such as GNG's 248-line one). */
     asic.sprite_y[0] = 259;
     pixels[0] = 0;
-    asic_draw_sprites_char(&asic, 5, 32, 3, pixels);
+    asic_draw_sprites_char(&asic, 5, 32, 3, 40, pixels);
     assert(pixels[0] == 0x112233);
 }
 
@@ -367,42 +367,58 @@ static void test_sprite_monitor_clipping(void) {
     asic.sprite_mag_y[0] = 1;
     asic.sprite[0][0][0] = 1;
 
-    /* Sprite coordinates are compared with the CRTC counters, so the
-     * visible window is the standard 200-line screen in counter space:
-     * X=1..639, Y=1..199. A sprite at X=64 lands fully inside. */
+    /* Sprite X is the CRTC counter; a sprite at X=64 fills char 4. */
     asic.sprite_x[0] = 64;
     asic.sprite_y[0] = 48;
-    asic_draw_sprites_char(&asic, 4, 6, 0, pixels);
+    asic_draw_sprites_char(&asic, 4, 6, 0, 40, pixels);
     assert(pixels[0] == 0x112233);
 
-    /* The single beam_x=0 subpixel of column zero is the only clipped
-     * pixel at the left edge; the sprite still enters from X=1. */
+    /* Column zero is fully drawn for a sprite at X=0 (no left clip). */
+    asic.sprite_x[0] = 0;
+    memset(pixels, 0, sizeof(pixels));
+    asic_draw_sprites_char(&asic, 0, 6, 0, 40, pixels);
+    assert(pixels[0] == 0x112233);
+
+    /* A sprite at X=1 leaves pixel 0 transparent; its first column is at
+     * beam_x 1, so it enters exactly at the display left edge. */
     asic.sprite_x[0] = 1;
     memset(pixels, 0, sizeof(pixels));
-    asic_draw_sprites_char(&asic, 0, 6, 0, pixels);
+    asic_draw_sprites_char(&asic, 0, 6, 0, 40, pixels);
     assert(pixels[0] == 0);
     assert(pixels[1] == 0x112233);
 
-    /* Beyond the 640-column window is clipped. */
+    /* The clip follows the CRTC display width (R1): with R1=34, the last
+     * drawable sprite column is X=543; X=544 (char 34) is clipped. */
+    asic.sprite_x[0] = 543;
+    memset(pixels, 0, sizeof(pixels));
+    asic_draw_sprites_char(&asic, 33, 6, 0, 34, pixels);
+    assert(pixels[15] == 0x112233);
+
+    asic.sprite_x[0] = 544;
+    memset(pixels, 0, sizeof(pixels));
+    asic_draw_sprites_char(&asic, 34, 6, 0, 34, pixels);
+    assert(pixels[0] == 0);
+
+    /* With a 40-char display, X=640 is clipped. */
     asic.sprite_x[0] = 640;
     memset(pixels, 0, sizeof(pixels));
-    asic_draw_sprites_char(&asic, 40, 6, 0, pixels);
+    asic_draw_sprites_char(&asic, 40, 6, 0, 40, pixels);
     assert(pixels[0] == 0);
 
     /* Vertical extent is not clipped: sprites may draw in the lower border. */
     asic.sprite_x[0] = 64;
     asic.sprite_y[0] = 0;
     memset(pixels, 0, sizeof(pixels));
-    asic_draw_sprites_char(&asic, 4, 0, 0, pixels);
+    asic_draw_sprites_char(&asic, 4, 0, 0, 40, pixels);
     assert(pixels[0] == 0x112233);
 
     asic.sprite_y[0] = 199;
-    asic_draw_sprites_char(&asic, 4, 24, 7, pixels);
+    asic_draw_sprites_char(&asic, 4, 24, 7, 40, pixels);
     assert(pixels[0] == 0x112233);
 
     asic.sprite_y[0] = 200;
     memset(pixels, 0, sizeof(pixels));
-    asic_draw_sprites_char(&asic, 4, 25, 0, pixels);
+    asic_draw_sprites_char(&asic, 4, 25, 0, 40, pixels);
     assert(pixels[0] == 0x112233);
 }
 


### PR DESCRIPTION
## Summary

Follow-up to issue #246 (and #244): the sprite clipping area now matches the
CRTC display width, so sprites enter and exit exactly at the playfield edges
instead of an asymmetric inset on the sides.

## Root cause

1984 (like Caprice32/konCePCja) clipped sprites to a fixed 40-character window
(`beam_x ∈ [0, 640)`). GNG runs a 34-character display (R1=34), and the visible
monitor window spans ~6 chars of left border + 34 display + ~7 chars of right
border. The fixed window therefore let sprites render past the playfield's
right edge into the border band while the display left border stayed empty —
so sprites appeared to enter/exit at an inset that did not match the visible
game area.

## Reference check

- **MAME** (`amstrad_m.cpp` `amstrad_plus_update_video_sprites`): clips
  sprites to the display-enable width (`h_end - h_start`); sprite X=0 is the
  display left edge.
- **Caprice32 / konCePCja**: fixed 40-char window (konCePCja is identical code).
- **xcpc-emulator**: no CPC Plus sprite support at all.

## Change

`asic_draw_sprites_char()` now takes the CRTC display width (`chars_per_row`,
R1) and clips `beam_x` to `[0, R1·16)` — matching MAME. The live `crtc.reg[1]`
is passed, so the clip tracks mid-frame splits. The left edge keeps wrapped /
negative coordinates so sprites enter at the display edge (MAME behavior); the
vertical axis is unchanged (no clip beyond the scanned beam).

Updated `src/asic.c`, `src/asic.h`, `src/cpc.c`, `tests/test_asic.c`, and the
CPC Plus docs.

## Verification

- All `tests/` binaries pass.
- GNG: right-border sprite bleed at a gameplay frame dropped 2225 → 339
  pixels (remaining is the game's own border graphics); playfield content
  unchanged.
- System cartridge and Sonic GX boot cleanly with full content.
- User confirmed the sprite enter/exit behavior now looks correct.
