### PR TITLE
Document WebAssembly browser edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 ![1984](1984.png)
 
 1984 is a cycle-stepped Amstrad CPC 464, 664, 6128, 464 Plus, 6128 Plus, and
-GX4000 emulator written in C using SDL3. It aims to run ordinary CPC software and
-timing-sensitive programs while also modelling modern storage, networking,
-and input expansions.
+GX4000 emulator with a core written in C. The native application uses SDL3,
+while the standalone browser edition compiles the same core to WebAssembly. It
+aims to run ordinary CPC software and timing-sensitive programs while also
+modelling modern storage, networking, and input expansions.
 
 ## Current status
 
@@ -172,8 +173,13 @@ Without Cairo the guest port still responds, but no host document is created.
 
 ## Web access
 
-1984 has two browser-facing modes:
+1984 has three browser-facing modes:
 
+- **Browser/WebAssembly edition** runs the emulator entirely in the browser
+  from static files in `web/dist`. It currently provides CPC 6128 and 6128 Plus
+  machines, DSK and CPR loading, Web Audio, keyboard, gamepad and AMX mouse
+  input, display controls, and selectable themes. Media can be selected from
+  the browser or loaded from server URLs; changes remain in browser memory.
 - **Web GUI** mirrors the one CPC already running in the SDL application. It
   streams screen and browser-started stereo audio, accepts keyboard, mouse,
   touch joystick, paste, and reset input, and can upload DSK images into either
@@ -184,9 +190,12 @@ Without Cairo the guest port still responds, but no host document is created.
   sessions ten minutes after their last viewer disconnects. Packages install
   the sandboxed `1984-web.service` system service.
 
-Both modes bind to `0.0.0.0` and provide no authentication. Anyone who can
-reach the port can view and control a machine, so use them only on a trusted
-network. The default port is `1984`.
+The native Web GUI and Web Service bind to `0.0.0.0` and provide no
+authentication. Anyone who can reach the port can view and control a machine,
+so use them only on a trusted network. The default port is `1984`. The static
+WebAssembly edition follows the access policy of the web server used to
+publish it. See [web/README.md](web/README.md) for browser build, deployment,
+controls, URL parameters, and current limitations.
 
 ## Development and automation
 
@@ -212,6 +221,17 @@ autoreconf -iv
 make -j"$(nproc)"
 ./1984 --disk-a=/path/to/software.dsk
 ```
+
+The standalone browser edition requires Emscripten. Build it and serve the
+generated static directory over HTTP:
+
+```bash
+make -C web
+python3 -m http.server 8080 --directory web/dist
+```
+
+Publish the contents of `web/dist/`, not the development files in `web/`. See
+[web/README.md](web/README.md) for server-hosted media and browser controls.
 
 Cairo is optional (`./configure --without-cairo` disables PDF capture), and
 `ffmpeg` is optional for WebM recording. The required CPC firmware, M4ROM, and

--- a/web/README.md
+++ b/web/README.md
@@ -1,39 +1,109 @@
 # Javascript 1984
 
-Build the browser edition with Emscripten and serve the publish directory:
+Javascript 1984 is the standalone, client-side WebAssembly edition of 1984.
+It compiles the same C emulation core used by the SDL3 application and wraps
+it in a static HTML, CSS, and JavaScript interface. It is separate from the
+native application's streaming Web GUI and multi-session Web Service: no 1984
+process runs on the server after the files have been published.
 
-    make -C web
-    python3 -m http.server 8080 --directory web/dist
+## Current capabilities
 
-The default CPC464 theme presents the emulator as a dark GT65 monitor above a
-CPC 464 chassis. Its optional on-screen keyboard and visual tape-deck
-placeholder expand and collapse together, and are collapsed by default. Retro
-CRT, Sapporo, and Sapporo Dark remain available from the theme selector.
+- CPC 6128 and CPC 6128 Plus machines using the bundled firmware and system
+  cartridge.
+- Local DSK loading in drive A and CPR cartridge loading on the Plus model.
+- Server-hosted DSK and CPR media selected through URL parameters.
+- CPC keyboard input from the physical keyboard or the collapsible on-screen
+  keyboard, including latched Shift, Ctrl, and Copy modifiers.
+- Browser Gamepad API joystick input and optional AMX mouse pointer capture.
+- Stereo Web Audio, fullscreen, display scaling, sharp or smooth pixels, and
+  colour or green-monochrome output.
+- CPC464, Retro CRT, Sapporo, and Sapporo Dark themes.
 
-A theme can be selected in a link using its case-insensitive display name:
+The browser frontend does not currently expose the native F9 overlay,
+expansion devices, tape emulation, snapshots, or additional CPC models. The
+CPC464 tape deck in the interface is a placeholder for future tape support.
+Disk writes and fetched media changes are held in browser memory and are lost
+when the page is reloaded; they are not uploaded to the server.
 
-    http://localhost:8080/?theme=CPC464
-    http://localhost:8080/?theme=Sapporo%20Dark
+## Build and publish
+
+Install Emscripten so `emcc` is available, then build from the repository root:
+
+```bash
+make -C web
+```
+
+The complete publishable application is written to `web/dist/`. Serve that
+directory over HTTP or HTTPS; loading `index.html` directly through a `file:`
+URL is not supported.
+
+```bash
+python3 -m http.server 8080 --directory web/dist
+```
+
+Open <http://localhost:8080/>. To deploy it elsewhere, publish the contents of
+`web/dist/`, including `6128.js`, `6128.wasm`, the CSS themes, JavaScript
+helpers, and image assets. The server should return `.wasm` files as
+`application/wasm`.
+
+## Controls
+
+Click the CPC display before using the physical keyboard. Browser audio also
+starts after a user gesture, as required by modern autoplay policies. The
+**Show keyboard** button expands the on-screen CPC keyboard and tape-deck
+assembly; **Hide keyboard** collapses both. On-screen Shift, Ctrl, and Copy
+latch until the next key, which makes combinations practical with a mouse.
+
+Enable **Joystick** and press **Detect controller** after connecting a
+gamepad. Whether a device is available depends on the browser and its sandbox
+permissions. Enable **Mouse** and click the display to capture the pointer;
+press Escape to release browser pointer lock.
+
+The media deck loads local DSK and CPR files using the browser file chooser.
+Reset, fullscreen, fit-to-window, pixel filtering, display size, and colour
+mode are available from the front panel.
+
+## Themes
+
+The default CPC464 theme presents a dark GT65 monitor above a CPC 464 chassis.
+Themes can be selected from the front panel or with a case-insensitive URL
+parameter:
+
+```text
+http://localhost:8080/?theme=CPC464
+http://localhost:8080/?theme=Retro%20CRT
+http://localhost:8080/?theme=Sapporo%20Dark
+```
+
+An unknown theme name falls back to CPC464. A front-panel choice is retained
+in browser local storage; a URL parameter overrides it for that page load.
 
 ## Server-hosted media
 
 Media URLs are resolved relative to the page URL. A disk can be mounted in
 drive A at startup:
 
-    http://localhost:8080/?disk=media/thisdisk.dsk
+```text
+http://localhost:8080/?disk=media/thisdisk.dsk
+```
 
 Add `autorun` to reset the CPC after mounting and inject `RUN"filename"` after
 the same 42-frame boot delay used by native 1984:
 
-    http://localhost:8080/?disk=media/thisdisk.dsk&autorun=disc.bas
+```text
+http://localhost:8080/?disk=media/thisdisk.dsk&autorun=disc.bas
+```
 
 A CPR cartridge URL starts the CPC 6128 Plus model:
 
-    http://localhost:8080/?cartridge=media/sonic.cpr
+```text
+http://localhost:8080/?cartridge=media/sonic.cpr
+```
 
-Parameter values containing spaces or other reserved characters must be URL
-encoded. Media must be available over HTTP or HTTPS. Cross-origin servers must
-permit the request with CORS headers.
+Theme and media parameters can be combined in the same URL. Parameter values
+containing spaces or other reserved characters must be URL encoded. Media
+must be available over HTTP or HTTPS. Cross-origin servers must permit the
+request with CORS headers.
 
 The fetched image lives in the browser's in-memory filesystem. Guest writes
 are not uploaded to the server.


### PR DESCRIPTION
Documents the standalone client-side WebAssembly edition in the main README and expands web/README.md with architecture, capabilities, limitations, controls, themes, static deployment, and server-hosted media URLs. Tests: make -C web test.