### PR TITLE
WASM POC: model picker, cartridge support and reset

### DIFF
--- a/web/Makefile
+++ b/web/Makefile
@@ -52,12 +52,13 @@ test-gamepad:
 $(WASM_ASSETS) &: $(OBJS) | $(DIST_DIR)
 	$(EMCC) $(CFLAGS) $(OBJS) -o $(DIST_DIR)/6128.js \
 	    -sMODULARIZE -sEXPORT_NAME=create6128 \
-	    -sEXPORTED_FUNCTIONS='_poc_init,_poc_step,_poc_pixels,_poc_key,_poc_joy,_poc_joy_matrix,_poc_disk_motor,_poc_load_disk,_poc_audio_reset,_poc_audio_avail,_poc_audio_read_pos,_poc_audio_buffer,_poc_audio_advance,_poc_width,_poc_height,_malloc,_free' \
+	    -sEXPORTED_FUNCTIONS='_poc_init,_poc_init_model,_poc_load_cartridge,_poc_reset,_poc_step,_poc_pixels,_poc_key,_poc_joy,_poc_joy_matrix,_poc_disk_motor,_poc_load_disk,_poc_audio_reset,_poc_audio_avail,_poc_audio_read_pos,_poc_audio_buffer,_poc_audio_advance,_poc_width,_poc_height,_malloc,_free' \
 	    -sEXPORTED_RUNTIME_METHODS='HEAPU8,HEAPU32,wasmMemory,getValue,setValue,ccall,cwrap,FS' \
 	    -sALLOW_MEMORY_GROWTH=1 -sINITIAL_MEMORY=67108864 \
 	    --embed-file ../roms/OS_6128.ROM@roms/OS_6128.ROM \
 	    --embed-file ../roms/BASIC_1.1.ROM@roms/BASIC_1.1.ROM \
-	    --embed-file ../roms/AMSDOS.ROM@roms/AMSDOS.ROM
+	    --embed-file ../roms/AMSDOS.ROM@roms/AMSDOS.ROM \
+	    --embed-file ../roms/system.cpr@roms/system.cpr
 
 $(BUILD_DIR)/%.o: ../src/%.c | $(BUILD_DIR)
 	$(EMCC) $(CFLAGS) -c $< -o $@

--- a/web/index.html
+++ b/web/index.html
@@ -14,6 +14,19 @@
 </style>
 </head>
 <body>
+<div id="topbar">
+  <label>Model:
+    <select id="model">
+      <option value="0">CPC 6128</option>
+      <option value="1">CPC 6128 PLUS</option>
+    </select>
+  </label>
+  <button id="reset" type="button">Reset</button>
+  <span id="cartspan" style="display:none">
+    <input type="file" id="cartfile" accept=".cpr,.CPR">
+  </span>
+  <span id="cartname"></span>
+</div>
 <canvas id="screen" width="768" height="576"></canvas>
 <div><span id="ledA" class="led"></span><span id="diskname"></span></div>
 <div id="status">loading…</div>
@@ -61,6 +74,67 @@ create6128().then(m => {
   statusEl.textContent = 'CPC 6128 booting… (click for keyboard focus)';
 
   const ptr = m._poc_pixels();
+  let currentModel = 0;
+
+  // Re-init the machine (model switch / cartridge load). The framebuffer
+  // pointer is stable (static CPC struct), so `ptr` stays valid.
+  function reinit(model, cartridge) {
+    const rc = (cartridge !== undefined)
+      ? m.ccall('poc_load_cartridge', 'number', ['string'], [cartridge])
+      : m._poc_init_model(model, 0);
+    if (rc !== 0) { statusEl.textContent = 'machine init failed'; return false; }
+    currentModel = model;
+    m._poc_audio_reset();
+    if (audioCtx) nextStart = audioCtx.currentTime + 0.3;
+    prevGamepad = null;
+    releaseAllJoy();
+    statusEl.textContent = 'Machine reset';
+    return true;
+  }
+
+  // ---- model picker + reset + cartridge ----
+  const modelEl = document.getElementById('model');
+  const resetEl = document.getElementById('reset');
+  const cartspanEl = document.getElementById('cartspan');
+  const cartfileEl = document.getElementById('cartfile');
+  const cartnameEl = document.getElementById('cartname');
+  function updateCartUi() {
+    cartspanEl.style.display = (currentModel === 1) ? '' : 'none';
+    if (currentModel === 1 && !cartnameEl.textContent)
+      cartnameEl.textContent = 'system.cpr';
+  }
+  modelEl.addEventListener('change', () => {
+    const model = parseInt(modelEl.value, 10);
+    if (reinit(model)) {
+      cartnameEl.textContent = (model === 1) ? 'system.cpr' : '';
+      updateCartUi();
+    }
+  });
+  resetEl.addEventListener('click', () => {
+    m._poc_reset();
+    m._poc_audio_reset();
+    if (audioCtx) nextStart = audioCtx.currentTime + 0.3;
+    prevGamepad = null;
+    releaseAllJoy();
+    statusEl.textContent = 'Reset';
+  });
+  cartfileEl.addEventListener('change', () => {
+    const f = cartfileEl.files[0];
+    if (!f) return;
+    f.arrayBuffer().then(buf => {
+      m.FS.writeFile('/system.cpr', new Uint8Array(buf));
+      const rc = m.ccall('poc_load_cartridge', 'number', ['string'], ['/system.cpr']);
+      if (rc === 0) {
+        cartnameEl.textContent = f.name;
+        currentModel = 1;
+        updateCartUi();
+        statusEl.textContent = 'Cartridge: ' + f.name;
+      } else {
+        statusEl.textContent = 'cartridge load failed';
+      }
+    });
+  });
+  updateCartUi();
 
   // ---- audio: schedule buffers ahead of the audio clock ----
   // The emulator fills an in-wasm ring at 50 Hz; each frame we schedule

--- a/web/poc_main.c
+++ b/web/poc_main.c
@@ -50,21 +50,37 @@ EMSCRIPTEN_KEEPALIVE void poc_audio_advance(int n) {
     g_audio_r = (g_audio_r + n) % AUDIO_RING_SAMPLES;
 }
 
-/* ---- emulator lifecycle ---- */
+/* ---- emulator lifecycle ----
+ * model 0 = CPC 6128 (OS/BASIC/AMSDOS), 1 = CPC 6128 Plus (cartridge;
+ * defaults to the bundled system cartridge when cartridge is NULL).
+ * May be called repeatedly to switch machines. */
 
-EMSCRIPTEN_KEEPALIVE int poc_init(void) {
-    if (g_inited) return 0;
-    if (cpc_init(&g_cpc, MODEL_6128, "roms/OS_6128.ROM",
-                 "roms/BASIC_1.1.ROM", NULL, 1) != 0)
+EMSCRIPTEN_KEEPALIVE int poc_init_model(int model, const char *cartridge) {
+    int rc;
+    if (model == 1) {
+        rc = cpc_init(&g_cpc, MODEL_6128_PLUS, NULL, NULL,
+                      cartridge ? cartridge : "roms/system.cpr", 1);
+    } else {
+        rc = cpc_init(&g_cpc, MODEL_6128, "roms/OS_6128.ROM",
+                      "roms/BASIC_1.1.ROM", NULL, 1);
+        if (rc == 0)
+            mem_load_amsdos(&g_cpc.mem, "roms/AMSDOS.ROM");
+    }
+    if (rc != 0)
         return -1;
-    /* AMSDOS is required to use floppy disks and for the firmware's boot-time
-     * AMSDOS detection (it probes upper ROM slot 7). */
-    if (mem_load_amsdos(&g_cpc.mem, "roms/AMSDOS.ROM") != 0)
-        return -2;
     cpc_set_audio_sink(&g_cpc, poc_audio_sink, NULL);
     g_inited = 1;
     return 0;
 }
+
+EMSCRIPTEN_KEEPALIVE int poc_init(void) { return poc_init_model(0, NULL); }
+
+EMSCRIPTEN_KEEPALIVE int poc_load_cartridge(const char *path) {
+    return poc_init_model(1, path);
+}
+
+/* Warm reset of the current machine (keeps loaded ROMs/cartridge). */
+EMSCRIPTEN_KEEPALIVE void poc_reset(void) { cpc_reset(&g_cpc); }
 
 EMSCRIPTEN_KEEPALIVE int poc_step(void) {
     return cpc_frame(&g_cpc);


### PR DESCRIPTION
Closes #260

- Model picker (CPC 6128 / CPC 6128 PLUS) at the top of the page; changing models re-inits the emulator
- Cartridge (.cpr) file picker, shown only for 6128 PLUS; bundles roms/system.cpr as the default
- Reset button (warm reset via cpc_reset)
- New C API: poc_init_model / poc_load_cartridge / poc_reset

Verified headlessly: 6128 boot, 6128 PLUS boot with system.cpr, cartridge reload, warm reset, and switch back to 6128 all run clean.