### PR TITLE
Mask CPC Plus horizontal scroll edge

### DIFF
--- a/docs/CPC-Plus.md
+++ b/docs/CPC-Plus.md
@@ -26,7 +26,8 @@ The initial ASIC implementation includes:
 - the 32-entry 12-bit palette;
 - sixteen 16x16 hardware sprites with magnification, priority, coordinate
   wrapping, raster-time register updates, and clipping to the scanned screen;
-- horizontal and vertical soft scrolling;
+- horizontal and vertical soft scrolling, including SSCR bit 7's one-character
+  left-border mask for the invalid data exposed by horizontal delay;
 - CRTC-derived programmable raster interrupts and screen splits;
 - ASIC interrupt-mode-2 vectors and source acknowledgement;
 - three PSG DMA channels with pause/prescaler timing, repeat, loop, interrupt,

--- a/src/asic.c
+++ b/src/asic.c
@@ -372,6 +372,12 @@ AsicVideoPosition asic_video_position(const Asic *asic, u16 crtc_ma,
     return pos;
 }
 
+bool asic_scroll_border_active(const Asic *asic, u16 hcc) {
+    /* SSCR bit 7 masks the invalid data exposed by horizontal scrolling by
+     * extending the left border over the first CRTC character. */
+    return asic->extend_border && hcc == 0;
+}
+
 void asic_draw_sprites_char(const Asic *asic, u16 hcc, u16 vcc, u16 vlc,
                             u8 chars_per_row, u32 *pixels) {
     int sprite_row[ASIC_SPRITE_COUNT];

--- a/src/asic.h
+++ b/src/asic.h
@@ -71,5 +71,6 @@ u16 asic_video_ma(const Asic *asic, u16 crtc_ma);
 AsicVideoPosition asic_video_position(const Asic *asic, u16 crtc_ma,
                                       u8 crtc_raster, u8 max_raster,
                                       u8 chars_per_row);
+bool asic_scroll_border_active(const Asic *asic, u16 hcc);
 void asic_draw_sprites_char(const Asic *asic, u16 hcc, u16 vcc, u16 vlc,
                             u8 chars_per_row, u32 *pixels);

--- a/src/cpc.c
+++ b/src/cpc.c
@@ -1451,8 +1451,15 @@ static void cpc_advance_bus(CPC *cpc, int cycles) {
                 u16 col  = video_ma & 0x3FF;
                 u16 addr = (u16)((bank << 14) | ((video_ra & 7) << 11) | (col << 1));
                 if (cpc_model_is_plus(cpc->model)) {
-                    render_char_plus(row, px, &cpc->ga, &cpc->mem, addr,
-                                     cpc->asic.hscroll);
+                    if (asic_scroll_border_active(&cpc->asic,
+                                                  cpc->crtc_pre_hcc)) {
+                        u32 border = cpc->ga.resolved_ink[16];
+                        for (int x = 0; x < 16; x++)
+                            row[px + x] = border;
+                    } else {
+                        render_char_plus(row, px, &cpc->ga, &cpc->mem, addr,
+                                         cpc->asic.hscroll);
+                    }
                 } else {
                     u8 b0 = mem_read_video(&cpc->mem, addr);
                     u8 b1 = mem_read_video(&cpc->mem, (u16)(addr + 1));

--- a/tests/test_asic.c
+++ b/tests/test_asic.c
@@ -38,6 +38,16 @@ static void test_palette_and_sprite_registers(void) {
     asic_register_write(&asic, &ga, &mem, 0x6007, 0x06);
     assert(asic.sprite_mag_x[0] == 1);
     assert(asic.sprite_mag_y[0] == 2);
+
+    /* SSCR bit 7 extends the border over character zero to hide the bytes
+     * exposed before the row start by horizontal soft scrolling. */
+    asic_register_write(&asic, &ga, &mem, 0x6804, 0x8C);
+    assert(asic.hscroll == 12);
+    assert(asic.extend_border);
+    assert(asic_scroll_border_active(&asic, 0));
+    assert(!asic_scroll_border_active(&asic, 1));
+    asic_register_write(&asic, &ga, &mem, 0x6804, 0x0C);
+    assert(!asic_scroll_border_active(&asic, 0));
 }
 
 static void test_raster_split_and_dma(void) {


### PR DESCRIPTION
## Summary
- implement the SSCR bit 7 one-character left-border extension
- mask invalid pre-row video data exposed by horizontal soft scrolling
- document the Plus behavior and add focused ASIC coverage

## Diagnosis
GNG cycles SSCR through 0x84, 0x88, and 0x8c, selecting horizontal delays 4/8/12 with bit 7 enabled. 1984 retained the bit but still rendered CRTC character zero, exposing bytes before the row start as a thin strip at the left edge.

## Verification
- make -C tests check
- GNG automated gameplay and left-movement GIF replay
- Sonic gameplay regression
- Plus system cartridge boot

Fixes #248