### PR TITLE
Update the M4 relay integration name

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -240,7 +240,7 @@ the machine re-applies them automatically after a model switch or page load.
 ### Relay
 
 The M4 bridge speaks the same binary relay protocol as the standalone
-[1983-msx-unapi-relay](https://github.com/salvogendut/1983-msx-unapi-relay)
+[ws-unapi-relay](https://github.com/salvogendut/ws-unapi-relay)
 service, so one deployed instance serves both the 1983 and 1984 emulators. The
 relay performs DNS lookups and TCP connections on behalf of the page. It only
 accepts IPv4 destinations on public addresses and allowlisted ports (23, 70,
@@ -249,18 +249,18 @@ Connections are limited to the M4's four TCP sockets, with bounded payloads,
 socket buffers, connect timeouts, heartbeats, and an idle sweep.
 
 ```bash
-git clone https://github.com/salvogendut/1983-msx-unapi-relay
-cd 1983-msx-unapi-relay
+git clone https://github.com/salvogendut/ws-unapi-relay
+cd ws-unapi-relay
 npm ci
 UNAPI_ORIGINS=http://127.0.0.1:8000 npm start
-# relay ready at ws://127.0.0.1:1983/unapi (health check: curl :1983/healthz)
+# relay ready at ws://127.0.0.1:9380/unapi (health check: curl :9380/healthz)
 ```
 
 Open the 1984 page (e.g. `python3 -m http.server 8000 --directory web/dist`),
 enable **Internet access** in the Expansion bay, and the panel connects to the
 relay. The default endpoint is same-origin `ws(s)://host/unapi`; a `?m4Relay=`
 URL parameter overrides it for that page load (for a separately hosted relay,
-set it to `ws(s)://relay-host:1983/unapi` and add the page origin to the
+set it to `ws(s)://relay-host:9380/unapi` and add the page origin to the
 relay's `UNAPI_ORIGINS`). On HTTPS pages the relay must use `wss:`; the
 **Trust certificate** button opens the relay's `/healthz` page so you can
 approve a self-signed certificate. Deployment guidance, WSS reverse-proxy
@@ -270,4 +270,3 @@ The C transport seam is `web/m4_web.c` (EM_JS) backed by `web/m4-bridge.js`;
 the frame-sharing protocol lives in `web/m4-relay-protocol.js`, byte-identical
 to the standalone relay's. Tests: `node test_m4_bridge.js` and
 `node test_m4_wasm.js` (the last needs a built `dist/`).
-

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -71,7 +71,7 @@
           <span><strong>Internet access</strong><small id="m4NetState" aria-live="polite">Disabled</small></span>
         </label>
         <p class="extension-help">Browsers cannot open TCP sockets. Traffic is
-          tunneled through the shared 1983-msx-unapi-relay service, which only
+          tunneled through the shared ws-unapi-relay service, which only
           permits public IPv4 hosts on common ports (23, 70, 80, 443, 2323).</p>
         <label class="expansion-text-field" for="m4Endpoint">
           <span>Relay endpoint</span>
@@ -87,10 +87,11 @@
           <button id="m4Certificate" class="extension-small-key" type="button" disabled>Trust certificate</button>
           <span>Opens the relay health page. Approve its certificate, then return here; reconnection is automatic.</span>
         </div>
+        <p class="relay-details-link">For details see <a href="https://github.com/salvogendut/ws-unapi-relay" target="_blank" rel="noopener noreferrer">ws-unapi-relay</a>.</p>
         <p class="extension-help">One shared relay instance serves the 1983 and
           1984 emulators. Run it with <code>npm start</code> from the
-          1983-msx-unapi-relay repository (defaults to
-          <code>ws://host:1983/unapi</code>); or serve this page and the relay
+          ws-unapi-relay repository (defaults to
+          <code>ws://host:9380/unapi</code>); or serve this page and the relay
           from one origin.</p>
       </div>
     </section>

--- a/web/dist/m4-bridge.js
+++ b/web/dist/m4-bridge.js
@@ -8,7 +8,7 @@
  * synchronously while the relay I/O happens between emulator frames.
  */
 (function (root, factory) {
-  const P = root.JS1984M4Protocol ||
+  const P = root.JSWsUnapiRelayProtocol || root.JS1984M4Protocol ||
     (typeof require === "function" ? require("./m4-relay-protocol.js") : null);
   const api = factory(P);
   if (typeof module === "object" && module.exports) module.exports = api;

--- a/web/dist/m4-relay-protocol.js
+++ b/web/dist/m4-relay-protocol.js
@@ -1,6 +1,7 @@
 (function (root, factory) {
   const api = factory();
   if (typeof module === "object" && module.exports) module.exports = api;
+  root.JSWsUnapiRelayProtocol = api;
   root.JS1984M4Protocol = api;
 }(typeof globalThis !== "undefined" ? globalThis : this, function () {
   "use strict";
@@ -8,7 +9,7 @@
   /* Shared relay protocol (magic 0x83) spoken by the M4 internet bridge.
    *
    * This is the same versioned binary protocol used by the standalone
-   * 1983-msx-unapi-relay service, so a single deployed relay instance can
+   * ws-unapi-relay service, so a single deployed relay instance can
    * serve both the 1983 MSX UNAPI bridge and the 1984 M4 bridge. Frame
    * layout (8-byte header + payload):
    *   byte 0  magic     0x83

--- a/web/dist/styles.css
+++ b/web/dist/styles.css
@@ -763,6 +763,9 @@ button.extension-small-key:disabled { opacity: .35; }
 .relay-certificate-action { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 10px; align-items: center; }
 .relay-certificate-action .extension-small-key { min-width: 112px; min-height: 30px; }
 .relay-certificate-action span { color: #777d78; font: 600 8px/1.4 ui-monospace, monospace; }
+.relay-details-link { margin: -6px 0 0; color: #777d78; font: 600 8px/1.4 ui-monospace, monospace; }
+.relay-details-link a { color: #b7cbbb; text-underline-offset: 2px; }
+.relay-details-link a:hover { color: #d9e6db; }
 .extension-help { margin: 0; color: #777d78; font: 600 8px/1.45 ui-monospace, monospace; }
 .extension-help code { color: #aeb4ae; font: inherit; }
 

--- a/web/index.html
+++ b/web/index.html
@@ -71,7 +71,7 @@
           <span><strong>Internet access</strong><small id="m4NetState" aria-live="polite">Disabled</small></span>
         </label>
         <p class="extension-help">Browsers cannot open TCP sockets. Traffic is
-          tunneled through the shared 1983-msx-unapi-relay service, which only
+          tunneled through the shared ws-unapi-relay service, which only
           permits public IPv4 hosts on common ports (23, 70, 80, 443, 2323).</p>
         <label class="expansion-text-field" for="m4Endpoint">
           <span>Relay endpoint</span>
@@ -87,10 +87,11 @@
           <button id="m4Certificate" class="extension-small-key" type="button" disabled>Trust certificate</button>
           <span>Opens the relay health page. Approve its certificate, then return here; reconnection is automatic.</span>
         </div>
+        <p class="relay-details-link">For details see <a href="https://github.com/salvogendut/ws-unapi-relay" target="_blank" rel="noopener noreferrer">ws-unapi-relay</a>.</p>
         <p class="extension-help">One shared relay instance serves the 1983 and
           1984 emulators. Run it with <code>npm start</code> from the
-          1983-msx-unapi-relay repository (defaults to
-          <code>ws://host:1983/unapi</code>); or serve this page and the relay
+          ws-unapi-relay repository (defaults to
+          <code>ws://host:9380/unapi</code>); or serve this page and the relay
           from one origin.</p>
       </div>
     </section>

--- a/web/m4-bridge.js
+++ b/web/m4-bridge.js
@@ -8,7 +8,7 @@
  * synchronously while the relay I/O happens between emulator frames.
  */
 (function (root, factory) {
-  const P = root.JS1984M4Protocol ||
+  const P = root.JSWsUnapiRelayProtocol || root.JS1984M4Protocol ||
     (typeof require === "function" ? require("./m4-relay-protocol.js") : null);
   const api = factory(P);
   if (typeof module === "object" && module.exports) module.exports = api;

--- a/web/m4-relay-protocol.js
+++ b/web/m4-relay-protocol.js
@@ -1,6 +1,7 @@
 (function (root, factory) {
   const api = factory();
   if (typeof module === "object" && module.exports) module.exports = api;
+  root.JSWsUnapiRelayProtocol = api;
   root.JS1984M4Protocol = api;
 }(typeof globalThis !== "undefined" ? globalThis : this, function () {
   "use strict";
@@ -8,7 +9,7 @@
   /* Shared relay protocol (magic 0x83) spoken by the M4 internet bridge.
    *
    * This is the same versioned binary protocol used by the standalone
-   * 1983-msx-unapi-relay service, so a single deployed relay instance can
+   * ws-unapi-relay service, so a single deployed relay instance can
    * serve both the 1983 MSX UNAPI bridge and the 1984 M4 bridge. Frame
    * layout (8-byte header + payload):
    *   byte 0  magic     0x83

--- a/web/styles.css
+++ b/web/styles.css
@@ -763,6 +763,9 @@ button.extension-small-key:disabled { opacity: .35; }
 .relay-certificate-action { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 10px; align-items: center; }
 .relay-certificate-action .extension-small-key { min-width: 112px; min-height: 30px; }
 .relay-certificate-action span { color: #777d78; font: 600 8px/1.4 ui-monospace, monospace; }
+.relay-details-link { margin: -6px 0 0; color: #777d78; font: 600 8px/1.4 ui-monospace, monospace; }
+.relay-details-link a { color: #b7cbbb; text-underline-offset: 2px; }
+.relay-details-link a:hover { color: #d9e6db; }
 .extension-help { margin: 0; color: #777d78; font: 600 8px/1.45 ui-monospace, monospace; }
 .extension-help code { color: #aeb4ae; font: inherit; }
 

--- a/web/test_m4_bridge.js
+++ b/web/test_m4_bridge.js
@@ -4,8 +4,19 @@
  * Run with: node test_m4_bridge.js */
 
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const P = require("./m4-relay-protocol.js");
 const { M4Bridge, relayHealthEndpoint, validEndpoint, POLL } = require("./m4-bridge.js");
+
+assert.equal(globalThis.JSWsUnapiRelayProtocol, P);
+assert.equal(globalThis.JS1984M4Protocol, P);
+
+const html = fs.readFileSync(path.join(__dirname, "index.html"), "utf8");
+assert.match(
+  html,
+  /For details see <a href="https:\/\/github\.com\/salvogendut\/ws-unapi-relay" target="_blank" rel="noopener noreferrer">ws-unapi-relay<\/a>/
+);
 
 assert.equal(
   relayHealthEndpoint("wss://relay.example:1984/m4?token=secret#fragment"),


### PR DESCRIPTION
Summary:
- add the renamed ws-unapi-relay link to the M4 internet panel
- update relay names, clone instructions, and the default port
- expose the generic protocol global while retaining the 1984 M4 alias
- regenerate tracked web distribution copies

Tests:
- make EMCC=/var/home/salvogendut/emsdk/upstream/emscripten/emcc test (from web/)