### PR TITLE
Add DSK autostart file browser

### DIFF
--- a/1984.1
+++ b/1984.1
@@ -348,6 +348,11 @@ Floppy drives A and B, cassette tape, external tape toggle (CPC 6128), and
 the active CPR cartridge on Plus models.
 Enter on a floppy drive uses the platform dialog, Shift+Enter opens the
 built-in browser, and native-dialog errors fall back automatically.
+Press A on a mounted floppy to browse its AMSDOS/CP/M directory. Enter or
+Space marks a file with an asterisk; S saves the session choice, resets the
+CPC, and runs the file after boot. The mark survives machine resets but is
+cleared when the disk changes or the emulator exits, and is not stored in the
+configuration file.
 .TP
 .B Extensions
 M4 board, Albireo USB, SYMBiFACE II IDE / mouse, Cyboard RTC,

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ automatically when the platform picker is unavailable. `--sdl-fm` forces the
 built-in browser, which makes disk changes usable on systems without a GUI
 file manager.
 
+With a mounted floppy highlighted, press **A** to browse its AMSDOS/CP/M
+directory. Enter or Space places the autostart asterisk, and **S** saves the
+session choice and resets the CPC to run it. The choice survives F5 and other
+machine resets, but is cleared when that disk is replaced/ejected or when the
+1984 process exits; it is never written to `1984.conf`.
+
 CPC 664 and 6128 models have floppy hardware built in. On the 464, enabling
 DDI-1 adds the controller and AMSDOS ROM. CDT/TZX cassette images support the
 common standard, turbo, pure-tone, pulse, pure-data, and pause blocks; tape

--- a/src/disk.c
+++ b/src/disk.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 
 void disk_init(Disk *d) {
     memset(d, 0, sizeof(*d));
@@ -154,6 +155,154 @@ bool disk_ensure_dsk_extension(char *path, size_t capacity) {
 
     memcpy(path + len, suffix, sizeof(suffix));
     return true;
+}
+
+static const DiskSector *disk_sector_by_id(const Disk *d, int track, int side,
+                                            uint8_t id) {
+    if (!d || !d->inserted || track < 0 || track >= d->track_count ||
+        side < 0 || side >= d->sides)
+        return NULL;
+    const DiskTrack *tr = &d->track[track][side];
+    for (int i = 0; i < tr->sector_count; i++)
+        if (tr->sectors[i].R == id)
+            return &tr->sectors[i];
+    return NULL;
+}
+
+static bool disk_read_directory_sector(const Disk *d, int track, uint8_t id,
+                                       uint8_t *out) {
+    const DiskSector *sec = disk_sector_by_id(d, track, 0, id);
+    if (!sec || sec->size < 512)
+        return false;
+    const DiskTrack *tr = &d->track[track][0];
+    if (!tr->data || sec->offset < 0 || sec->offset + 512 > tr->data_size)
+        return false;
+    memcpy(out, tr->data + sec->offset, 512);
+    return true;
+}
+
+static bool disk_directory_geometry(const Disk *d, int *track,
+                                    uint8_t *first_sector) {
+    if (disk_sector_by_id(d, 0, 0, 0xC1)) {
+        *track = 0;             /* CPC DATA format */
+        *first_sector = 0xC1;
+        return true;
+    }
+    if (disk_sector_by_id(d, 0, 0, 0x41)) {
+        *track = 2;             /* CPC SYSTEM format: two reserved tracks */
+        *first_sector = 0x41;
+        return true;
+    }
+    if (disk_sector_by_id(d, 0, 0, 0x01)) {
+        *track = 1;             /* IBM format: one reserved track */
+        *first_sector = 0x01;
+        return true;
+    }
+    return false;
+}
+
+static bool cpm_directory_name(const uint8_t *entry,
+                               char out[DISK_AMSDOS_NAME_MAX]) {
+    char name[9];
+    char ext[4];
+    int name_len = 8;
+    int ext_len = 3;
+
+    for (int i = 0; i < 8; i++) {
+        unsigned char c = entry[1 + i] & 0x7F;
+        if (c != ' ' && (c < 0x21 || c > 0x7E || c == '.'))
+            return false;
+        name[i] = (char)c;
+    }
+    name[8] = '\0';
+    while (name_len > 0 && name[name_len - 1] == ' ')
+        name_len--;
+    if (name_len == 0)
+        return false;
+
+    for (int i = 0; i < 3; i++) {
+        unsigned char c = entry[9 + i] & 0x7F;
+        if (c != ' ' && (c < 0x21 || c > 0x7E || c == '.'))
+            return false;
+        ext[i] = (char)c;
+    }
+    ext[3] = '\0';
+    while (ext_len > 0 && ext[ext_len - 1] == ' ')
+        ext_len--;
+
+    int pos = 0;
+    for (int i = 0; i < name_len; i++)
+        out[pos++] = (char)toupper((unsigned char)name[i]);
+    if (ext_len > 0) {
+        out[pos++] = '.';
+        for (int i = 0; i < ext_len; i++)
+            out[pos++] = (char)toupper((unsigned char)ext[i]);
+    }
+    out[pos] = '\0';
+    return true;
+}
+
+static int directory_entry_compare(const void *a_, const void *b_) {
+    const DiskDirectoryEntry *a = a_;
+    const DiskDirectoryEntry *b = b_;
+    if (a->user != b->user)
+        return (int)a->user - (int)b->user;
+    return strcmp(a->name, b->name);
+}
+
+int disk_list_directory(const Disk *d, DiskDirectoryEntry *entries,
+                        int capacity) {
+    uint8_t directory[64 * 32];
+    int dir_track;
+    uint8_t first_sector;
+
+    if (!d || !d->inserted || !entries || capacity <= 0 ||
+        !disk_directory_geometry(d, &dir_track, &first_sector))
+        return -1;
+    if (dir_track >= d->track_count)
+        return -1;
+    for (int i = 0; i < 4; i++)
+        if (!disk_read_directory_sector(d, dir_track,
+                                        (uint8_t)(first_sector + i),
+                                        directory + i * 512))
+            return -1;
+
+    int count = 0;
+    for (int i = 0; i < 64; i++) {
+        const uint8_t *raw = directory + i * 32;
+        if (raw[0] > 15)
+            continue;
+
+        char name[DISK_AMSDOS_NAME_MAX];
+        if (!cpm_directory_name(raw, name))
+            continue;
+
+        int found = -1;
+        for (int j = 0; j < count; j++) {
+            if (entries[j].user == raw[0] && !strcmp(entries[j].name, name)) {
+                found = j;
+                break;
+            }
+        }
+        if (found < 0) {
+            if (count >= capacity)
+                continue;
+            found = count++;
+            entries[found].user = raw[0];
+            snprintf(entries[found].name, sizeof(entries[found].name),
+                     "%s", name);
+            entries[found].size = 0;
+        }
+
+        unsigned extent = (raw[12] & 0x1F) | ((raw[14] & 0x3F) << 5);
+        unsigned records = raw[15] > 128 ? 128 : raw[15];
+        uint32_t end = (uint32_t)(extent * 128U + records) * 128U;
+        if (end > entries[found].size)
+            entries[found].size = end;
+    }
+
+    qsort(entries, (size_t)count, sizeof(*entries), directory_entry_compare);
+    return count;
 }
 
 int disk_create_blank(const char *path) {

--- a/src/disk.h
+++ b/src/disk.h
@@ -7,6 +7,8 @@
 #define DISK_MAX_SIDES     2
 #define DISK_MAX_SECTORS  29
 #define DISK_PATH_MAX    4096
+#define DISK_DIRECTORY_MAX_FILES 64
+#define DISK_AMSDOS_NAME_MAX     13
 
 typedef struct {
     uint8_t C, H, R, N;    /* CHRN — cylinder, head, record, size code */
@@ -35,6 +37,12 @@ typedef struct {
     int       cur_sector;   /* last-used sector index (for READ ID rotation) */
 } Disk;
 
+typedef struct {
+    uint8_t  user;
+    char     name[DISK_AMSDOS_NAME_MAX]; /* AMSDOS 8.3, NUL-terminated */
+    uint32_t size;                       /* extent-derived byte count */
+} DiskDirectoryEntry;
+
 void disk_init(Disk *d);
 void disk_eject(Disk *d);
 
@@ -49,6 +57,12 @@ int  disk_create_blank(const char *path);
 /* Ensure a newly created disk path ends in .dsk (case-insensitive).
  * Returns false if path is empty or the suffix would not fit. */
 bool disk_ensure_dsk_extension(char *path, size_t capacity);
+
+/* List unique CP/M/AMSDOS files from common CPC DATA, SYSTEM, or IBM format
+ * directory sectors. Returns the number of files, 0 for an empty directory,
+ * or -1 when the mounted image has no supported directory layout. */
+int disk_list_directory(const Disk *d, DiskDirectoryEntry *entries,
+                        int capacity);
 
 /* Find a sector by CHRN on the current track. Returns NULL if not found. */
 DiskSector *disk_find_sector(Disk *d, int side, uint8_t C, uint8_t H,

--- a/src/main.c
+++ b/src/main.c
@@ -451,6 +451,38 @@ static void usage(const char *prog, int code) {
     exit(code);
 }
 
+typedef enum {
+    AUTOSTART_NONE = 0,
+    AUTOSTART_CLI,
+    AUTOSTART_PASTE,
+    AUTOSTART_DISK_SESSION
+} AutostartSource;
+
+static int autostart_delay_frames(void) {
+    int delay = 42;
+    const char *e = getenv("ONE_K_AUTOSTART_FRAMES");
+    if (e) {
+        int requested = atoi(e);
+        if (requested > 0)
+            delay = requested;
+    }
+    return delay;
+}
+
+static bool arm_disk_session_autostart(const Overlay *overlay,
+                                       const CPC *cpc,
+                                       AutostartSource *source,
+                                       int *countdown) {
+    int drive;
+    if (!overlay_disk_autostart_get(overlay, &drive, NULL, NULL) ||
+        !cpc_model_has_keyboard(cpc->model) || drive < 0 || drive > 1 ||
+        !cpc->drive[drive].inserted)
+        return false;
+    *source = AUTOSTART_DISK_SESSION;
+    *countdown = autostart_delay_frames();
+    return true;
+}
+
 int main(int argc, char *argv[]) {
 
     SD_INIT();
@@ -905,14 +937,11 @@ int main(int argc, char *argv[]) {
     /* Frames to wait before injecting autostart text (matches caprice32 timing).
      * ONE_K_AUTOSTART_FRAMES overrides for headless QA scripts that need a
      * larger margin (paste before BASIC Ready is silently dropped). */
-    int autostart_countdown = (autostart || paste_arg) ? 42 : 0;
-    {
-        const char *e = getenv("ONE_K_AUTOSTART_FRAMES");
-        if (e && autostart_countdown > 0) {
-            int n = atoi(e);
-            if (n > 0) autostart_countdown = n;
-        }
-    }
+    AutostartSource autostart_source = paste_arg ? AUTOSTART_PASTE
+                                         : autostart ? AUTOSTART_CLI
+                                                     : AUTOSTART_NONE;
+    int autostart_countdown = autostart_source == AUTOSTART_NONE
+                            ? 0 : autostart_delay_frames();
 
     /* Host pacer. A normal CPC frame is 20 ms, but software can program a
      * different CRTC frame length. Pace from the CPU cycles cpc_frame()
@@ -1155,6 +1184,9 @@ int main(int argc, char *argv[]) {
                     }
                 } else if (ev.key.scancode == SDL_SCANCODE_F5) {
                     cpc_reset(&cpc);
+                    arm_disk_session_autostart(&overlay, &cpc,
+                                               &autostart_source,
+                                               &autostart_countdown);
                 } else if (ev.key.scancode == SDL_SCANCODE_F10) {
                     /* Toggle host-side card browse: pause the guest, mount
                      * every active FAT card image (M4 SD / IDE / Albireo)
@@ -1218,7 +1250,7 @@ int main(int argc, char *argv[]) {
         }
 
         if (autostart_countdown > 0 && --autostart_countdown == 0) {
-            if (paste_arg) {
+            if (autostart_source == AUTOSTART_PASTE) {
                 /* --paste=TEXT: expand \n to real newline then inject */
                 char buf[512];
                 int j = 0;
@@ -1228,14 +1260,33 @@ int main(int argc, char *argv[]) {
                 }
                 buf[j] = '\0';
                 paste_text(&paste, buf);
-            } else {
+            } else if (autostart_source == AUTOSTART_CLI) {
                 char cmd[256];
                 snprintf(cmd, sizeof(cmd), "run\"%s", autostart);
                 paste_text(&paste, cmd);
+            } else if (autostart_source == AUTOSTART_DISK_SESSION) {
+                int drive;
+                uint8_t user;
+                const char *file;
+                if (overlay_disk_autostart_get(&overlay, &drive,
+                                               &user, &file)) {
+                    char cmd[96];
+                    if (user > 0)
+                        snprintf(cmd, sizeof(cmd),
+                                 "|%c\n|user,%u\nrun\"%s",
+                                 drive ? 'b' : 'a', (unsigned)user, file);
+                    else
+                        snprintf(cmd, sizeof(cmd), "|%c\nrun\"%s",
+                                 drive ? 'b' : 'a', file);
+                    paste_text(&paste, cmd);
+                }
             }
+            autostart_source = AUTOSTART_NONE;
         }
 
         overlay_tick(&overlay);
+        bool disk_autostart_requested = !overlay.visible &&
+            overlay_take_disk_autostart_request(&overlay);
 
         /* Auto-finish F10 mount session if the user ejected the card from
          * the file manager (Nautilus, Files, …). Same effect as a second
@@ -1348,6 +1399,14 @@ int main(int argc, char *argv[]) {
                                   &mouse_captured, cpc.model);
             net4cpc_reset();
             cpc_reset(&cpc);
+            arm_disk_session_autostart(&overlay, &cpc,
+                                       &autostart_source,
+                                       &autostart_countdown);
+        } else if (disk_autostart_requested) {
+            cpc_reset(&cpc);
+            arm_disk_session_autostart(&overlay, &cpc,
+                                       &autostart_source,
+                                       &autostart_countdown);
         }
 
         monitor_pty_tick(monitor);

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -33,6 +33,7 @@ static void overlay_file_callback(void *userdata, const char * const *files, int
 #define ROMSLOT_TOTAL   (ROM_EXT_COUNT + 1)
 #define BROWSER_VISIBLE_ROWS 16
 #define BROWSER_ROW_H 16
+#define DISK_AUTOSTART_VISIBLE_ROWS 16
 #define REAL_TAPE_ROWS 10
 
 #define ABOUT_TEXT "1984 Amstrad CPC emulator (c) 2026 salvogendut"
@@ -339,6 +340,73 @@ static void trunc_path(const char *path, char *out, size_t sz) {
 static bool floppy_accessible(const Overlay *ov) {
     return !cpc_model_is_console(ov->cfg->model) &&
            (cpc_model_has_builtin_fdc(ov->cfg->model) || ov->cfg->dd1);
+}
+
+static void disk_autostart_clear(Overlay *ov, int drive) {
+    if (ov->disk_autostart_drive != drive)
+        return;
+    ov->disk_autostart_drive = -1;
+    ov->disk_autostart_user = 0;
+    ov->disk_autostart_file[0] = '\0';
+    ov->disk_autostart_request = false;
+}
+
+static void disk_autostart_ensure_visible(Overlay *ov) {
+    if (ov->disk_file_row < ov->disk_file_scroll)
+        ov->disk_file_scroll = ov->disk_file_row;
+    if (ov->disk_file_row >=
+        ov->disk_file_scroll + DISK_AUTOSTART_VISIBLE_ROWS)
+        ov->disk_file_scroll =
+            ov->disk_file_row - DISK_AUTOSTART_VISIBLE_ROWS + 1;
+    if (ov->disk_file_scroll < 0)
+        ov->disk_file_scroll = 0;
+}
+
+static void disk_autostart_move(Overlay *ov, int delta) {
+    if (ov->disk_file_count <= 0)
+        return;
+    int row = ov->disk_file_row + delta;
+    if (row < 0)
+        row = 0;
+    if (row >= ov->disk_file_count)
+        row = ov->disk_file_count - 1;
+    ov->disk_file_row = row;
+    disk_autostart_ensure_visible(ov);
+}
+
+static void open_disk_autostart_browser(Overlay *ov, int drive) {
+    if (!ov->cpc || drive < 0 || drive > 1 ||
+        !ov->cpc->drive[drive].inserted) {
+        notify_post("Insert a disk in Drive %c first", drive ? 'B' : 'A');
+        return;
+    }
+
+    int count = disk_list_directory(&ov->cpc->drive[drive], ov->disk_files,
+                                    DISK_DIRECTORY_MAX_FILES);
+    if (count < 0) {
+        notify_post("Drive %c disk directory format is unsupported",
+                    drive ? 'B' : 'A');
+        return;
+    }
+
+    ov->disk_file_drive = drive;
+    ov->disk_file_count = count;
+    ov->disk_file_row = 0;
+    ov->disk_file_scroll = 0;
+    ov->disk_file_marked_row = -1;
+    if (ov->disk_autostart_drive == drive) {
+        for (int i = 0; i < count; i++) {
+            if (ov->disk_files[i].user == ov->disk_autostart_user &&
+                !strcmp(ov->disk_files[i].name,
+                        ov->disk_autostart_file)) {
+                ov->disk_file_row = i;
+                ov->disk_file_marked_row = i;
+                disk_autostart_ensure_visible(ov);
+                break;
+            }
+        }
+    }
+    ov->state = OV_STATE_DISK_AUTOSTART;
 }
 
 static bool path_separator(char c) {
@@ -760,7 +828,9 @@ static void item_text(const Overlay *ov, int row,
                 snprintf(val, vsz, "[enable DD1 in Advanced]");
                 *readonly = true;
             } else if (da && da->inserted && ov->cfg->disk_a[0]) {
-                trunc_path(ov->cfg->disk_a, val, vsz);
+                char shown[34];
+                trunc_path(ov->cfg->disk_a, shown, sizeof(shown));
+                snprintf(val, vsz, "%s  A=autostart", shown);
             }
             else
                 snprintf(val, vsz, "[empty]  Enter=load, N=new, Del=clear");
@@ -774,7 +844,9 @@ static void item_text(const Overlay *ov, int row,
                 snprintf(val, vsz, "[enable DD1 in Advanced]");
                 *readonly = true;
             } else if (db && db->inserted && ov->cfg->disk_b[0]) {
-                trunc_path(ov->cfg->disk_b, val, vsz);
+                char shown[34];
+                trunc_path(ov->cfg->disk_b, shown, sizeof(shown));
+                snprintf(val, vsz, "%s  A=autostart", shown);
             }
             else
                 snprintf(val, vsz, "[empty]  Enter=load, N=new, Del=clear");
@@ -2224,6 +2296,9 @@ void overlay_init(Overlay *ov, Config *cfg, CPC *cpc, bool sdl_fm) {
     ov->dialog_kind  = DIALOG_NONE;
     ov->dialog_drive = -1;
     ov->dialog_slot  = -1;
+    ov->disk_file_drive = -1;
+    ov->disk_file_marked_row = -1;
+    ov->disk_autostart_drive = -1;
     ov->last_m4            = cfg->m4;
     ov->last_albireo       = cfg->albireo;
     ov->last_symbiface_ide = cfg->symbiface_ide;
@@ -2231,6 +2306,24 @@ void overlay_init(Overlay *ov, Config *cfg, CPC *cpc, bool sdl_fm) {
 
 void overlay_quit(Overlay *ov) {
     browser_clear_entries(ov);
+}
+
+bool overlay_disk_autostart_get(const Overlay *ov, int *drive,
+                                uint8_t *user, const char **file) {
+    if (!ov || ov->disk_autostart_drive < 0 ||
+        !ov->disk_autostart_file[0])
+        return false;
+    if (drive) *drive = ov->disk_autostart_drive;
+    if (user) *user = ov->disk_autostart_user;
+    if (file) *file = ov->disk_autostart_file;
+    return true;
+}
+
+bool overlay_take_disk_autostart_request(Overlay *ov) {
+    if (!ov || !ov->disk_autostart_request)
+        return false;
+    ov->disk_autostart_request = false;
+    return true;
 }
 
 /* Check whether any of the ROM-owning hardware toggles flipped since
@@ -2301,6 +2394,8 @@ void overlay_tick(Overlay *ov) {
         int drv = ov->dialog_drive;
         ov->dialog_drive = -1;
         char *dest = (drv == 0) ? ov->cfg->disk_a : ov->cfg->disk_b;
+        if (strcmp(dest, ov->dialog_path))
+            disk_autostart_clear(ov, drv);
         snprintf(dest, CONFIG_PATH_MAX, "%s", ov->dialog_path);
         if (ov->cpc) {
             Disk *d = &ov->cpc->drive[drv];
@@ -2316,6 +2411,7 @@ void overlay_tick(Overlay *ov) {
         int drv = ov->dialog_drive;
         ov->dialog_drive = -1;
         char *dest = (drv == 0) ? ov->cfg->disk_a : ov->cfg->disk_b;
+        disk_autostart_clear(ov, drv);
         if (!disk_ensure_dsk_extension(ov->dialog_path,
                                        sizeof(ov->dialog_path))) {
             fprintf(stderr,
@@ -2811,6 +2907,72 @@ bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
         return true;
     }
 
+    if (ov->state == OV_STATE_DISK_AUTOSTART) {
+        switch (sc) {
+        case SDL_SCANCODE_ESCAPE:
+            ov->state = OV_STATE_MENU;
+            break;
+        case SDL_SCANCODE_UP:
+            disk_autostart_move(ov, -1);
+            break;
+        case SDL_SCANCODE_DOWN:
+            disk_autostart_move(ov, 1);
+            break;
+        case SDL_SCANCODE_PAGEUP:
+            disk_autostart_move(ov, -DISK_AUTOSTART_VISIBLE_ROWS);
+            break;
+        case SDL_SCANCODE_PAGEDOWN:
+            disk_autostart_move(ov, DISK_AUTOSTART_VISIBLE_ROWS);
+            break;
+        case SDL_SCANCODE_HOME:
+            if (ov->disk_file_count > 0) {
+                ov->disk_file_row = 0;
+                disk_autostart_ensure_visible(ov);
+            }
+            break;
+        case SDL_SCANCODE_END:
+            if (ov->disk_file_count > 0) {
+                ov->disk_file_row = ov->disk_file_count - 1;
+                disk_autostart_ensure_visible(ov);
+            }
+            break;
+        case SDL_SCANCODE_RETURN:
+        case SDL_SCANCODE_KP_ENTER:
+        case SDL_SCANCODE_SPACE:
+            if (ov->disk_file_row >= 0 &&
+                ov->disk_file_row < ov->disk_file_count)
+                ov->disk_file_marked_row = ov->disk_file_row;
+            break;
+        case SDL_SCANCODE_DELETE:
+        case SDL_SCANCODE_BACKSPACE:
+            ov->disk_file_marked_row = -1;
+            break;
+        case SDL_SCANCODE_S:
+            if (ov->disk_file_marked_row >= 0 &&
+                ov->disk_file_marked_row < ov->disk_file_count) {
+                const DiskDirectoryEntry *entry =
+                    &ov->disk_files[ov->disk_file_marked_row];
+                ov->disk_autostart_drive = ov->disk_file_drive;
+                ov->disk_autostart_user = entry->user;
+                snprintf(ov->disk_autostart_file,
+                         sizeof(ov->disk_autostart_file), "%s", entry->name);
+                ov->disk_autostart_request = true;
+                notify_post("Drive %c autostart: %s",
+                            ov->disk_file_drive ? 'B' : 'A', entry->name);
+            } else {
+                disk_autostart_clear(ov, ov->disk_file_drive);
+                notify_post("Drive %c autostart cleared",
+                            ov->disk_file_drive ? 'B' : 'A');
+            }
+            ov->state = OV_STATE_MENU;
+            try_close(ov);
+            break;
+        default:
+            break;
+        }
+        return true;
+    }
+
     /* ---- Confirm dialog ---- */
     if (ov->state == OV_STATE_CONFIRM) {
         switch (sc) {
@@ -3095,6 +3257,11 @@ bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
                 dsk_filters, 2, ov->cfg->last_dir[0] ? ov->cfg->last_dir : NULL);
         }
         break;
+    case SDL_SCANCODE_A:
+        if (ov->section == OV_STORAGE &&
+            (ov->row == 0 || ov->row == 1) && floppy_accessible(ov))
+            open_disk_autostart_browser(ov, ov->row);
+        break;
     case SDL_SCANCODE_DELETE:
     case SDL_SCANCODE_BACKSPACE:
         if (reset_tinker_item(ov))
@@ -3106,6 +3273,7 @@ bool overlay_handle_event(Overlay *ov, SDL_Event *ev) {
             if ((ov->row == 0 || ov->row == 1) && floppy_accessible(ov)) {
                 int drv = ov->row;
                 char *dest = (drv == 0) ? ov->cfg->disk_a : ov->cfg->disk_b;
+                disk_autostart_clear(ov, drv);
                 if (dest[0]) {
                     dest[0] = '\0';
                     if (ov->cpc) disk_eject(&ov->cpc->drive[drv]);
@@ -3411,6 +3579,60 @@ void overlay_render(const Overlay *ov, SDL_Renderer *r) {
 
     SDL_SetRenderScale(r, SCALE, SCALE);
 
+    /* ---- Files inside the mounted DSK ---- */
+    if (ov->state == OV_STATE_DISK_AUTOSTART) {
+        fill_rect(r, 0, 0, lw, lh, 10, 10, 30, 245);
+        char title[96];
+        snprintf(title, sizeof(title),
+                 "Drive %c files  Enter=mark S=save/reset Del=clear Esc=back",
+                 ov->disk_file_drive ? 'B' : 'A');
+        draw_text(r, DROP_PAD, 4, title, 180, 180, 220);
+        SDL_SetRenderDrawColor(r, 70, 90, 200, 255);
+        SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_NONE);
+        SDL_RenderLine(r, 0, BAR_H - 1, lw, BAR_H - 1);
+
+        for (int shown = 0; shown < DISK_AUTOSTART_VISIBLE_ROWS; shown++) {
+            int index = ov->disk_file_scroll + shown;
+            if (index >= ov->disk_file_count)
+                break;
+            const DiskDirectoryEntry *entry = &ov->disk_files[index];
+            float iy = BAR_H + 2.0f + shown * BROWSER_ROW_H;
+            bool selected = index == ov->disk_file_row;
+            if (selected)
+                fill_rect(r, 0, iy - 2.0f, lw, 14.0f,
+                          70, 90, 200, 255);
+
+            char line[64];
+            snprintf(line, sizeof(line), "%c U%02u  %-12s %6uK",
+                     index == ov->disk_file_marked_row ? '*' : ' ',
+                     (unsigned)entry->user, entry->name,
+                     (unsigned)((entry->size + 1023U) / 1024U));
+            draw_text(r, DROP_PAD, iy, line,
+                      selected ? 255 : 215,
+                      selected ? 255 : 220,
+                      index == ov->disk_file_marked_row ? 100 : 225);
+        }
+
+        float status_y = BAR_H + 2.0f +
+                         DISK_AUTOSTART_VISIBLE_ROWS * BROWSER_ROW_H + 4.0f;
+        if (ov->disk_file_count == 0) {
+            draw_text(r, DROP_PAD, status_y,
+                      "The disk directory contains no files.",
+                      160, 160, 180);
+        } else {
+            char count[64];
+            snprintf(count, sizeof(count), "%d file%s",
+                     ov->disk_file_count,
+                     ov->disk_file_count == 1 ? "" : "s");
+            draw_text(r, DROP_PAD, status_y, count, 150, 160, 180);
+        }
+        draw_text(r, DROP_PAD, status_y + 17.0f,
+                  "Session-only mark: survives F5 reset; clears when 1984 exits.",
+                  150, 190, 230);
+        SDL_SetRenderScale(r, 1.0f, 1.0f);
+        return;
+    }
+
     /* ---- ROM slots sub-panel ---- */
     if (ov->state == OV_STATE_ROMSLOTS) {
         fill_rect(r, 0, 0, lw, lh, 10, 10, 30, 245);
@@ -3638,8 +3860,8 @@ void overlay_render(const Overlay *ov, SDL_Renderer *r) {
         const char *help = cpc_model_is_console(ov->cfg->model)
             ? "Cartridge: Enter=load CPR  Del=default"
             : (ov->sdl_fm
-                ? "Enter: built-in  N:new  Del:eject/default"
-                : "Enter: system  Shift+Enter: built-in  N:new  Del:eject/default");
+                ? "Enter=load A=autostart N=new Del=eject/default"
+                : "Enter=load Shift+Enter=built-in A=autostart N=new Del=eject");
         draw_text(r, DROP_PAD, BAR_H + drop_h + 7.0f, help,
                   150, 150, 175);
     }

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <SDL3/SDL.h>
 #include "config.h"
+#include "disk.h"
 
 typedef enum {
     OV_GENERAL  = 0,
@@ -17,7 +18,8 @@ typedef enum {
     OV_STATE_ROMSLOTS = 2,   /* ROM slots sub-panel */
     OV_STATE_FILE_BROWSER = 3,
     OV_STATE_REAL_TAPE = 4,  /* Tinker-gated physical cassette controls */
-    OV_STATE_ABOUT    = 5    /* About dialog with an OK button */
+    OV_STATE_ABOUT    = 5,   /* About dialog with an OK button */
+    OV_STATE_DISK_AUTOSTART = 6
 } OvState;
 
 typedef enum {
@@ -71,6 +73,18 @@ typedef struct {
     int          browser_entry_capacity;
     int          browser_row;
     int          browser_scroll;
+    /* Session-only DSK autostart selector. The committed choice survives
+     * machine resets but is deliberately absent from Config. */
+    DiskDirectoryEntry disk_files[DISK_DIRECTORY_MAX_FILES];
+    int          disk_file_count;
+    int          disk_file_row;
+    int          disk_file_scroll;
+    int          disk_file_drive;
+    int          disk_file_marked_row;
+    int          disk_autostart_drive;
+    uint8_t      disk_autostart_user;
+    char         disk_autostart_file[DISK_AMSDOS_NAME_MAX];
+    bool         disk_autostart_request;
     int          real_tape_row;
     /* ROM slots sub-panel state */
     int          romslot_row;    /* selected slot 0-31 */
@@ -111,3 +125,9 @@ void overlay_render_real_tape_scope(const Overlay *ov, SDL_Renderer *r);
 
 /* Call once per frame to process any pending file-dialog results. */
 void overlay_tick(Overlay *ov);
+
+/* Query the session-only DSK autostart choice. The request accessor consumes
+ * only the immediate reset request; the selected file remains armed. */
+bool overlay_disk_autostart_get(const Overlay *ov, int *drive,
+                                uint8_t *user, const char **file);
+bool overlay_take_disk_autostart_request(Overlay *ov);

--- a/tests/test_disk.c
+++ b/tests/test_disk.c
@@ -122,9 +122,152 @@ static void test_format_track_persists_after_reload(void) {
     unlink(path);
 }
 
+static void directory_entry(uint8_t *entry, uint8_t user,
+                            const char name[8], const char ext[3],
+                            uint8_t extent, uint8_t records) {
+    memset(entry, 0, 32);
+    entry[0] = user;
+    memcpy(entry + 1, name, 8);
+    memcpy(entry + 9, ext, 3);
+    entry[12] = extent & 0x1F;
+    entry[14] = extent >> 5;
+    entry[15] = records;
+}
+
+static void write_directory(Disk *disk, int track, uint8_t first_sector,
+                            const uint8_t directory[2048]) {
+    disk->cur_track = track;
+    for (int i = 0; i < 4; i++) {
+        DiskSector *sec = disk_find_sector(
+            disk, 0, (uint8_t)track, 0,
+            (uint8_t)(first_sector + i), 2);
+        assert(sec);
+        assert(disk_write_sector(disk, sec, directory + i * 512, 512) == 0);
+    }
+}
+
+static void test_list_data_directory(void) {
+    const char *path = "/tmp/1984-test-disk-directory.dsk";
+    uint8_t directory[2048];
+    DiskDirectoryEntry files[DISK_DIRECTORY_MAX_FILES];
+
+    memset(directory, 0xE5, sizeof(directory));
+    directory_entry(directory, 0, "GAME    ", "BAS", 0, 128);
+    directory_entry(directory + 32, 0, "GAME    ", "BAS", 1, 3);
+    directory_entry(directory + 64, 1, "UTILITY ", "BI\316", 0, 10);
+    directory_entry(directory + 96, 0x20, "LABEL   ", "   ", 0, 0);
+
+    unlink(path);
+    assert(disk_create_blank(path) == 0);
+
+    Disk disk;
+    disk_init(&disk);
+    assert(disk_load(&disk, path) == 0);
+    write_directory(&disk, 0, 0xC1, directory);
+    disk_eject(&disk);
+    assert(disk_load(&disk, path) == 0);
+
+    int count = disk_list_directory(&disk, files, DISK_DIRECTORY_MAX_FILES);
+    assert(count == 2);
+    assert(files[0].user == 0);
+    assert(strcmp(files[0].name, "GAME.BAS") == 0);
+    assert(files[0].size == (128U + 3U) * 128U);
+    assert(files[1].user == 1);
+    assert(strcmp(files[1].name, "UTILITY.BIN") == 0);
+    assert(files[1].size == 10U * 128U);
+
+    disk_eject(&disk);
+    unlink(path);
+}
+
+static void test_list_system_directory(void) {
+    const char *path = "/tmp/1984-test-system-directory.dsk";
+    uint8_t directory[2048];
+    uint8_t ids[9 * 4];
+    DiskDirectoryEntry files[DISK_DIRECTORY_MAX_FILES];
+
+    memset(directory, 0xE5, sizeof(directory));
+    directory_entry(directory, 0, "DISC    ", "   ", 0, 4);
+    for (int i = 0; i < 9; i++) {
+        ids[i * 4 + 0] = 0;
+        ids[i * 4 + 1] = 0;
+        ids[i * 4 + 2] = (uint8_t)(0x41 + i);
+        ids[i * 4 + 3] = 2;
+    }
+
+    unlink(path);
+    assert(disk_create_blank(path) == 0);
+
+    Disk disk;
+    disk_init(&disk);
+    assert(disk_load(&disk, path) == 0);
+    disk.cur_track = 0;
+    assert(disk_format_track(&disk, 0, ids, 9, 2, 0x4E, 0xE5) == 0);
+    for (int i = 0; i < 9; i++)
+        ids[i * 4 + 0] = 2;
+    disk.cur_track = 2;
+    assert(disk_format_track(&disk, 0, ids, 9, 2, 0x4E, 0xE5) == 0);
+    write_directory(&disk, 2, 0x41, directory);
+    disk_eject(&disk);
+    assert(disk_load(&disk, path) == 0);
+
+    int count = disk_list_directory(&disk, files, DISK_DIRECTORY_MAX_FILES);
+    assert(count == 1);
+    assert(files[0].user == 0);
+    assert(strcmp(files[0].name, "DISC") == 0);
+    assert(files[0].size == 4U * 128U);
+
+    disk_eject(&disk);
+    unlink(path);
+}
+
+static void test_list_ibm_directory(void) {
+    const char *path = "/tmp/1984-test-ibm-directory.dsk";
+    uint8_t directory[2048];
+    uint8_t ids[9 * 4];
+    DiskDirectoryEntry files[DISK_DIRECTORY_MAX_FILES];
+
+    memset(directory, 0xE5, sizeof(directory));
+    directory_entry(directory, 0, "START   ", "BAS", 0, 2);
+    for (int i = 0; i < 9; i++) {
+        ids[i * 4 + 0] = 0;
+        ids[i * 4 + 1] = 0;
+        ids[i * 4 + 2] = (uint8_t)(0x01 + i);
+        ids[i * 4 + 3] = 2;
+    }
+
+    unlink(path);
+    assert(disk_create_blank(path) == 0);
+
+    Disk disk;
+    disk_init(&disk);
+    assert(disk_load(&disk, path) == 0);
+    disk.cur_track = 0;
+    assert(disk_format_track(&disk, 0, ids, 9, 2, 0x4E, 0xE5) == 0);
+    for (int i = 0; i < 9; i++)
+        ids[i * 4 + 0] = 1;
+    disk.cur_track = 1;
+    assert(disk_format_track(&disk, 0, ids, 9, 2, 0x4E, 0xE5) == 0);
+    write_directory(&disk, 1, 0x01, directory);
+    disk_eject(&disk);
+    assert(disk_load(&disk, path) == 0);
+
+    int count = disk_list_directory(&disk, files, DISK_DIRECTORY_MAX_FILES);
+    assert(count == 1);
+    assert(files[0].user == 0);
+    assert(strcmp(files[0].name, "START.BAS") == 0);
+    assert(files[0].size == 2U * 128U);
+
+    disk_eject(&disk);
+    unlink(path);
+}
+
 int main(void) {
     test_new_disk_extension();
     test_sector_write_persists_after_reload();
     test_format_track_persists_after_reload();
+    test_list_data_directory();
+    test_list_system_directory();
+    test_list_ibm_directory();
     return 0;
 }


### PR DESCRIPTION
Closes #234. Adds an in-DSK AMSDOS/CP/M file browser, session-only autostart selection that survives resets, drive A/B command generation, and DATA/SYSTEM/IBM parser coverage. Verified with the full unit suite and Bomb Jack, CP/M Plus, and HBL disks.