### PR TITLE
Fix CPC partial I/O decoding

### DIFF
--- a/docs/cpc-chips-cross-check.md
+++ b/docs/cpc-chips-cross-check.md
@@ -1,0 +1,125 @@
+# CPC implementation cross-check
+
+Issue: #266
+
+Reference revision: floooh/chips `afc331442ce28bf455bee7d81bc0b0c52ebf833d`
+
+Primary references:
+
+- [systems/cpc.h](https://github.com/floooh/chips/blob/afc331442ce28bf455bee7d81bc0b0c52ebf833d/systems/cpc.h)
+- [chips/am40010.h](https://github.com/floooh/chips/blob/afc331442ce28bf455bee7d81bc0b0c52ebf833d/chips/am40010.h)
+- [chips/i8255.h](https://github.com/floooh/chips/blob/afc331442ce28bf455bee7d81bc0b0c52ebf833d/chips/i8255.h)
+- [chips/ay38910.h](https://github.com/floooh/chips/blob/afc331442ce28bf455bee7d81bc0b0c52ebf833d/chips/ay38910.h)
+- [chips/mc6845.h](https://github.com/floooh/chips/blob/afc331442ce28bf455bee7d81bc0b0c52ebf833d/chips/mc6845.h)
+- [chips/upd765.h](https://github.com/floooh/chips/blob/afc331442ce28bf455bee7d81bc0b0c52ebf833d/chips/upd765.h)
+
+The comparison is behavioral. `chips` is a useful independent pin-level model,
+but it is not a complete golden implementation: it has one CRTC type, one disk
+drive, incomplete cassette support, and no CPC Plus or GX4000 support.
+
+## Confirmed matches
+
+| Area | Result |
+| --- | --- |
+| Master clocks | Both use a 4 MHz Z80 and 1 MHz CRTC/AY clock domain. |
+| 6128 RAM banking | All eight four-page mappings match exactly. 1984 additionally supports expansion groups and larger RAM. |
+| ROM overlays | Lower and upper ROMs overlay reads while writes continue to the RAM behind them. |
+| Video RAM | CRTC video fetches use the physical base 64 KB, independent of CPU RAM banking. |
+| Core selects | CRTC `A14=0`, PPI `A11=0`, Gate Array `A15=0/A14=1`, and printer `A12=0` agree. |
+| Keyboard/joystick | PPI port C selects a matrix row and AY port A returns the active-low row; joystick 1 shares row 9. |
+| Gate Array IRQ | The 52-HSYNC counter, two-HSYNC VSYNC resynchronization, IRQ reset, and acknowledge clearing counter bit 5 agree. |
+| CRTC addressing | The displayed address combines `MA13..12`, `RA2..0`, `MA9..0`, and the byte phase in the same order. |
+| FDC registers | The conventional `FAxx` motor and `FBxx` status/data behavior agrees with Caprice32 and 1984. |
+
+## Defects corrected on this branch
+
+### Simultaneous I/O selection
+
+1984 previously used an `if/else if` read dispatcher and early returns on
+writes. Real CPC partial decoding allows several onboard devices to observe one
+I/O cycle. The important case documented by `chips` is Arnold Acid `OnlyInc`:
+the PPI drives the data bus first, then an overlapping Gate Array selection
+consumes that value even though the CPU executed `IN`.
+
+The dispatcher is now compositional. PPI, Gate Array, ROM latch, CRTC, and
+printer selects are represented independently in `src/io_decode.h`. Gate Array
+register writes occur on both CPU reads and writes, with the PPI evaluated
+first. CRTC write-side aliases reached through `IN` also consume the current bus
+value because CRTC R/W is wired to address line A9 rather than Z80 RD/WR.
+
+### Upper-ROM latch aliases
+
+1984 accepted ROM selection only at `C0xx-DFxx`. The hardware latch only checks
+`A13=0` during a write. All corresponding aliases now select the upper ROM and
+can overlap other onboard devices.
+
+### 8255 direction and reset behavior
+
+The PPI was reset directly to firmware mode `0x82`, ignored port direction on
+reads and writes, and returned `0xFF` for the control register. It now resets to
+the 8255 hardware state `0x9B` (all ports input), gates A/B latches by direction,
+combines port C output halves correctly, and returns the control word. The CPC
+firmware still programs `0x82` during normal boot.
+
+### AY register and port-A reads
+
+AY register 7 was incorrectly masked to six bits, deleting the port-A direction
+bit. PPI reads also always returned keyboard data rather than the selected AY
+register. Register 7 now retains its I/O direction bits. AY registers read back
+normally, while register 14 reads the keyboard only when port A is configured as
+input and reads its latch when configured as output.
+
+### Reset clock phase
+
+`cpc_reset()` left the CRTC divide-by-four accumulator and pre-render bus state
+from the prior run. These sub-cycle fields are now reset with the machine.
+
+## Deliberate or unresolved differences
+
+### CPU/WAIT timing
+
+`chips` advances one Z80 T-state at a time and lets the Gate Array assert WAIT
+according to its sequencer phase. 1984 executes an instruction at a time, uses
+Caprice32/konCePCja cycle tables with CPC wait costs included, and splits selected
+I/O instructions around their bus access. This is much faster and already runs
+timing-sensitive software, but it is not equivalent at arbitrary memory and I/O
+edges. Converting to pin-level execution would be a separate CPU/bus project,
+not a local Gate Array fix.
+
+### FDC address aliases
+
+`chips` selects the motor and uPD765 from only `A10`, `A8`, and `A7`, exposing
+many aliases. 1984 and Caprice32 require high bytes `FA`/`FB` plus `A7=0`.
+Broadening this decode could conflict with emulated expansion cards, so it was
+not changed without a hardware test or a known program that requires an alias.
+
+### RAM-configuration decode disagreement
+
+`chips` treats RAM configuration as Gate Array function 3 and therefore also
+requires the Gate Array address select. Caprice32 handles a `C0-C7` data byte on
+any output with `A15=0`. 1984 currently agrees with `chips`. This needs a
+hardware-backed test before changing it.
+
+### Reset defaults
+
+The `chips` CRTC reset preserves register contents and its Gate Array reset
+clears all registers. 1984 reinitializes the CRTC to firmware-compatible timing
+defaults and the Gate Array to a usable mode-1 palette. This differs during the
+short interval before firmware initializes video, and on resets performed by
+software that expects CRTC registers to survive. It is retained for now and
+should be split into power-on versus reset behavior in a dedicated change.
+
+### Scope where 1984 is broader
+
+1984 supports selectable CRTC types 0-3, two floppy drives, cassette/CDT/WAV
+paths, expansion ROMs and RAM, M4/MX4 peripherals, CPC Plus ASIC features, and
+GX4000 cartridges. None of those extensions should be reduced to match the
+simpler reference system.
+
+## Verification
+
+- Full `tests/Makefile` suite, including new PPI and I/O-decode tests.
+- Clean `autoreconf -iv`, `./configure`, and `make -j4` in the SDL3 distrobox.
+- CPC 6128 boot to BASIC and pasted `print 123` keyboard path.
+- CP/M Plus boot from `cpmplus6128_1.dsk` to the `A>` prompt.
+- CPC 6128 Plus boot to the system-cartridge menu.

--- a/src/cpc.c
+++ b/src/cpc.c
@@ -3,6 +3,7 @@
 #include "snapshot.h"
 #include "kbd_pty.h"
 #include "config.h"
+#include "io_decode.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -349,36 +350,117 @@ static void bus_mem_write(void *ctx, u16 addr, u8 val) {
                 cpc->mem.lower_rom_enabled);
 }
 
+static void plus_asic_lock_write(CPC *cpc, u8 val);
+
+static void gate_array_bus_write(CPC *cpc, u16 port, u8 val) {
+    u8 hi = port >> 8;
+
+    if (cpc_model_is_plus(cpc->model) && !cpc->asic_locked &&
+            (val & 0xE0) == 0xA0) {
+        mem_plus_set_rmr2(&cpc->mem, val);
+        return;
+    }
+    if (cpc_trace_palette && cpc_frame_count > 520 && (val & 0xC0) == 0x40)
+        fprintf(stderr, "[f%04d ga] pen=%02X col=%02X\n",
+                cpc_frame_count, cpc->ga.selected_pen, val & 0x1F);
+    else if (cpc_trace_palette && cpc_frame_count > 520
+             && (val & 0xC0) == 0x00 && val <= 0x10)
+        fprintf(stderr, "[f%04d ga] select pen=%02X\n",
+                cpc_frame_count, val);
+    if (dbg_getenv("ONE_K_TRACE_FE58") && (val & 0xC0) == 0xC0)
+        fprintf(stderr, "[GA-bank] frame=%d  val=%02X  PC=%04X  was=%02X\n",
+                cpc_frame_count, val, cpc->cpu.pc, cpc->mem.ram_bank);
+    if ((val & 0xC0) == 0x80 && (val & 0x10)) {
+        cpc->cpu.pending_irq = false;
+        if (cpc_model_is_plus(cpc->model))
+            asic_clear_raster_irq(&cpc->asic, &cpc->mem);
+    }
+    ga_write(&cpc->ga, val);
+    cpc->mem.lower_rom_enabled = cpc->ga.lower_rom;
+    cpc->mem.upper_rom_enabled = cpc->ga.upper_rom;
+
+    if ((val & 0xC0) == 0xC0 && cpc->mem.ram_size > 0x10000) {
+        u8 bank_high = ((hi & 0xFC) == 0x7C) ? ((~hi) & 0x03) : 0;
+        u8 mode  = val & 0x07;
+        u8 group = (val >> 3) & 0x07;
+        u32 full_bg = (u32)bank_high * 8u + (u32)group;
+        if (((full_bg + 2u) * 64u * 1024u) > (u32)cpc->mem.ram_size) {
+            group     = 0;
+            bank_high = 0;
+        }
+        cpc->mem.ram_bank = (u8)((bank_high << 6) | (group << 3) | mode);
+        if (dbg_getenv("ONE_K_TRACE_BANK"))
+            fprintf(stderr, "[BANK] ram_bank=%02X (group=%u mode=%u bank_high=%u) PC=%04X\n",
+                    cpc->mem.ram_bank, group, mode, bank_high, cpc->cpu.pc);
+    }
+}
+
+static void prepare_ppi_port_a_input(CPC *cpc) {
+    u8 psg_ctrl = (ppi_output_c(&cpc->ppi) >> 6) & 0x03;
+    u8 value = 0xFF;
+
+    if (psg_ctrl == 0x01) {
+        if (cpc->psg.selected == 14) {
+            if (cpc->amx_mouse)
+                amx_pre_read(&cpc->amx, &cpc->kbd, cpc->ppi.kbd_row);
+            psg_set_kbd_row(&cpc->psg,
+                            kbd_read_row(&cpc->kbd, cpc->ppi.kbd_row));
+        }
+        value = psg_read(&cpc->psg);
+    }
+    ppi_set_port_a_input(&cpc->ppi, value);
+}
+
 static u8 bus_io_read(void *ctx, u16 port) {
     CPC *cpc = ctx;
     u8 hi = port >> 8;
-    u8 result;
+    u8 result = 0xFF;
+    unsigned selected = cpc_io_decode(port);
 
-    /* CRTC read: A14=0 (hi & ~0x40 → 0xBF area) */
-    if (!(hi & 0x40)) {
-        u8 func = (port >> 8) & 0x03;
-        if (func == 0x03)      result = crtc_read(&cpc->crtc);
-        else if (func == 0x02) result = crtc_read_status(&cpc->crtc);
-        else                   result = 0xFF;
+    /* Devices are deliberately not mutually exclusive. PPI must run before
+     * the Gate Array so an overlapping IN can transfer PPI data directly into
+     * a GA register (the Arnold Acid "OnlyInc" case). */
+    if (selected & CPC_IO_PPI) {
+        u8 ppi_port = hi & 0x03;
+        if (ppi_port == 0) prepare_ppi_port_a_input(cpc);
+        result = ppi_read(&cpc->ppi, ppi_port);
     }
-    /* PPI: A11=0 selects PPI (0xF4xx/0xF5xx/0xF6xx/0xF7xx) */
-    else if (!(hi & 0x08)) {
-        result = ppi_read(&cpc->ppi, (port >> 8) & 0x03);
+    if (selected & CPC_IO_GATE_ARRAY)
+        gate_array_bus_write(cpc, port, result);
+
+    /* The CRTC R/W pin is wired to A9, not the Z80 RD pin. An IN through a
+     * write-side alias therefore writes the value already on the data bus. */
+    if (selected & CPC_IO_CRTC) {
+        switch (hi & 0x03) {
+        case 0:
+            if (cpc_model_is_plus(cpc->model)) plus_asic_lock_write(cpc, result);
+            crtc_select(&cpc->crtc, result);
+            break;
+        case 1:
+            crtc_write(&cpc->crtc, result);
+            break;
+        case 2:
+            result = crtc_read_status(&cpc->crtc);
+            break;
+        case 3:
+            result = crtc_read(&cpc->crtc);
+            break;
+        }
     }
+
     /* USIfAC II serial @ 0xFBD0..FBDF. Decoded before the FDC clause so
      * even if the FDC's lo-bit-7 gate ever changes, USIfAC keeps its
      * range. Internally dispatches on the low nibble (D0/D1/D8/DD). */
-    else if (cpc->mx4 && cpc->usifac.present && hi == 0xFB &&
-             (port & 0xF0) == 0xD0) {
-        result = usifac_read(&cpc->usifac, (u8)(port & 0x0F));
-    }
+    if (cpc->mx4 && cpc->usifac.present && hi == 0xFB &&
+            (port & 0xF0) == 0xD0)
+        return usifac_read(&cpc->usifac, (u8)(port & 0x0F));
     /* FDC: hi=0xFB AND lo bit 7=0 → status (lo bit 0=0) or data (lo bit 0=1).
      * Real CPC hardware decodes the FDC at 0xFB7E/0xFB7F only; the upper
      * half (0xFB80–0xFBFF) is free for peripherals like USIfAC at
      * 0xFBD0/D1. Without the lo-bit-7 gate, generic IN A,(0xFBxx) probes
      * from other software read the FDC main status register instead of
      * 0xFF and mistake the FDC for a different device. */
-    else if (hi == 0xFB && !(port & 0x80)) {
+    if (hi == 0xFB && !(port & 0x80)) {
         u8 lo = port & 0xFF;
         if (lo & 0x01) {
             FdcPhase phase_before = cpc->fdc.phase;
@@ -392,22 +474,19 @@ static u8 bus_io_read(void *ctx, u16 port) {
             trace_fdc_status(cpc, port, result);
         }
     }
-    else if (hi == 0xFA) {
-        result = 0xFF;
-    }
+    else if (hi == 0xFA) return 0xFF;
     /* Albireo CH376: hi=0xFE, lo=0x80/0x81 (left chip, storage or USB
      * mouse) or 0x40/0x41 (right chip, dual-mode storage).
      * Claim before M4 wide decode. */
-    else if (cpc->mx4 && cpc->albireo && hi == 0xFE && (port & 0xFE) == 0x80) {
-        result = ch376_read(&cpc->ch376, (u8)(port & 0x01));
-    }
+    else if (cpc->mx4 && cpc->albireo && hi == 0xFE && (port & 0xFE) == 0x80)
+        return ch376_read(&cpc->ch376, (u8)(port & 0x01));
     else if (cpc->mx4 && cpc->albireo && cpc->albireo_mouse &&
              hi == 0xFE && (port & 0xFE) == 0x40) {
-        result = ch376_read(&cpc->ch376_b, (u8)(port & 0x01));
+        return ch376_read(&cpc->ch376_b, (u8)(port & 0x01));
     }
     /* M4 DATAPORT: hi=0xFE or 0xFF (read = ready/status) */
     else if (cpc->mx4 && cpc->m4 && (hi == 0xFE || hi == 0xFF)) {
-        result = m4_dataport_read(&cpc->m4_card);
+        return m4_dataport_read(&cpc->m4_card);
     }
     /* hi=0xFD: Mouse (0xFD10), IDE (0xFD06,0xFD08-0xFD0F), RTC (0xFD14), Net4CPC (0xFD20-0xFD23) */
     else if (cpc->mx4 && hi == 0xFD) {
@@ -443,10 +522,6 @@ static u8 bus_io_read(void *ctx, u16 port) {
         else
             result = 0xFF;
     }
-    else {
-        result = 0xFF;
-    }
-
     return result;
 }
 
@@ -483,87 +558,67 @@ static void plus_asic_lock_write(CPC *cpc, u8 val) {
 static void bus_io_write(void *ctx, u16 port, u8 val) {
     CPC *cpc = ctx;
     u8 hi = port >> 8;
+    unsigned selected = cpc_io_decode(port);
 
-    /* Parallel printer port: any write with A12 LOW (0xEFxx). The
-     * printer module handles the strobe-edge detect and bit-7 invert.
-     * Side-effect only — fall through so any expansion that happens to
-     * decode the same address space (none in the stock CPC, but the
-     * decoder is permissive) still sees the write. Caprice32
-     * cap32.cpp:768. */
-    if (!(hi & 0x10))
+    if (selected & CPC_IO_PRINTER)
         printer_out(&cpc->printer, val);
 
-    /* Gate Array: A15=0, A14=1 → 0x7Fxx */
-    if (!(hi & 0x80) && (hi & 0x40)) {
-        if (cpc_model_is_plus(cpc->model) && !cpc->asic_locked &&
-                (val & 0xE0) == 0xA0) {
-            mem_plus_set_rmr2(&cpc->mem, val);
-            return;
-        }
-        if (cpc_trace_palette && cpc_frame_count > 520 && (val & 0xC0) == 0x40)
-            fprintf(stderr, "[f%04d ga] pen=%02X col=%02X\n",
-                    cpc_frame_count, cpc->ga.selected_pen, val & 0x1F);
-        else if (cpc_trace_palette && cpc_frame_count > 520
-                 && (val & 0xC0) == 0x00 && val <= 0x10)
-            fprintf(stderr, "[f%04d ga] select pen=%02X\n",
-                    cpc_frame_count, val);
-        /* #102 layer A: trace every RAM-banking write (top 2 bits = 11)
-         * so we can correlate banking flips against $FE58 writes and
-         * IRQ events. */
-        if (dbg_getenv("ONE_K_TRACE_FE58") && (val & 0xC0) == 0xC0)
-            fprintf(stderr, "[GA-bank] frame=%d  val=%02X  PC=%04X  was=%02X\n",
-                    cpc_frame_count, val, cpc->cpu.pc, cpc->mem.ram_bank);
-        /* Interrupt reset also cancels a request already latched by the CPU. */
-        if ((val & 0xC0) == 0x80 && (val & 0x10)) {
-            cpc->cpu.pending_irq = false;
-            if (cpc_model_is_plus(cpc->model))
-                asic_clear_raster_irq(&cpc->asic, &cpc->mem);
-        }
-        ga_write(&cpc->ga, val);
-        cpc->mem.lower_rom_enabled = cpc->ga.lower_rom;
-        cpc->mem.upper_rom_enabled = cpc->ga.upper_rom;
-        /* RAM banking — bits[5:0] of data select bank group and mode.
-         * Standard on 6128; emulator extension enables it on 464 too
-         * when memory > 64 KB is configured.
-         * Yarek extension: port address bits A10-A8 carry an upper bank_high
-         * selector for RAM above 576 KB. Port 0x7Fxx = bank_high 0 (DK'tronics
-         * compatible); 0x7Exx = 1, 0x7Dxx = 2, 0x7Cxx = 3. bank_high is packed
-         * into ram_bank bits[7:6] so banked_ram_offset() can read it. */
-        if ((val & 0xC0) == 0xC0 && cpc->mem.ram_size > 0x10000) {
-            u8 bank_high = ((hi & 0xFC) == 0x7C) ? ((~hi) & 0x03) : 0;
-            u8 mode  = val & 0x07;
-            u8 group = (val >> 3) & 0x07;
-            /* Caprice32 ga_memory_manager() quirk: when the selected
-             * expansion group would point past installed RAM, force
-             * group=0 (fall back to the first 64K extension bank).
-             * Without this, CP/M+ and other software that probes more
-             * banks than physically exist see 0xFF reads where real
-             * hardware mirrors to group 0. Materially affects smaller
-             * configs (128/192/256/384/448K); a no-op at 576K/1024K
-             * where all standard groups fit. */
-            u32 full_bg = (u32)bank_high * 8u + (u32)group;
-            if (((full_bg + 2u) * 64u * 1024u) > (u32)cpc->mem.ram_size) {
-                group     = 0;
-                bank_high = 0;
+    /* PPI runs first so its pins already drive the bus before other partially
+     * decoded devices observe the same cycle. */
+    if (selected & CPC_IO_PPI) {
+        u8 ppi_port = hi & 0x03;
+        ppi_write(&cpc->ppi, ppi_port, val);
+        u8 port_c_pins = ppi_output_c(&cpc->ppi);
+        tape_set_motor(&cpc->tape, (port_c_pins & 0x10) != 0);
+        /* The AY bus is driven only when a write can change PPI port A or
+         * upper port C. Port B and mode-set writes must not replay stale
+         * BDIR/BC1 levels. */
+        bool drives_psg = (ppi_port == 0 && !(cpc->ppi.control & 0x10))
+                       || (ppi_port == 2 && !(cpc->ppi.control & 0x08))
+                       || (ppi_port == 3 && !(val & 0x80)
+                                         && !(cpc->ppi.control & 0x08));
+        if (drives_psg) {
+            u8 psg_ctrl = (port_c_pins >> 6) & 0x03;
+            if (psg_ctrl == 0x03) {
+                if (dbg_getenv("ONE_K_TRACE_PSG"))
+                    fprintf(stderr, "[PSG f%d] select=%02X PC=%04X port=%04X\n",
+                            cpc_frame_count, cpc->ppi.port_a, cpc->cpu.pc, port);
+                psg_select(&cpc->psg, cpc->ppi.port_a);
             }
-            cpc->mem.ram_bank = (u8)((bank_high << 6) | (group << 3) | mode);
-            if (dbg_getenv("ONE_K_TRACE_BANK"))
-                fprintf(stderr, "[BANK] ram_bank=%02X (group=%u mode=%u bank_high=%u) PC=%04X\n",
-                        cpc->mem.ram_bank, group, mode, bank_high, cpc->cpu.pc);
+            else if (psg_ctrl == 0x02) {
+                if (dbg_getenv("ONE_K_TRACE_PSG"))
+                    fprintf(stderr, "[PSG f%d] R%u <- %02X PC=%04X port=%04X\n",
+                            cpc_frame_count, cpc->psg.selected, cpc->ppi.port_a,
+                            cpc->cpu.pc, port);
+                psg_write(&cpc->psg, cpc->ppi.port_a);
+            }
+            else if (psg_ctrl == 0x01) {
+                prepare_ppi_port_a_input(cpc);
+                if (cpc_trace_input && cpc->ppi.kbd_row == 9)
+                    fprintf(stderr, "[input] kbd scan row9 = %02X  (matrix=%02X)\n",
+                            cpc->ppi.input_a, cpc->kbd.matrix[9]);
+            }
         }
-        return;
     }
-    /* CRTC write functions: A14=0 AND A9=0. A8 selects:
-     *   A8=0 → 0xBCxx select, A8=1 → 0xBDxx write.
-     * A9=1 (0xBExx/0xBFxx) is the CRTC read side — OUT to those ports
-     * is a no-op on real hardware. FUZIX's SDCC port helper at
-     * F995 issues OUT (C),B with BC=0x03FF for unrelated reasons; the
-     * old A14-only decode wrongly latched that as R12 := 0x03 and
-     * pointed the screen at block 0. */
-    if (!(hi & 0x40) && !(hi & 0x02)) {
+
+    if (selected & CPC_IO_GATE_ARRAY)
+        gate_array_bus_write(cpc, port, val);
+
+    /* The upper-ROM latch only decodes A13, so aliases outside DFxx work and
+     * may overlap another onboard device. */
+    if (selected & CPC_IO_ROM_SELECT) {
+        if (dbg_getenv("ONE_K_TRACE_HDCPM") && val == 0x01 &&
+                cpc->mem.upper_rom_select != 0x01)
+            fprintf(stderr, "[HDCPM ROM SELECTED] PC=%04X (caller about to use HDCPM ROM)\n",
+                    cpc->cpu.pc);
+        mem_plus_select_upper_rom(&cpc->mem, val);
+    }
+
+    /* A9 is the CRTC R/W signal. Only its write-side aliases alter state on
+     * an OUT; read-side aliases merely drive data against the CPU bus. */
+    if ((selected & CPC_IO_CRTC) && !(hi & 0x02)) {
         if (!(hi & 0x01)) {
-            if (cpc_model_is_plus(cpc->model))
-                plus_asic_lock_write(cpc, val);
+            if (cpc_model_is_plus(cpc->model)) plus_asic_lock_write(cpc, val);
             crtc_select(&cpc->crtc, val);
         } else {
             if (cpc_trace_io)
@@ -575,62 +630,8 @@ static void bus_io_write(void *ctx, u16 port, u8 val) {
                         cpc->cpu.bc, cpc->cpu.hl, cpc->cpu.de, cpc->cpu.af);
             crtc_write(&cpc->crtc, val);
         }
-        return;
     }
-    /* Upper ROM select: A15=1, A14=1, A13=0 → 0xC0xx–0xDFxx */
-    if ((hi & 0xE0) == 0xC0) {
-        if (dbg_getenv("ONE_K_TRACE_HDCPM") && val == 0x01 && cpc->mem.upper_rom_select != 0x01) {
-            fprintf(stderr, "[HDCPM ROM SELECTED] PC=%04X (caller about to use HDCPM ROM)\n", cpc->cpu.pc);
-        }
-        mem_plus_select_upper_rom(&cpc->mem, val);
-        return;
-    }
-    /* PPI: A11=0 → 0xF4 (port A), 0xF5 (B), 0xF6 (C), 0xF7 (ctrl) */
-    if (!(hi & 0x08)) {
-        u8 ppi_port = hi & 0x03;
-        ppi_write(&cpc->ppi, ppi_port, val);
-        /* Cassette motor follows PPI port C bit 4. */
-        tape_set_motor(&cpc->tape, (cpc->ppi.port_c & 0x10) != 0);
-        /* The AY bus is driven only when a write can change PPI port A or
-         * upper port C. Port B and mode-set writes must not replay stale
-         * BDIR/BC1 levels. */
-        bool drives_psg = (ppi_port == 0 && !(cpc->ppi.control & 0x10))
-                       || (ppi_port == 2 && !(cpc->ppi.control & 0x08))
-                       || (ppi_port == 3 && !(val & 0x80)
-                                         && !(cpc->ppi.control & 0x08));
-        if (!drives_psg)
-            return;
 
-        u8 psg_ctrl = (cpc->ppi.port_c >> 6) & 0x03;
-        if (psg_ctrl == 0x03) {
-            if (dbg_getenv("ONE_K_TRACE_PSG"))
-                fprintf(stderr, "[PSG f%d] select=%02X PC=%04X port=%04X\n",
-                        cpc_frame_count, cpc->ppi.port_a, cpc->cpu.pc, port);
-            psg_select(&cpc->psg, cpc->ppi.port_a);
-        }
-        else if (psg_ctrl == 0x02) {
-            if (dbg_getenv("ONE_K_TRACE_PSG"))
-                fprintf(stderr, "[PSG f%d] R%u <- %02X PC=%04X port=%04X\n",
-                        cpc_frame_count, cpc->psg.selected, cpc->ppi.port_a,
-                        cpc->cpu.pc, port);
-            psg_write(&cpc->psg, cpc->ppi.port_a);
-        }
-        else if (psg_ctrl == 0x01) {
-            /* AMX mouse (Fallback Input) delivers one row-9 pulse per fresh
-             * select-edge; run it on the value being read so it's robust to
-             * both PPI row-select write paths. */
-            if (cpc->amx_mouse)
-                amx_pre_read(&cpc->amx, &cpc->kbd, cpc->ppi.kbd_row);
-            psg_set_kbd_row(&cpc->psg, kbd_read_row(&cpc->kbd, cpc->ppi.kbd_row));
-            /* PSG read mode on CPC always reads I/O port A (reg 14 = keyboard matrix).
-             * Bypass psg_read() to avoid depending on psg->selected being 14. */
-            cpc->ppi.port_a = cpc->psg.kbd_data;
-            if (cpc_trace_input && cpc->ppi.kbd_row == 9)
-                fprintf(stderr, "[input] kbd scan row9 = %02X  (matrix=%02X)\n",
-                        cpc->ppi.port_a, cpc->kbd.matrix[9]);
-        }
-        return;
-    }
     /* Albireo CH376: hi=0xFE, lo=0x80/0x81 (left chip, storage or USB
      * mouse) or 0x40/0x41 (right chip, dual-mode storage).
      * Claim before M4 wide decode. */
@@ -1069,6 +1070,11 @@ void cpc_reset(CPC *cpc) {
     cpc_monitor_reset(cpc);
     cpc->prev_hsync = false;
     cpc->prev_vsync = false;
+    cpc->crtc_cycle_acc = 0;
+    cpc->crtc_pre_ma = cpc->crtc.ma;
+    cpc->crtc_pre_ra = cpc->crtc.vlc;
+    cpc->crtc_pre_de = cpc->crtc.display_enable;
+    cpc->bus_ticked_in_step = 0;
     cpc->cycle_debt = 0;
     cpc->audio_frame_pos = 0;
     cpc->audio_sample_cycles = 0;
@@ -1337,6 +1343,7 @@ static inline int cpc_monitor_px(const CPC *cpc) {
  * on the CPC struct (crtc_pre_ma/ra/de) so partial calls share state. */
 static void cpc_advance_bus(CPC *cpc, int cycles) {
     if (cycles <= 0) return;
+    u8 cassette_pins = ppi_output_c(&cpc->ppi);
     /* INPUT and CPC SAVE output pause the virtual tape. CDT output keeps it
      * connected so the decoded waveform reaches both the CPC and host. */
     bool real_input = real_tape_mode_has_input(cpc->real_tape.mode);
@@ -1358,7 +1365,7 @@ static void cpc_advance_bus(CPC *cpc, int cycles) {
      * this is required for volume-register sample playback. */
     cpc->audio_sample_cycles += cycles * AUDIO_SAMPLE_RATE;
     while (cpc->audio_sample_cycles >= cpc->cpu_clk_hz) {
-        real_tape_sample(&cpc->real_tape, cpc->ppi.port_c);
+        real_tape_sample(&cpc->real_tape, cassette_pins);
         if (real_tape_input_active(&cpc->real_tape))
             ppi_set_tape_level(&cpc->ppi,
                                real_tape_input_level(&cpc->real_tape));
@@ -1374,13 +1381,13 @@ static void cpc_advance_bus(CPC *cpc, int cycles) {
             s16 *dst = &cpc->audio_frame[cpc->audio_frame_pos * 2];
             psg_render_stereo(&cpc->psg, dst, 1, PSG_CLOCK_HZ, AUDIO_SAMPLE_RATE);
             int t = 0;
-            if (real_input && (cpc->ppi.port_c & 0x10))
+            if (real_input && (cassette_pins & 0x10))
                 t = real_tape_monitor_sample(&cpc->real_tape);
             else if (cpc_save_output &&
-                     (cpc->ppi.port_c & 0x10) &&
+                     (cassette_pins & 0x10) &&
                      real_tape_audible_monitor_enabled(
                          &cpc->real_tape))
-                t = (cpc->ppi.port_c & 0x20) ? 2500 : -2500;
+                t = (cassette_pins & 0x20) ? 2500 : -2500;
             else if (cdt_audio &&
                      (!real_tape_mode_has_output(cpc->real_tape.mode) ||
                       real_tape_audible_monitor_enabled(&cpc->real_tape)))

--- a/src/io_decode.h
+++ b/src/io_decode.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "types.h"
+
+/* The stock CPC devices use partial address decoding. More than one device
+ * can therefore observe the same I/O cycle; callers must not treat this mask
+ * as a priority-ordered device number. */
+enum {
+    CPC_IO_CRTC       = 1u << 0, /* A14=0 */
+    CPC_IO_PPI        = 1u << 1, /* A11=0 */
+    CPC_IO_GATE_ARRAY = 1u << 2, /* A15=0, A14=1 */
+    CPC_IO_ROM_SELECT = 1u << 3, /* A13=0, writes only */
+    CPC_IO_PRINTER    = 1u << 4, /* A12=0, writes only */
+};
+
+static inline unsigned cpc_io_decode(u16 port) {
+    unsigned selected = 0;
+    if (!(port & 0x4000)) selected |= CPC_IO_CRTC;
+    if (!(port & 0x0800)) selected |= CPC_IO_PPI;
+    if ((port & 0xC000) == 0x4000) selected |= CPC_IO_GATE_ARRAY;
+    if (!(port & 0x2000)) selected |= CPC_IO_ROM_SELECT;
+    if (!(port & 0x1000)) selected |= CPC_IO_PRINTER;
+    return selected;
+}

--- a/src/ppi.c
+++ b/src/ppi.c
@@ -3,16 +3,27 @@
 
 void ppi_init(PPI *p) {
     memset(p, 0, sizeof(*p));
-    p->control = 0x82;   /* standard CPC init: A=input, B=input, C=output */
+    /* An 8255 reset makes every port an input. The CPC firmware subsequently
+     * programs 0x82 (A/C output, B input) during machine startup. */
+    p->control = 0x9B;
+    p->input_a = 0xFF;
+}
+
+void ppi_refresh_outputs(PPI *p) {
+    p->kbd_row = (p->control & 0x01) ? 0 : (p->port_c & 0x0F);
 }
 
 void ppi_write(PPI *p, u8 port, u8 val) {
     switch (port & 0x03) {
-        case 0: p->port_a = val; break;
-        case 1: p->port_b = val; break;
+        case 0:
+            if (!(p->control & 0x10)) p->port_a = val;
+            break;
+        case 1:
+            if (!(p->control & 0x02)) p->port_b = val;
+            break;
         case 2:
             p->port_c = val;
-            p->kbd_row = val & 0x0F;
+            ppi_refresh_outputs(p);
             break;
         case 3:
             if (val & 0x80) {
@@ -21,7 +32,7 @@ void ppi_write(PPI *p, u8 port, u8 val) {
                 p->port_a = 0;
                 p->port_b = 0;
                 p->port_c = 0;
-                p->kbd_row = 0;
+                ppi_refresh_outputs(p);
             } else {
                 /* bit set/reset mode for port C */
                 u8 bit = (val >> 1) & 0x07;
@@ -29,7 +40,7 @@ void ppi_write(PPI *p, u8 port, u8 val) {
                     p->port_c |= (1 << bit);
                 else
                     p->port_c &= ~(1 << bit);
-                p->kbd_row = p->port_c & 0x0F;
+                ppi_refresh_outputs(p);
             }
             break;
     }
@@ -37,8 +48,10 @@ void ppi_write(PPI *p, u8 port, u8 val) {
 
 u8 ppi_read(PPI *p, u8 port) {
     switch (port & 0x03) {
-        case 0: return p->port_a;
+        case 0:
+            return (p->control & 0x10) ? p->input_a : p->port_a;
         case 1: {
+            if (!(p->control & 0x02)) return p->port_b;
             /* bit 7: cassette data input; bit 6: printer BUSY (active
              * high — firmware's MC BUSY PRINTER rotates this bit into
              * carry and treats carry=1 as busy);
@@ -52,9 +65,22 @@ u8 ppi_read(PPI *p, u8 port) {
             b |= (p->tape_level & 0x80);
             return b;
         }
-        case 2: return p->port_c;
-        default: return 0xFF;
+        case 2:
+            return ppi_output_c(p);
+        default:
+            return p->control;
     }
+}
+
+u8 ppi_output_c(const PPI *p) {
+    u8 pins = 0;
+    if (!(p->control & 0x08)) pins |= p->port_c & 0xF0;
+    if (!(p->control & 0x01)) pins |= p->port_c & 0x0F;
+    return pins;
+}
+
+void ppi_set_port_a_input(PPI *p, u8 value) {
+    p->input_a = value;
 }
 
 void ppi_set_vsync(PPI *p, bool v) {

--- a/src/ppi.h
+++ b/src/ppi.h
@@ -15,6 +15,7 @@ typedef struct {
     u8 port_b;
     u8 port_c;
     u8 control;        /* mode control word */
+    u8 input_a;        /* value currently driven onto external port A pins */
 
     u8 kbd_row;        /* keyboard matrix row selected by port C bits 0-3 */
     bool vsync_signal; /* fed from CRTC */
@@ -24,5 +25,8 @@ typedef struct {
 void ppi_init(PPI *p);
 void ppi_write(PPI *p, u8 port, u8 val);   /* port 0-3 (A/B/C/ctrl) */
 u8   ppi_read(PPI *p, u8 port);
+u8   ppi_output_c(const PPI *p);           /* externally driven port C pins */
+void ppi_refresh_outputs(PPI *p);
+void ppi_set_port_a_input(PPI *p, u8 value);
 void ppi_set_vsync(PPI *p, bool v);
 void ppi_set_tape_level(PPI *p, u8 level);   /* 0x00 or 0x80 */

--- a/src/psg.c
+++ b/src/psg.c
@@ -101,7 +101,9 @@ static u8 psg_register_mask(u8 reg, u8 val) {
     case 10:
         return val & 0x1F;
     case 7:
-        return val & 0x3F;
+        /* Bits 6 and 7 configure the AY I/O ports. The CPC uses bit 6 to
+         * switch port A between keyboard input and register output. */
+        return val;
     default:
         return val;
     }
@@ -125,10 +127,10 @@ void psg_write(PSG *psg, u8 val) {
 }
 
 u8 psg_read(PSG *psg) {
-    if (psg->selected == 14)
-        return psg->kbd_data;
     if (psg->selected >= PSG_NUM_REGS)
         return 0xFF;
+    if (psg->selected == 14 && !(psg->reg[7] & 0x40))
+        return psg->kbd_data;
     return psg->reg[psg->selected];
 }
 

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -133,7 +133,8 @@ int snapshot_load(CPC *cpc, const char *path) {
     cpc->ppi.port_b = hdr[0x57];
     cpc->ppi.port_c = hdr[0x58];
     cpc->ppi.control = hdr[0x59];
-    cpc->ppi.kbd_row = cpc->ppi.port_c & 0x0F;
+    ppi_set_port_a_input(&cpc->ppi, 0xFF);
+    ppi_refresh_outputs(&cpc->ppi);
 
     /* ---- PSG ---- */
     psg_load_registers(&cpc->psg, &hdr[SNA_PSG_REGS], hdr[SNA_PSG_SELECT],

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,7 +5,7 @@ CPPFLAGS ?=
 SDL3_CFLAGS ?= $(shell pkg-config --cflags sdl3)
 SDL3_LIBS ?= $(shell pkg-config --libs sdl3)
 
-TESTS = test-gate-array test-crtc test-z80 test-psg test-mem test-disk test-gifcap test-tape-signal test-real-tape test-kbd test-cartridge test-asic test-model test-config
+TESTS = test-gate-array test-crtc test-z80 test-psg test-ppi test-io-decode test-mem test-disk test-gifcap test-tape-signal test-real-tape test-kbd test-cartridge test-asic test-model test-config
 
 .PHONY: all check clean
 
@@ -26,6 +26,14 @@ test-z80: test_z80.c ../src/z80.c ../src/z80.h
 test-psg: test_psg.c ../src/psg.c ../src/psg.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -std=c11 -Wall -Wextra -I../src \
 		test_psg.c ../src/psg.c -o $@
+
+test-ppi: test_ppi.c ../src/ppi.c ../src/ppi.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) -std=c11 -Wall -Wextra -I../src \
+		test_ppi.c ../src/ppi.c -o $@
+
+test-io-decode: test_io_decode.c ../src/io_decode.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) -std=c11 -Wall -Wextra -I../src \
+		test_io_decode.c -o $@
 
 test-mem: test_mem.c ../src/mem.c ../src/mem.h ../src/cartridge.c ../src/cartridge.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -std=c11 -Wall -Wextra -I../src \
@@ -74,6 +82,8 @@ check: $(TESTS)
 	./test-crtc
 	./test-z80
 	./test-psg
+	./test-ppi
+	./test-io-decode
 	./test-mem
 	./test-disk
 	./test-gifcap

--- a/tests/test_io_decode.c
+++ b/tests/test_io_decode.c
@@ -1,0 +1,23 @@
+#include "io_decode.h"
+
+#include <assert.h>
+
+static void expect(u16 port, unsigned selected) {
+    assert(cpc_io_decode(port) == selected);
+}
+
+int main(void) {
+    expect(0xBC00, CPC_IO_CRTC);
+    expect(0x7F00, CPC_IO_GATE_ARRAY);
+    expect(0xDF00, CPC_IO_ROM_SELECT);
+    expect(0xF400, CPC_IO_PPI);
+    expect(0xEF00, CPC_IO_PRINTER);
+
+    /* Partial decoding permits intentional overlaps. */
+    expect(0x7700, CPC_IO_GATE_ARRAY | CPC_IO_PPI);
+    expect(0x4000, CPC_IO_GATE_ARRAY | CPC_IO_PPI |
+                   CPC_IO_ROM_SELECT | CPC_IO_PRINTER);
+    expect(0x0000, CPC_IO_CRTC | CPC_IO_PPI |
+                   CPC_IO_ROM_SELECT | CPC_IO_PRINTER);
+    return 0;
+}

--- a/tests/test_ppi.c
+++ b/tests/test_ppi.c
@@ -1,0 +1,55 @@
+#include "ppi.h"
+
+#include <assert.h>
+
+static void test_reset_and_direction(void) {
+    PPI ppi;
+    ppi_init(&ppi);
+
+    assert(ppi.control == 0x9B);
+    assert(ppi_read(&ppi, 0) == 0xFF);
+    assert(ppi_read(&ppi, 1) == 0x1E);
+    assert(ppi_read(&ppi, 2) == 0x00);
+    assert(ppi_read(&ppi, 3) == 0x9B);
+
+    /* Writes to input-configured A/B ports do not change their latches. */
+    ppi_write(&ppi, 0, 0x12);
+    ppi_write(&ppi, 1, 0x34);
+    assert(ppi.port_a == 0);
+    assert(ppi.port_b == 0);
+
+    /* Firmware mode: A/C output, B input. */
+    ppi_write(&ppi, 3, 0x82);
+    ppi_write(&ppi, 0, 0x56);
+    ppi_write(&ppi, 1, 0x78);
+    ppi_write(&ppi, 2, 0xA9);
+    assert(ppi_read(&ppi, 0) == 0x56);
+    assert(ppi_read(&ppi, 1) == 0x1E);
+    assert(ppi_read(&ppi, 2) == 0xA9);
+    assert(ppi_output_c(&ppi) == 0xA9);
+    assert(ppi.kbd_row == 9);
+}
+
+static void test_split_port_c_and_input_a(void) {
+    PPI ppi;
+    ppi_init(&ppi);
+    ppi_set_port_a_input(&ppi, 0x5A);
+    assert(ppi_read(&ppi, 0) == 0x5A);
+
+    /* Upper C input, lower C output. */
+    ppi_write(&ppi, 3, 0x88);
+    ppi_write(&ppi, 2, 0xF5);
+    assert(ppi_read(&ppi, 2) == 0x05);
+    assert(ppi_output_c(&ppi) == 0x05);
+    assert(ppi.kbd_row == 5);
+
+    ppi_write(&ppi, 3, 0x0D); /* set port C bit 6 */
+    assert(ppi.port_c == 0xF5);
+    assert(ppi_output_c(&ppi) == 0x05);
+}
+
+int main(void) {
+    test_reset_and_direction();
+    test_split_port_c_and_input_a();
+    return 0;
+}

--- a/tests/test_psg.c
+++ b/tests/test_psg.c
@@ -17,7 +17,7 @@ static void test_register_write_masks(void) {
 
     psg_select(&psg, 7);
     psg_write(&psg, 0xFF);
-    assert(psg.reg[7] == 0x3F);
+    assert(psg.reg[7] == 0xFF);
 
     psg_select(&psg, 8);
     psg_write(&psg, 0xFF);
@@ -51,7 +51,7 @@ static void test_snapshot_register_load_and_store(void) {
     assert(psg.reg[0] == 0xFF);
     assert(psg.reg[1] == 0x0F);
     assert(psg.reg[6] == 0x1F);
-    assert(psg.reg[7] == 0x3F);
+    assert(psg.reg[7] == 0xFF);
     assert(psg.reg[8] == 0x1F);
     assert(psg.reg[13] == 0x0F);
     assert(!psg.env_dir);
@@ -63,6 +63,25 @@ static void test_snapshot_register_load_and_store(void) {
     assert(memcmp(stored, psg.reg, sizeof(stored)) == 0);
     assert(env_step == 12);
     assert(env_direction == 0xFF);
+}
+
+static void test_port_a_input_and_output_readback(void) {
+    PSG psg;
+    psg_init(&psg);
+    psg_set_kbd_row(&psg, 0x5A);
+
+    psg_select(&psg, 14);
+    psg_write(&psg, 0xA5);
+    assert(psg_read(&psg) == 0x5A); /* R7 bit 6 clear: keyboard input */
+
+    psg_select(&psg, 7);
+    psg_write(&psg, 0x40);
+    psg_select(&psg, 14);
+    assert(psg_read(&psg) == 0xA5); /* R7 bit 6 set: output latch */
+
+    psg_select(&psg, 3);
+    psg_write(&psg, 0x0B);
+    assert(psg_read(&psg) == 0x0B);
 }
 
 static void test_snapshot_held_envelope_level(void) {
@@ -130,6 +149,7 @@ int main(void) {
     test_register_write_masks();
     test_snapshot_register_load_and_store();
     test_snapshot_held_envelope_level();
+    test_port_a_input_and_output_readback();
     test_envelope_period_uses_ay_prescaler();
     test_disabled_sources_can_act_as_volume_dac();
     return 0;


### PR DESCRIPTION
Closes #266. Cross-checks the CPC implementation against floooh/chips and corrects overlapping partial I/O selection, upper-ROM aliases, 8255 direction/reset behavior, AY port reads, and reset clock phase. Adds focused I/O/PPI/PSG tests and documents deliberate architectural differences. Verified with the full test suite, a clean build, BASIC input, CP/M Plus boot, and CPC Plus cartridge boot.