### PR TITLE
Fix Eerie Forest Plus demo compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -485,6 +485,7 @@ noinst_HEADERS = \
 	src/websvc.h \
 	src/host_mount.h \
 	src/ide.h \
+	src/io_decode.h \
 	src/joy.h \
 	src/kbd.h \
 	src/kbd_pty.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -77,6 +77,7 @@ noinst_HEADERS = \
 	src/websvc.h \
 	src/host_mount.h \
 	src/ide.h \
+	src/io_decode.h \
 	src/joy.h \
 	src/kbd.h \
 	src/kbd_pty.h \

--- a/Makefile.in
+++ b/Makefile.in
@@ -485,6 +485,7 @@ noinst_HEADERS = \
 	src/websvc.h \
 	src/host_mount.h \
 	src/ide.h \
+	src/io_decode.h \
 	src/joy.h \
 	src/kbd.h \
 	src/kbd_pty.h \

--- a/src/asic.c
+++ b/src/asic.c
@@ -276,7 +276,8 @@ void asic_raster_tick(Asic *asic, const CRTC *crtc, Mem *mem, GateArray *ga) {
 
 void asic_new_frame(Asic *asic) {
     asic->scanline = 0;
-    asic->split_active = false;
+    asic->video_ma_offset = 0;
+    asic->video_next_valid = false;
 }
 
 bool asic_irq_pending(const Asic *asic) {
@@ -349,55 +350,52 @@ void asic_latch_split(Asic *asic, const CRTC *crtc, u16 previous_vcc,
     asic->split_pending = true;
 }
 
-void asic_apply_split(Asic *asic, const CRTC *crtc) {
-    if (!asic->split_pending)
+void asic_latch_video_row(Asic *asic, const CRTC *crtc) {
+    u16 width = crtc->reg[1];
+    if (!width || crtc->hcc != width)
         return;
 
-    /* The Plus ASIC does not reload the CRTC's internal MA counters. It
-     * translates the video address from the MA present at the split to SSA.
-     * Keeping the CRTC running independently matters when software programs
-     * another split later in the same frame. */
-    asic->split_ma_started = crtc->ma & 0x3FFF;
-    asic->split_ma_base = asic->split_pending_base;
+    /* SSCR changes the three raster-address bits immediately, but its carry
+     * into the next video-memory row is sampled only by the R1 comparator.
+     * Keeping this row base stateful matters when software rewrites SSCR near
+     * the start of every raster, as Eerie Forest does for its lower panel. */
+    u16 raw_start = (u16)((crtc->ma - crtc->hcc) & 0x3FFF);
+    u16 video_start = (u16)((raw_start + asic->video_ma_offset) & 0x3FFF);
+    unsigned scrolled_raster = (crtc->vlc + asic->vscroll) & 0x1F;
+    if (scrolled_raster == crtc->reg[9])
+        video_start = (u16)((video_start + width) & 0x3FFF);
+    asic->video_next_base = video_start;
+    asic->video_next_valid = true;
+}
 
-    /* SSA is the absolute row base for the scanline after the split. If that
-     * line crosses the SSCR fine-scroll wrap, video_position() will advance
-     * by R1; compensate the translation baseline so it still resolves to
-     * SSA. Hardware gives the split load priority over the row advance. */
-    unsigned row_height = (unsigned)crtc->reg[9] + 1;
-    unsigned rows = (crtc->vlc + asic->vscroll) / row_height;
-    asic->split_ma_base = (u16)((asic->split_ma_base -
-                                 rows * crtc->reg[1]) & 0x3FFF);
-    asic->split_pending = false;
-    asic->split_active = true;
+void asic_apply_split(Asic *asic, const CRTC *crtc) {
+    u16 raw_start = (u16)((crtc->ma - crtc->hcc) & 0x3FFF);
+    u16 video_start;
+
+    if (asic->split_pending) {
+        /* SSA has priority over the row advance sampled at R1. */
+        video_start = asic->split_pending_base;
+        asic->split_pending = false;
+    } else if (asic->video_next_valid) {
+        video_start = asic->video_next_base;
+    } else {
+        video_start = (u16)((raw_start + asic->video_ma_offset) & 0x3FFF);
+    }
+
+    asic->video_ma_offset = (u16)((video_start - raw_start) & 0x3FFF);
+    asic->video_next_valid = false;
 }
 
 u16 asic_video_ma(const Asic *asic, u16 crtc_ma) {
-    if (!asic->split_active)
-        return crtc_ma & 0x3FFF;
-    return (u16)((crtc_ma - asic->split_ma_started +
-                  asic->split_ma_base) & 0x3FFF);
+    return (u16)((crtc_ma + asic->video_ma_offset) & 0x3FFF);
 }
 
 AsicVideoPosition asic_video_position(const Asic *asic, u16 crtc_ma,
-                                      u8 crtc_raster, u8 max_raster,
-                                      u8 chars_per_row) {
+                                      u8 crtc_raster) {
     AsicVideoPosition pos = {
         .ma = asic_video_ma(asic, crtc_ma),
-        .raster = crtc_raster & 7,
+        .raster = (u8)((crtc_raster + asic->vscroll) & 7),
     };
-    unsigned scrolled = crtc_raster + asic->vscroll;
-    unsigned row_height = (unsigned)max_raster + 1;
-
-    /* SSCR advances the raster presented to the video address generator.
-     * Crossing R9 therefore selects the next CRTC row, whose width is R1
-     * characters. It is not necessarily the 40-character firmware width. */
-    if (scrolled >= row_height) {
-        unsigned rows = scrolled / row_height;
-        pos.ma = (u16)((pos.ma + rows * chars_per_row) & 0x3FFF);
-        scrolled %= row_height;
-    }
-    pos.raster = (u8)(scrolled & 7);
     return pos;
 }
 

--- a/src/asic.c
+++ b/src/asic.c
@@ -8,6 +8,12 @@
 
 static void dma_store_status(Asic *asic, Mem *mem);
 
+static void raise_raster_interrupt(Asic *asic, Mem *mem, GateArray *ga) {
+    asic->raster_interrupt = true;
+    ga->interrupt_pending = true;
+    dma_store_status(asic, mem);
+}
+
 static u8 decode_magnification(u8 value) {
     value &= 3;
     return value == 3 ? 4 : value;
@@ -91,7 +97,20 @@ void asic_register_write(Asic *asic, GateArray *ga, Mem *mem,
 
     mem->plus_registers[off] = value;
     switch (addr) {
-    case 0x6800: asic->raster_line = value; break;
+    case 0x6800: {
+        u8 previous = asic->raster_line;
+        asic->raster_line = value;
+        /* PRI is a level-sensitive request. Programming a different nonzero
+         * line withdraws an outstanding raster request unless the new value
+         * matches immediately (handled by asic_program_raster()). Eerie
+         * Forest relies on the withdrawal while rebuilding its IRQ chain. */
+        if (value && value != previous) {
+            asic->raster_interrupt = false;
+            ga->interrupt_pending = asic_irq_pending(asic);
+            dma_store_status(asic, mem);
+        }
+        break;
+    }
     case 0x6801: asic->split_line = value; break;
     case 0x6802:
         asic->split_address = (asic->split_address & 0x00FF) | ((u16)value << 8);
@@ -137,6 +156,19 @@ void asic_register_write(Asic *asic, GateArray *ga, Mem *mem,
     default:
         break;
     }
+}
+
+void asic_program_raster(Asic *asic, GateArray *ga, Mem *mem,
+                         const CRTC *crtc, u8 value) {
+    u8 previous = asic->raster_line;
+    asic_register_write(asic, ga, mem, 0x6800, value);
+    if (!crtc || !value || value == previous || !crtc->hsync ||
+        crtc->vcc >= 32)
+        return;
+
+    u8 line = (u8)((crtc->vcc << 3) | (crtc->vlc & 7));
+    if (line == value)
+        raise_raster_interrupt(asic, mem, ga);
 }
 
 static void dma_store_status(Asic *asic, Mem *mem) {
@@ -238,11 +270,8 @@ void asic_raster_tick(Asic *asic, const CRTC *crtc, Mem *mem, GateArray *ga) {
     if (crtc->vcc >= 32)
         return;
     u8 line = (u8)((crtc->vcc << 3) | (crtc->vlc & 7));
-    if (line == asic->raster_line) {
-        asic->raster_interrupt = true;
-        ga->interrupt_pending = true;
-        dma_store_status(asic, mem);
-    }
+    if (line == asic->raster_line)
+        raise_raster_interrupt(asic, mem, ga);
 }
 
 void asic_new_frame(Asic *asic) {

--- a/src/asic.h
+++ b/src/asic.h
@@ -34,10 +34,10 @@ typedef struct {
     u8 split_line;
     u16 split_address;
     u16 split_pending_base;
-    u16 split_ma_started;
-    u16 split_ma_base;
+    u16 video_ma_offset;
+    u16 video_next_base;
     bool split_pending;
-    bool split_active;
+    bool video_next_valid;
     u8 hscroll;
     u8 vscroll;
     bool extend_border;
@@ -68,11 +68,11 @@ void asic_irq_ack(Asic *asic, Mem *mem, GateArray *ga);
 void asic_clear_raster_irq(Asic *asic, Mem *mem);
 void asic_latch_split(Asic *asic, const CRTC *crtc, u16 previous_vcc,
                       u16 previous_vlc, bool new_scanline);
+void asic_latch_video_row(Asic *asic, const CRTC *crtc);
 void asic_apply_split(Asic *asic, const CRTC *crtc);
 u16 asic_video_ma(const Asic *asic, u16 crtc_ma);
 AsicVideoPosition asic_video_position(const Asic *asic, u16 crtc_ma,
-                                      u8 crtc_raster, u8 max_raster,
-                                      u8 chars_per_row);
+                                      u8 crtc_raster);
 bool asic_scroll_border_active(const Asic *asic, u16 hcc);
 void asic_draw_sprites_char(const Asic *asic, u16 hcc, u16 vcc, u16 vlc,
                             u8 chars_per_row, u32 *pixels);

--- a/src/asic.h
+++ b/src/asic.h
@@ -57,6 +57,8 @@ typedef struct {
 void asic_reset(Asic *asic, GateArray *ga);
 void asic_register_write(Asic *asic, GateArray *ga, Mem *mem,
                          u16 addr, u8 value);
+void asic_program_raster(Asic *asic, GateArray *ga, Mem *mem,
+                         const CRTC *crtc, u8 value);
 void asic_hsync(Asic *asic, Mem *mem, PSG *psg, GateArray *ga);
 void asic_raster_tick(Asic *asic, const CRTC *crtc, Mem *mem, GateArray *ga);
 void asic_new_frame(Asic *asic);

--- a/src/cpc.c
+++ b/src/cpc.c
@@ -1424,6 +1424,7 @@ static void cpc_advance_bus(CPC *cpc, int cycles) {
             asic_latch_split(&cpc->asic, &cpc->crtc,
                              cpc->crtc_pre_vcc, cpc->crtc_pre_ra,
                              new_crtc_line);
+            asic_latch_video_row(&cpc->asic, &cpc->crtc);
         }
 
         /* GA interrupt counter on hsync falling edge (matches Caprice32) */
@@ -1446,6 +1447,7 @@ static void cpc_advance_bus(CPC *cpc, int cycles) {
         /* --- Render 16 pixels for this char clock --- */
         int px = cpc_monitor_px(cpc);
         int py = cpc->raster_y;
+        bool plus_scroll_border = false;
 
         if (py >= 0 && py < CPC_SCREEN_H && px >= 0 && px <= CPC_SCREEN_W - 16) {
             u32 *row = cpc->display.pixels + py * CPC_SCREEN_W;
@@ -1455,8 +1457,7 @@ static void cpc_advance_bus(CPC *cpc, int cycles) {
                 u8 video_ra = cpc->crtc_pre_ra & 7;
                 if (cpc_model_is_plus(cpc->model)) {
                     AsicVideoPosition pos = asic_video_position(
-                        &cpc->asic, video_ma, cpc->crtc_pre_ra,
-                        cpc->crtc.reg[9], cpc->crtc.reg[1]);
+                        &cpc->asic, video_ma, cpc->crtc_pre_ra);
                     video_ma = pos.ma;
                     video_ra = pos.raster;
                 }
@@ -1464,15 +1465,11 @@ static void cpc_advance_bus(CPC *cpc, int cycles) {
                 u16 col  = video_ma & 0x3FF;
                 u16 addr = (u16)((bank << 14) | ((video_ra & 7) << 11) | (col << 1));
                 if (cpc_model_is_plus(cpc->model)) {
-                    if (asic_scroll_border_active(&cpc->asic,
-                                                  cpc->crtc_pre_hcc)) {
-                        u32 border = cpc->ga.resolved_ink[16];
-                        for (int x = 0; x < 16; x++)
-                            row[px + x] = border;
-                    } else {
+                    plus_scroll_border = asic_scroll_border_active(
+                        &cpc->asic, cpc->crtc_pre_hcc);
+                    if (!plus_scroll_border)
                         render_char_plus(row, px, &cpc->ga, &cpc->mem, addr,
                                          cpc->asic.hscroll);
-                    }
                 } else {
                     u8 b0 = mem_read_video(&cpc->mem, addr);
                     u8 b1 = mem_read_video(&cpc->mem, (u16)(addr + 1));
@@ -1490,6 +1487,14 @@ static void cpc_advance_bus(CPC *cpc, int cycles) {
                 asic_draw_sprites_char(&cpc->asic, cpc->crtc_pre_hcc,
                                        cpc->crtc_pre_vcc, cpc->crtc_pre_ra,
                                        cpc->crtc.reg[1], row + px);
+            /* SSCR bit 7 is a final video-output mask. It hides both the
+             * invalid bitmap data exposed by horizontal scrolling and any
+             * hardware sprites in that first character. */
+            if (plus_scroll_border) {
+                u32 border = cpc->ga.resolved_ink[16];
+                for (int x = 0; x < 16; x++)
+                    row[px + x] = border;
+            }
             memset(cpc->display.touched + py * CPC_SCREEN_W + px, 1, 16);
         }
 
@@ -1987,7 +1992,8 @@ int cpc_frame(CPC *cpc) {
      * are valid hardware colour indices (0x00-0x1F).  Values outside that range
      * (e.g. 0xFF or 0x55 written by a diagnostic RAM fill) suppress the flush,
      * preventing false triggers during memory tests. */
-    if (mem_read(&cpc->mem, 0xB7F7) == 0xFF) {
+    if (!cpc_model_is_plus(cpc->model) &&
+            mem_read(&cpc->mem, 0xB7F7) == 0xFF) {
         bool palette_valid = true;
         for (int p = 0; p < 17; p++) {
             if (mem_read(&cpc->mem, (u16)(0xB7D4 + p)) > 0x1F) {
@@ -2020,7 +2026,8 @@ int cpc_frame(CPC *cpc) {
      * The 464 firmware uses 0xB1FC as dirty flag and 0xB1D9-0xB1E9 as the
      * palette buffer (17 bytes: border first, then inks 0-15).  Same validity
      * guard as above: only flush when all bytes are in 0x00-0x1F range. */
-    if (mem_read(&cpc->mem, 0xB1FC) == 0xFF) {
+    if (!cpc_model_is_plus(cpc->model) &&
+            mem_read(&cpc->mem, 0xB1FC) == 0xFF) {
         bool palette_valid = true;
         for (int p = 0; p < 17; p++) {
             if (mem_read(&cpc->mem, (u16)(0xB1D9 + p)) > 0x1F) {

--- a/src/cpc.c
+++ b/src/cpc.c
@@ -250,7 +250,11 @@ static void bus_mem_write(void *ctx, u16 addr, u8 val) {
     CPC *cpc = ctx;
     if (cpc_model_is_plus(cpc->model) && cpc->mem.plus_register_page &&
             addr >= 0x4000 && addr < 0x8000) {
-        asic_register_write(&cpc->asic, &cpc->ga, &cpc->mem, addr, val);
+        if (addr == 0x6800)
+            asic_program_raster(&cpc->asic, &cpc->ga, &cpc->mem,
+                                &cpc->crtc, val);
+        else
+            asic_register_write(&cpc->asic, &cpc->ga, &cpc->mem, addr, val);
         if (!asic_irq_pending(&cpc->asic)) {
             cpc->ga.interrupt_pending = false;
             cpc->cpu.pending_irq = false;

--- a/tests/test_asic.c
+++ b/tests/test_asic.c
@@ -95,6 +95,7 @@ static void test_raster_split_and_dma(void) {
     asic_register_write(&asic, &ga, &mem, 0x6802, 0x3A);
     asic_register_write(&asic, &ga, &mem, 0x6803, 0xBC);
     crtc.ma = 0x3040;
+    crtc.hcc = 0;
     asic_apply_split(&asic, &crtc);
     assert(crtc.ma == 0x3040);
     assert(crtc.ma_row_start == 0x3000);
@@ -108,8 +109,10 @@ static void test_raster_split_and_dma(void) {
     asic_register_write(&asic, &ga, &mem, 0x6802, 0x23);
     asic_register_write(&asic, &ga, &mem, 0x6803, 0x40);
     crtc.vlc = 4;
+    crtc.hcc = crtc.reg[1];
     asic_latch_split(&asic, &crtc, 0, 4, false);
     crtc.ma = 0x3090;
+    crtc.hcc = 0;
     asic_apply_split(&asic, &crtc);
     assert(asic_video_ma(&asic, 0x3090) == 0x2340);
     assert(asic_video_ma(&asic, 0x3093) == 0x2343);
@@ -156,8 +159,7 @@ static void test_raster_split_and_dma(void) {
     asic_latch_split(&compare_asic, &compare_crtc, 2, 2, false);
     assert(compare_asic.split_pending);
 
-    /* A split address overrides the fine-scroll row advance. Its first
-     * displayed scanline must begin at SSA even when RA+SSCR wraps R9. */
+    /* A split address overrides the fine-scroll row advance sampled at R1. */
     Asic wrap_asic = {
         .split_pending_base = 0x1234,
         .split_pending = true,
@@ -168,34 +170,75 @@ static void test_raster_split_and_dma(void) {
     wrap_crtc.reg[1] = 49;
     wrap_crtc.reg[9] = 7;
     wrap_crtc.ma = 0x3040;
-    wrap_crtc.vlc = 6;
+    wrap_crtc.hcc = 0;
+    wrap_crtc.vlc = 5;
     asic_apply_split(&wrap_asic, &wrap_crtc);
     AsicVideoPosition split_pos = asic_video_position(
-        &wrap_asic, wrap_crtc.ma, wrap_crtc.vlc,
-        wrap_crtc.reg[9], wrap_crtc.reg[1]);
+        &wrap_asic, wrap_crtc.ma, wrap_crtc.vlc);
     assert(split_pos.ma == 0x1234);
-    assert(split_pos.raster == 0);
-    split_pos = asic_video_position(&wrap_asic, wrap_crtc.ma, 7, 7, 49);
-    assert(split_pos.ma == 0x1234);
-    assert(split_pos.raster == 1);
-    split_pos = asic_video_position(
-        &wrap_asic, wrap_crtc.ma + 49, 0, 7, 49);
-    assert(split_pos.ma == 0x1234);
-    assert(split_pos.raster == 2);
+    assert(split_pos.raster == 7);
 
-    /* Fine vertical scroll wraps into a row whose width comes from R1.
-     * Sonic GX uses 49 characters, so a firmware-width constant corrupts
-     * the wrapped scanlines into displaced horizontal strips. */
+    /* RA 5 + SSCR 2 reaches R9, which would normally advance by R1. */
+    wrap_crtc.hcc = 49;
+    wrap_crtc.ma = 0x3040 + 49;
+    asic_latch_video_row(&wrap_asic, &wrap_crtc);
+    assert(wrap_asic.video_next_base == 0x1234 + 49);
+    wrap_asic.split_pending_base = 0x2345;
+    wrap_asic.split_pending = true;
+    wrap_crtc.hcc = 0;
+    wrap_crtc.ma = 0x3040;
+    wrap_crtc.vlc = 6;
+    asic_apply_split(&wrap_asic, &wrap_crtc);
+    split_pos = asic_video_position(&wrap_asic, wrap_crtc.ma, 6);
+    assert(split_pos.ma == 0x2345);
+    assert(split_pos.raster == 0);
+
+    /* Changing SSCR at HCC 0 affects RA immediately but cannot carry MA into
+     * another row until the R1 comparator samples the new value. */
+    wrap_asic.vscroll = 6;
+    split_pos = asic_video_position(&wrap_asic, wrap_crtc.ma, 6);
+    assert(split_pos.ma == 0x2345);
+    assert(split_pos.raster == 4);
+
+    wrap_crtc.hcc = 49;
+    wrap_crtc.ma = 0x3040 + 49;
+    asic_latch_video_row(&wrap_asic, &wrap_crtc);
+    wrap_crtc.hcc = 0;
+    wrap_crtc.ma = 0x3040;
+    wrap_crtc.vlc = 7;
+    asic_apply_split(&wrap_asic, &wrap_crtc);
+    split_pos = asic_video_position(&wrap_asic, wrap_crtc.ma, 7);
+    assert(split_pos.ma == 0x2345);
+    assert(split_pos.raster == 5);
+
+    /* With a stable SSCR, the R1-sampled carry uses the programmed display
+     * width. Sonic GX uses 49 characters rather than the firmware's 40. */
     asic.vscroll = 2;
-    AsicVideoPosition pos = asic_video_position(&asic, 0x3005, 4, 7, 49);
+    AsicVideoPosition pos = asic_video_position(&asic, 0x3005, 4);
     assert(pos.ma == 0x3005);
     assert(pos.raster == 6);
-    pos = asic_video_position(&asic, 0x3005, 7, 7, 49);
+
+    CRTC scroll_crtc;
+    crtc_init(&scroll_crtc);
+    scroll_crtc.reg[1] = 49;
+    scroll_crtc.reg[9] = 7;
+    scroll_crtc.hcc = 49;
+    scroll_crtc.ma = 0x3005 + 49;
+    scroll_crtc.vlc = 5;
+    asic_latch_video_row(&asic, &scroll_crtc);
+    scroll_crtc.hcc = 0;
+    scroll_crtc.ma = 0x3005;
+    scroll_crtc.vlc = 6;
+    asic_apply_split(&asic, &scroll_crtc);
+    pos = asic_video_position(&asic, 0x3005, 7);
     assert(pos.ma == 0x3036);
     assert(pos.raster == 1);
+
+    /* SSCR adds to the three raster-address bits; it does not perform an
+     * immediate multi-row MA carry when R9 is smaller than seven. */
     asic.vscroll = 6;
-    pos = asic_video_position(&asic, 0x3005, 3, 3, 49);
-    assert(pos.ma == 0x3067);
+    pos = asic_video_position(&asic, 0x3005, 3);
+    assert(pos.ma == 0x3036);
     assert(pos.raster == 1);
 
     /* A programmable raster replaces legacy GA IRQ requests, but the GA

--- a/tests/test_asic.c
+++ b/tests/test_asic.c
@@ -257,6 +257,50 @@ static void test_vectored_interrupts(void) {
     assert(!asic.dma[1].interrupt);
 }
 
+static void test_pri_write_withdraws_raster_request(void) {
+    Asic asic;
+    GateArray ga = {0};
+    Mem mem;
+    PSG psg;
+    init_parts(&asic, &ga, &mem, &psg);
+
+    asic.raster_line = 7;
+    asic.raster_interrupt = true;
+    ga.interrupt_pending = true;
+    asic_register_write(&asic, &ga, &mem, 0x6800, 11);
+    assert(!asic.raster_interrupt);
+    assert(!ga.interrupt_pending);
+
+    /* Rewriting the active comparator value does not withdraw its request. */
+    asic.raster_interrupt = true;
+    ga.interrupt_pending = true;
+    asic_register_write(&asic, &ga, &mem, 0x6800, 11);
+    assert(asic.raster_interrupt);
+    assert(ga.interrupt_pending);
+
+    /* DMA requests remain asserted when PRI is reprogrammed. */
+    asic.dma[2].interrupt = true;
+    asic_register_write(&asic, &ga, &mem, 0x6800, 14);
+    assert(!asic.raster_interrupt);
+    assert(ga.interrupt_pending);
+
+    /* A changed PRI matching the current line during HSYNC fires at once. */
+    asic.dma[2].interrupt = false;
+    ga.interrupt_pending = false;
+    CRTC crtc;
+    crtc_init(&crtc);
+    crtc.vcc = 1;
+    crtc.vlc = 6;
+    crtc.hsync = true;
+    asic_program_raster(&asic, &ga, &mem, &crtc, 14);
+    assert(!asic.raster_interrupt); /* unchanged PRI does not retrigger */
+    asic_program_raster(&asic, &ga, &mem, &crtc, 13);
+    assert(!asic.raster_interrupt); /* changed, but not the current line */
+    asic_program_raster(&asic, &ga, &mem, &crtc, 14);
+    assert(asic.raster_interrupt);
+    assert(ga.interrupt_pending);
+}
+
 static void test_dma_pause_cadence(void) {
     Asic asic;
     GateArray ga = {0};
@@ -436,6 +480,7 @@ int main(void) {
     test_palette_and_sprite_registers();
     test_raster_split_and_dma();
     test_vectored_interrupts();
+    test_pri_write_withdraws_raster_request();
     test_dma_pause_cadence();
     test_sprite_beam_composition();
     test_sprite_monitor_clipping();


### PR DESCRIPTION
## Summary
- withdraw and immediately re-evaluate CPC Plus programmable raster interrupts when PRI is reprogrammed
- latch Plus vertical scrolling at the CRTC row boundary while preserving immediate raster changes and split priority
- apply the SSCR border extension after sprite composition and prevent classic firmware palette fallbacks on Plus models
- add focused ASIC regression coverage

## Verification
- make -C tests check
- Eerie Forest deterministic captures through frame 4500
- Ghosts n Goblins, Sonic, Plus system cartridge, GX4000, and classic CPC boot regressions

Closes #257