### PR TITLE
Toggle CPC tape deck with keyboard

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -6,9 +6,9 @@ Build the browser edition with Emscripten and serve the publish directory:
     python3 -m http.server 8080 --directory web/dist
 
 The default CPC464 theme presents the emulator as a dark GT65 monitor above a
-CPC 464 chassis. Its optional on-screen keyboard is collapsed by default and
-the tape deck is a visual placeholder for future support. Retro CRT, Sapporo,
-and Sapporo Dark remain available from the theme selector.
+CPC 464 chassis. Its optional on-screen keyboard and visual tape-deck
+placeholder expand and collapse together, and are collapsed by default. Retro
+CRT, Sapporo, and Sapporo Dark remain available from the theme selector.
 
 A theme can be selected in a link using its case-insensitive display name:
 

--- a/web/app.js
+++ b/web/app.js
@@ -128,10 +128,12 @@ document.addEventListener("click", event => {
 const cpcKeyboardEl = document.querySelector(".cpc464-keyboard");
 const cpcKeyboardKeysEl = $("cpcKeyboardKeys");
 const cpcKeyboardToggleEl = $("cpcKeyboardToggle");
+const cpcTapeDeckEl = $("tapeDeckMock");
 
 function setCpcKeyboardOpen(open) {
   cpcKeyboardEl.dataset.keyboardOpen = String(open);
   cpcKeyboardKeysEl.hidden = !open;
+  cpcTapeDeckEl.hidden = !open;
   cpcKeyboardToggleEl.setAttribute("aria-expanded", String(open));
   cpcKeyboardToggleEl.textContent = open ? "Hide keyboard" : "Show keyboard";
 }

--- a/web/dist/app.js
+++ b/web/dist/app.js
@@ -128,10 +128,12 @@ document.addEventListener("click", event => {
 const cpcKeyboardEl = document.querySelector(".cpc464-keyboard");
 const cpcKeyboardKeysEl = $("cpcKeyboardKeys");
 const cpcKeyboardToggleEl = $("cpcKeyboardToggle");
+const cpcTapeDeckEl = $("tapeDeckMock");
 
 function setCpcKeyboardOpen(open) {
   cpcKeyboardEl.dataset.keyboardOpen = String(open);
   cpcKeyboardKeysEl.hidden = !open;
+  cpcTapeDeckEl.hidden = !open;
   cpcKeyboardToggleEl.setAttribute("aria-expanded", String(open));
   cpcKeyboardToggleEl.textContent = open ? "Hide keyboard" : "Show keyboard";
 }

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -207,7 +207,7 @@
       <div class="cpc-keyboard-bar">
         <span>Optional on-screen keyboard</span>
         <button id="cpcKeyboardToggle" type="button" aria-expanded="false"
-                aria-controls="cpcKeyboardKeys">Show keyboard</button>
+                aria-controls="cpcKeyboardKeys tapeDeckMock">Show keyboard</button>
       </div>
 
       <div id="cpcKeyboardKeys" class="cpc464-keybed" role="group"
@@ -288,7 +288,7 @@
       </div>
 
       <section id="tapeDeckMock" class="cpc464-tape-deck" data-future-control="tape"
-               aria-hidden="true">
+               aria-hidden="true" hidden>
         <div class="tape-deck-heading">
           <strong>DATA RECORDER</strong>
           <span>FUTURE TAPE SUPPORT</span>

--- a/web/dist/theme-cpc464.css
+++ b/web/dist/theme-cpc464.css
@@ -440,11 +440,6 @@ html[data-theme="cpc464"] .cpc464-keyboard[data-keyboard-open="false"] {
   grid-template-columns: 1fr;
 }
 
-html[data-theme="cpc464"] .cpc464-keyboard[data-keyboard-open="false"] .cpc464-tape-deck {
-  width: min(285px, 100%);
-  justify-self: end;
-}
-
 html[data-theme="cpc464"] .cpc-keyboard-bar {
   display: flex;
   grid-column: 1 / -1;
@@ -478,6 +473,10 @@ html[data-theme="cpc464"] .cpc-keyboard-bar button:hover { color: #fff; backgrou
 html[data-theme="cpc464"] .cpc-keyboard-bar button:active { transform: translateY(2px); box-shadow: 0 1px #080908; }
 
 html[data-theme="cpc464"] .cpc464-keybed[hidden] {
+  display: none !important;
+}
+
+html[data-theme="cpc464"] .cpc464-tape-deck[hidden] {
   display: none !important;
 }
 
@@ -684,7 +683,6 @@ html[data-theme="cpc464"] .toast {
   html[data-theme="cpc464"] .control-deck { grid-template-columns: 1fr 1fr; }
   html[data-theme="cpc464"] .media-module { grid-column: 1 / -1; grid-row: 1; }
   html[data-theme="cpc464"] .cpc464-keyboard { grid-template-columns: 1fr; }
-  html[data-theme="cpc464"] .cpc464-keyboard[data-keyboard-open="false"] .cpc464-tape-deck { width: 100%; }
   html[data-theme="cpc464"] .cpc464-tape-deck { grid-template-columns: 1fr auto; }
   html[data-theme="cpc464"] .cpc-key { min-height: 30px; font-size: 6px; }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -207,7 +207,7 @@
       <div class="cpc-keyboard-bar">
         <span>Optional on-screen keyboard</span>
         <button id="cpcKeyboardToggle" type="button" aria-expanded="false"
-                aria-controls="cpcKeyboardKeys">Show keyboard</button>
+                aria-controls="cpcKeyboardKeys tapeDeckMock">Show keyboard</button>
       </div>
 
       <div id="cpcKeyboardKeys" class="cpc464-keybed" role="group"
@@ -288,7 +288,7 @@
       </div>
 
       <section id="tapeDeckMock" class="cpc464-tape-deck" data-future-control="tape"
-               aria-hidden="true">
+               aria-hidden="true" hidden>
         <div class="tape-deck-heading">
           <strong>DATA RECORDER</strong>
           <span>FUTURE TAPE SUPPORT</span>

--- a/web/theme-cpc464.css
+++ b/web/theme-cpc464.css
@@ -440,11 +440,6 @@ html[data-theme="cpc464"] .cpc464-keyboard[data-keyboard-open="false"] {
   grid-template-columns: 1fr;
 }
 
-html[data-theme="cpc464"] .cpc464-keyboard[data-keyboard-open="false"] .cpc464-tape-deck {
-  width: min(285px, 100%);
-  justify-self: end;
-}
-
 html[data-theme="cpc464"] .cpc-keyboard-bar {
   display: flex;
   grid-column: 1 / -1;
@@ -478,6 +473,10 @@ html[data-theme="cpc464"] .cpc-keyboard-bar button:hover { color: #fff; backgrou
 html[data-theme="cpc464"] .cpc-keyboard-bar button:active { transform: translateY(2px); box-shadow: 0 1px #080908; }
 
 html[data-theme="cpc464"] .cpc464-keybed[hidden] {
+  display: none !important;
+}
+
+html[data-theme="cpc464"] .cpc464-tape-deck[hidden] {
   display: none !important;
 }
 
@@ -684,7 +683,6 @@ html[data-theme="cpc464"] .toast {
   html[data-theme="cpc464"] .control-deck { grid-template-columns: 1fr 1fr; }
   html[data-theme="cpc464"] .media-module { grid-column: 1 / -1; grid-row: 1; }
   html[data-theme="cpc464"] .cpc464-keyboard { grid-template-columns: 1fr; }
-  html[data-theme="cpc464"] .cpc464-keyboard[data-keyboard-open="false"] .cpc464-tape-deck { width: 100%; }
   html[data-theme="cpc464"] .cpc464-tape-deck { grid-template-columns: 1fr auto; }
   html[data-theme="cpc464"] .cpc-key { min-height: 30px; font-size: 6px; }
 }


### PR DESCRIPTION
Makes the CPC464 tape deck part of the collapsible keyboard assembly. Both start hidden, expand together, and collapse together. Updates source and web/dist. Tests: make -C web test plus browser-level toggle verification.